### PR TITLE
Improve screen recording recovery and rewind history controls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,8 @@ Local release credentials live in `.env.release.local` (gitignored). The local r
 
 After every successful build, always install and launch from `/Applications/` before reporting completion. Screen Recording permission is tied to the app location.
 
+If you switch a machine from older dev-signed/Xcode builds to Developer ID or notarised builds, macOS may keep a stale Screen Recording entry that still appears enabled. If capture fails in that state, remove the `JustNow` entry from **System Settings → Privacy & Security → Screen Recording** once and relaunch so TCC can recreate it for the new signing identity.
+
 ```bash
 pkill -x JustNow 2>/dev/null || true
 if [ -e /Applications/JustNow.app ]; then

--- a/Docs/release-and-distribution.md
+++ b/Docs/release-and-distribution.md
@@ -55,6 +55,8 @@ Local notarisation prerequisites:
 - the Developer Team ID
 - the issuer ID for Team API keys
 
+If you are switching a machine from older Xcode/dev-signed `JustNow` builds to Developer ID / notarised builds, macOS can keep a stale Screen Recording entry that still looks enabled but no longer matches the app's current signing requirement. If capture still fails after the switch, remove the `JustNow` entry from **System Settings → Privacy & Security → Screen Recording** once and relaunch so macOS can recreate it. Later updates signed with the same Developer ID identity should retain the permission normally.
+
 ## Local publish flow
 
 Use the local publish helper when you want to upload release artefacts to GitHub:

--- a/JustNow.xcodeproj/project.pbxproj
+++ b/JustNow.xcodeproj/project.pbxproj
@@ -8,8 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		AF3F00FA2F095126000F5208 /* HotKey in Frameworks */ = {isa = PBXBuildFile; productRef = AF3F00F92F095126000F5208 /* HotKey */; };
-		B1E5C8E6B82E4C0FA5BFF001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B1E5C8E6B82E4C0FA5BFF003 /* Sparkle */; };
 		AF7DAF982F5D88840041C674 /* AppIcon.icon in Resources */ = {isa = PBXBuildFile; fileRef = AF7DAF972F5D88840041C674 /* AppIcon.icon */; };
+		B1E5C8E6B82E4C0FA5BFF001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B1E5C8E6B82E4C0FA5BFF003 /* Sparkle */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,10 +42,10 @@
 		AF3F00E52F094EE1000F5208 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
-				files = (
-					AF3F00FA2F095126000F5208 /* HotKey in Frameworks */,
-					B1E5C8E6B82E4C0FA5BFF001 /* Sparkle in Frameworks */,
-				);
+			files = (
+				AF3F00FA2F095126000F5208 /* HotKey in Frameworks */,
+				B1E5C8E6B82E4C0FA5BFF001 /* Sparkle in Frameworks */,
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -87,10 +87,10 @@
 				AF3F00EA2F094EE1000F5208 /* JustNow */,
 			);
 			name = JustNow;
-				packageProductDependencies = (
-					AF3F00F92F095126000F5208 /* HotKey */,
-					B1E5C8E6B82E4C0FA5BFF003 /* Sparkle */,
-				);
+			packageProductDependencies = (
+				AF3F00F92F095126000F5208 /* HotKey */,
+				B1E5C8E6B82E4C0FA5BFF003 /* Sparkle */,
+			);
 			productName = JustNow;
 			productReference = AF3F00E82F094EE1000F5208 /* JustNow.app */;
 			productType = "com.apple.product-type.application";
@@ -119,10 +119,10 @@
 			);
 			mainGroup = AF3F00DF2F094EE1000F5208;
 			minimizedProjectReferenceProxies = 1;
-				packageReferences = (
-					AF3F00F82F095126000F5208 /* XCRemoteSwiftPackageReference "HotKey" */,
-					B1E5C8E6B82E4C0FA5BFF002 /* XCRemoteSwiftPackageReference "Sparkle" */,
-				);
+			packageReferences = (
+				AF3F00F82F095126000F5208 /* XCRemoteSwiftPackageReference "HotKey" */,
+				B1E5C8E6B82E4C0FA5BFF002 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AF3F00E92F094EE1000F5208 /* Products */;
 			projectDirPath = "";

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -107,8 +107,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private let ocrIndexBatteryQueueDepth: Int = 60
     private let ocrIndexIdleQueueDepth: Int = 40
     private let ocrIndexThermalQueueDepth: Int = 24
-    private let screenRecordingPermissionRequestCooldown: TimeInterval = 5 * 60
-    private let screenRecordingPermissionRequestTimestampKey = "screenRecordingPermissionRequestTimestamp"
 
     private struct CapturePolicy: Equatable {
         let interval: TimeInterval
@@ -123,7 +121,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private enum LaunchPermissionState {
         case granted
         case requestedThisLaunch
-        case recentlyRequested
         case deniedPreviously
     }
 
@@ -298,9 +295,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
                 }
             case .requestedThisLaunch:
                 updateCaptureStatus("Awaiting Permission")
-            case .recentlyRequested:
-                updateCaptureStatus("No Permission")
-                showPermissionAlert()
             case .deniedPreviously:
                 updateCaptureStatus("No Permission")
                 showPermissionAlert()
@@ -866,12 +860,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     private func resolveLaunchPermissionState() -> LaunchPermissionState {
         if ScreenCaptureManager.hasScreenRecordingPermission() {
-            clearRecentScreenRecordingPermissionRequest()
             return .granted
-        }
-
-        if hasRecentScreenRecordingPermissionRequest() {
-            return .recentlyRequested
         }
 
         guard !didRequestScreenRecordingPermissionThisLaunch else {
@@ -880,11 +869,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         didRequestScreenRecordingPermissionThisLaunch = true
         if ScreenCaptureManager.requestScreenRecordingPermission() {
-            clearRecentScreenRecordingPermissionRequest()
             return .granted
         }
 
-        markRecentScreenRecordingPermissionRequest()
         return .requestedThisLaunch
     }
 
@@ -916,34 +903,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         NSApp.terminate(nil)
     }
-
-    private func hasRecentScreenRecordingPermissionRequest() -> Bool {
-        guard UserDefaults.standard.object(forKey: screenRecordingPermissionRequestTimestampKey) != nil else {
-            return false
-        }
-
-        let timestamp = UserDefaults.standard.double(forKey: screenRecordingPermissionRequestTimestampKey)
-
-        let elapsed = Date().timeIntervalSince1970 - timestamp
-        guard elapsed < screenRecordingPermissionRequestCooldown else {
-            clearRecentScreenRecordingPermissionRequest()
-            return false
-        }
-
-        return true
-    }
-
-    private func markRecentScreenRecordingPermissionRequest() {
-        UserDefaults.standard.set(
-            Date().timeIntervalSince1970,
-            forKey: screenRecordingPermissionRequestTimestampKey
-        )
-    }
-
-    private func clearRecentScreenRecordingPermissionRequest() {
-        UserDefaults.standard.removeObject(forKey: screenRecordingPermissionRequestTimestampKey)
-    }
-
     private func showErrorAlert(_ error: Error) {
         let alert = NSAlert()
         alert.messageText = "Capture Error"

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -84,6 +84,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private var isPausedForSession = false
     private var idleTransitionTimer: Timer?
     private var didRequestScreenRecordingPermissionThisLaunch = false
+    private var didShowPermissionAlertThisLaunch = false
 
     private let idleThreshold: TimeInterval = 60
     private let inputPolicyUpdateInterval: TimeInterval = 1
@@ -106,6 +107,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private let ocrIndexBatteryQueueDepth: Int = 60
     private let ocrIndexIdleQueueDepth: Int = 40
     private let ocrIndexThermalQueueDepth: Int = 24
+    private let screenRecordingPermissionRequestCooldown: TimeInterval = 5 * 60
+    private let screenRecordingPermissionRequestTimestampKey = "screenRecordingPermissionRequestTimestamp"
 
     private struct CapturePolicy: Equatable {
         let interval: TimeInterval
@@ -119,7 +122,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     private enum LaunchPermissionState {
         case granted
-        case deniedAfterSystemPrompt
+        case requestedThisLaunch
+        case recentlyRequested
         case deniedPreviously
     }
 
@@ -292,8 +296,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
                     updateCaptureStatus("Error")
                     showErrorAlert(error)
                 }
-            case .deniedAfterSystemPrompt:
+            case .requestedThisLaunch:
+                updateCaptureStatus("Awaiting Permission")
+            case .recentlyRequested:
                 updateCaptureStatus("No Permission")
+                showPermissionAlert()
             case .deniedPreviously:
                 updateCaptureStatus("No Permission")
                 showPermissionAlert()
@@ -859,7 +866,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     private func resolveLaunchPermissionState() -> LaunchPermissionState {
         if ScreenCaptureManager.hasScreenRecordingPermission() {
+            clearRecentScreenRecordingPermissionRequest()
             return .granted
+        }
+
+        if hasRecentScreenRecordingPermissionRequest() {
+            return .recentlyRequested
         }
 
         guard !didRequestScreenRecordingPermissionThisLaunch else {
@@ -867,15 +879,28 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         }
 
         didRequestScreenRecordingPermissionThisLaunch = true
-        return ScreenCaptureManager.requestScreenRecordingPermission()
-            ? .granted
-            : .deniedAfterSystemPrompt
+        if ScreenCaptureManager.requestScreenRecordingPermission() {
+            clearRecentScreenRecordingPermissionRequest()
+            return .granted
+        }
+
+        markRecentScreenRecordingPermissionRequest()
+        return .requestedThisLaunch
     }
 
     private func showPermissionAlert() {
+        guard !didShowPermissionAlertThisLaunch else { return }
+        didShowPermissionAlertThisLaunch = true
+
         let alert = NSAlert()
         alert.messageText = "Screen Recording Permission Required"
-        alert.informativeText = "JustNow needs screen recording permission to capture your screen history.\n\nPlease grant permission in System Settings → Privacy & Security → Screen Recording, then restart the app."
+        alert.informativeText = """
+        JustNow needs Screen Recording permission to capture your screen history.
+
+        Open System Settings → Privacy & Security → Screen Recording and allow JustNow.
+
+        If JustNow is already enabled there but capture still fails after a recent build, signing, or notarisation change, remove the JustNow entry from Screen Recording and relaunch once so macOS can create a fresh permission record.
+        """
         alert.alertStyle = .warning
         alert.addButton(withTitle: "Open System Settings")
         alert.addButton(withTitle: "Quit")
@@ -886,8 +911,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
                 NSWorkspace.shared.open(url)
             }
+            return
         }
+
         NSApp.terminate(nil)
+    }
+
+    private func hasRecentScreenRecordingPermissionRequest() -> Bool {
+        guard UserDefaults.standard.object(forKey: screenRecordingPermissionRequestTimestampKey) != nil else {
+            return false
+        }
+
+        let timestamp = UserDefaults.standard.double(forKey: screenRecordingPermissionRequestTimestampKey)
+
+        let elapsed = Date().timeIntervalSince1970 - timestamp
+        guard elapsed < screenRecordingPermissionRequestCooldown else {
+            clearRecentScreenRecordingPermissionRequest()
+            return false
+        }
+
+        return true
+    }
+
+    private func markRecentScreenRecordingPermissionRequest() {
+        UserDefaults.standard.set(
+            Date().timeIntervalSince1970,
+            forKey: screenRecordingPermissionRequestTimestampKey
+        )
+    }
+
+    private func clearRecentScreenRecordingPermissionRequest() {
+        UserDefaults.standard.removeObject(forKey: screenRecordingPermissionRequestTimestampKey)
     }
 
     private func showErrorAlert(_ error: Error) {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -14,6 +14,7 @@ enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
     case oneMinute = 60
     case twoMinutes = 120
     case fiveMinutes = 300
+    case tenMinutes = 600
 
     static let defaultValue: Self = .fiveMinutes
 
@@ -29,6 +30,8 @@ enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
             return "2 min"
         case .fiveMinutes:
             return "5 min"
+        case .tenMinutes:
+            return "10 min"
         }
     }
 
@@ -50,8 +53,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         userDriverDelegate: nil
     )
     private var appNapPreventer = AppNapPreventer()
+    private let launchAtLoginManager = LaunchAtLoginManager()
     private var settingsWindow: NSWindow?
     private lazy var settingsContext = SettingsContext(
+        launchAtLoginManager: launchAtLoginManager,
         updater: updaterController.updater,
         onCheckForUpdates: { [weak self] in
             self?.checkForUpdates(nil)
@@ -62,6 +67,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     )
 
     @AppStorage("captureInterval") private var captureInterval: Double = 0.5
+    @AppStorage("rewindHistorySeconds") private var rewindHistorySeconds: Double = RewindHistoryOption.defaultValue.rawValue
     @AppStorage("recentTimelineWindowSeconds")
     private var recentTimelineWindowSeconds: Double = RecentTimelineWindow.defaultValue.rawValue
     @AppStorage("reduceCaptureOnBattery") private var reduceCaptureOnBattery: Bool = true
@@ -70,6 +76,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     @AppStorage("backgroundSearchIndexingEnabled") private var backgroundSearchIndexingEnabled: Bool = true
     @AppStorage("shortcutKeyCode") private var shortcutKeyCode: Int = 38  // J key
     @AppStorage("shortcutModifiers") private var shortcutModifiers: Int = 1_572_864  // ⌘⌥
+    @AppStorage("overlayDismissKeyCode") private var overlayDismissKeyCode: Int = 53
+    @AppStorage("overlayDismissModifiers") private var overlayDismissModifiers: Int = 0
 
     private var capturePolicyTimer: Timer?
     private var userDefaultsObserver: NSObjectProtocol?
@@ -249,7 +257,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         Task { @MainActor in
             // Initialize frame buffer (loads persisted frames from disk)
             do {
-                let buffer = try await FrameBuffer()
+                let buffer = try await FrameBuffer(retentionPolicy: currentRetentionPolicy())
                 frameBuffer = buffer
                 settingsContext.frameBuffer = buffer
 
@@ -322,6 +330,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.updateCapturePolicy()
+                if let self {
+                    await self.frameBuffer?.updateRetentionPolicy(self.currentRetentionPolicy())
+                }
             }
         }
 
@@ -570,13 +581,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             if overlayController == nil {
                 overlayController = OverlayWindowController(
                     frameBuffer: frameBuffer,
+                    dismissShortcutKeyCode: overlayDismissKeyCode,
+                    dismissShortcutModifiers: overlayDismissModifiers,
                     onVisibilityChanged: { [weak self] isVisible in
                         self?.handleOverlayVisibilityChanged(isVisible: isVisible)
                     }
                 )
+            } else {
+                overlayController?.updateDismissShortcut(
+                    keyCode: overlayDismissKeyCode,
+                    modifiers: overlayDismissModifiers
+                )
             }
             let recentTimelineWindow = RecentTimelineWindow.resolved(from: recentTimelineWindowSeconds)
-            overlayController?.showOverlay(recentTimelineWindow: recentTimelineWindow.timeInterval)
+            let rewindHistoryOption = RewindHistoryOption.resolved(from: rewindHistorySeconds)
+            overlayController?.showOverlay(
+                recentTimelineWindow: recentTimelineWindow.timeInterval,
+                rewindHistoryOption: rewindHistoryOption
+            )
         }
     }
 
@@ -678,6 +700,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
                 appNapPreventer.stopActivity()
             }
         }
+    }
+
+    private func currentRetentionPolicy() -> RetentionPolicy {
+        RewindHistoryOption.resolved(from: rewindHistorySeconds).retentionPolicy
     }
 
     private func computeCapturePolicy() -> CapturePolicy {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -917,21 +917,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         permissionPromptFollowUpTask = Task { @MainActor [weak self] in
             guard let self else { return }
 
-            for _ in 0..<30 {
-                try? await Task.sleep(for: .seconds(1))
+            if NSApp.isActive {
+                try? await Task.sleep(for: .milliseconds(400))
                 guard !Task.isCancelled else { return }
                 guard didRequestScreenRecordingPermissionThisLaunch else { return }
-                guard NSApp.isActive else { continue }
-
-                if ScreenCaptureManager.hasScreenRecordingPermission() {
-                    updateCaptureStatus("Restart Required")
-                    showPermissionRestartAlert()
-                } else {
-                    updateCaptureStatus("No Permission")
-                    showPermissionAlert()
-                }
+                handlePermissionPromptResolution()
                 return
             }
+
+            let becameActiveNotifications = NotificationCenter.default.notifications(
+                named: NSApplication.didBecomeActiveNotification,
+                object: NSApp
+            )
+
+            for await _ in becameActiveNotifications {
+                guard !Task.isCancelled else { return }
+                guard didRequestScreenRecordingPermissionThisLaunch else { return }
+                handlePermissionPromptResolution()
+                return
+            }
+        }
+    }
+
+    private func handlePermissionPromptResolution() {
+        if ScreenCaptureManager.hasScreenRecordingPermission() {
+            updateCaptureStatus("Restart Required")
+            showPermissionRestartAlert()
+        } else {
+            updateCaptureStatus("No Permission")
+            showPermissionAlert()
         }
     }
 

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -86,6 +86,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private var thermalObserver: NSObjectProtocol?
     private var inputEventMonitor: Any?
     private var lastAppliedPolicy: CapturePolicy?
+    private var lastAppliedRetentionPolicy: RetentionPolicy?
     private var lastUserActivityUpdate: Date = .distantPast
     private var isUserPaused = false
     private var wasCapturingBeforeOverlay = false
@@ -262,8 +263,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         Task { @MainActor in
             // Initialize frame buffer (loads persisted frames from disk)
             do {
-                let buffer = try await FrameBuffer(retentionPolicy: currentRetentionPolicy())
+                let retentionPolicy = currentRetentionPolicy()
+                let buffer = try await FrameBuffer(retentionPolicy: retentionPolicy)
                 frameBuffer = buffer
+                lastAppliedRetentionPolicy = retentionPolicy
                 settingsContext.frameBuffer = buffer
 
                 let loadedCount = buffer.frameCount
@@ -335,9 +338,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         ) { [weak self] _ in
             Task { @MainActor in
                 self?.updateCapturePolicy()
-                if let self {
-                    await self.frameBuffer?.updateRetentionPolicy(self.currentRetentionPolicy())
-                }
+                await self?.updateRetentionPolicyIfNeeded()
             }
         }
 
@@ -705,6 +706,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
                 appNapPreventer.stopActivity()
             }
         }
+    }
+
+    private func updateRetentionPolicyIfNeeded() async {
+        guard let frameBuffer else { return }
+        let retentionPolicy = currentRetentionPolicy()
+        guard retentionPolicy != lastAppliedRetentionPolicy else { return }
+        lastAppliedRetentionPolicy = retentionPolicy
+        await frameBuffer.updateRetentionPolicy(retentionPolicy)
     }
 
     private func currentRetentionPolicy() -> RetentionPolicy {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -78,6 +78,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     @AppStorage("shortcutModifiers") private var shortcutModifiers: Int = 1_572_864  // ⌘⌥
     @AppStorage("overlayDismissKeyCode") private var overlayDismissKeyCode: Int = 53
     @AppStorage("overlayDismissModifiers") private var overlayDismissModifiers: Int = 0
+    @AppStorage("hasRequestedScreenRecordingPermission")
+    private var hasRequestedScreenRecordingPermission = false
 
     private var capturePolicyTimer: Timer?
     private var userDefaultsObserver: NSObjectProtocol?
@@ -93,6 +95,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private var idleTransitionTimer: Timer?
     private var didRequestScreenRecordingPermissionThisLaunch = false
     private var didShowPermissionAlertThisLaunch = false
+    private var didShowPermissionRestartAlertThisLaunch = false
+    private var permissionPromptFollowUpTask: Task<Void, Never>?
 
     private let idleThreshold: TimeInterval = 60
     private let inputPolicyUpdateInterval: TimeInterval = 1
@@ -153,6 +157,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         appNapPreventer.stopActivity()
         capturePolicyTimer?.invalidate()
         idleTransitionTimer?.invalidate()
+        permissionPromptFollowUpTask?.cancel()
         if let observer = userDefaultsObserver {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -889,16 +894,45 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             return .granted
         }
 
+        if hasRequestedScreenRecordingPermission {
+            return .deniedPreviously
+        }
+
         guard !didRequestScreenRecordingPermissionThisLaunch else {
             return .deniedPreviously
         }
 
         didRequestScreenRecordingPermissionThisLaunch = true
+        hasRequestedScreenRecordingPermission = true
         if ScreenCaptureManager.requestScreenRecordingPermission() {
             return .granted
         }
 
+        schedulePermissionPromptFollowUp()
         return .requestedThisLaunch
+    }
+
+    private func schedulePermissionPromptFollowUp() {
+        permissionPromptFollowUpTask?.cancel()
+        permissionPromptFollowUpTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+
+            for _ in 0..<30 {
+                try? await Task.sleep(for: .seconds(1))
+                guard !Task.isCancelled else { return }
+                guard didRequestScreenRecordingPermissionThisLaunch else { return }
+                guard NSApp.isActive else { continue }
+
+                if ScreenCaptureManager.hasScreenRecordingPermission() {
+                    updateCaptureStatus("Restart Required")
+                    showPermissionRestartAlert()
+                } else {
+                    updateCaptureStatus("No Permission")
+                    showPermissionAlert()
+                }
+                return
+            }
+        }
     }
 
     private func showPermissionAlert() {
@@ -911,6 +945,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         JustNow needs Screen Recording permission to capture your screen history.
 
         Open System Settings → Privacy & Security → Screen Recording and allow JustNow.
+
+        After enabling JustNow, quit and reopen the app once so capture can restart cleanly with the new permission.
 
         If JustNow is already enabled there but capture still fails after a recent build, signing, or notarisation change, remove the JustNow entry from Screen Recording and relaunch once so macOS can create a fresh permission record.
         """
@@ -929,6 +965,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         NSApp.terminate(nil)
     }
+
+    private func showPermissionRestartAlert() {
+        guard !didShowPermissionRestartAlertThisLaunch else { return }
+        didShowPermissionRestartAlertThisLaunch = true
+
+        let alert = NSAlert()
+        alert.messageText = "Restart JustNow to Start Capture"
+        alert.informativeText = """
+        Screen Recording is now enabled for JustNow.
+
+        Quit and reopen the app once so capture can restart cleanly with the new permission.
+        """
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Quit JustNow")
+        alert.addButton(withTitle: "Later")
+
+        NSApp.activate(ignoringOtherApps: true)
+
+        if alert.runModal() == .alertFirstButtonReturn {
+            NSApp.terminate(nil)
+        }
+    }
+
     private func showErrorAlert(_ error: Error) {
         let alert = NSAlert()
         alert.messageText = "Capture Error"

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -44,7 +44,7 @@ struct OCRIndexingPolicy: Sendable, Equatable {
 class FrameBuffer {
     private var frames: [StoredFrame] = []
     private let frameStore: FrameStore
-    private let retentionManager = RetentionManager()
+    private let retentionManager: RetentionManager
     private var blackFrameFilterUntil: Date?
     private var lastStoredHash: UInt64?
     private var lastStoredTimestamp: Date?
@@ -67,8 +67,9 @@ class FrameBuffer {
     // OCR text cache for faster subsequent searches
     let textCache = TextCache()
 
-    init() async throws {
+    init(retentionPolicy: RetentionPolicy = .default24Hours) async throws {
         self.frameStore = try FrameStore()
+        self.retentionManager = RetentionManager(policy: retentionPolicy)
         thumbnailCache.countLimit = 100
 
         // Load persisted frames
@@ -152,14 +153,26 @@ class FrameBuffer {
 
     /// Get frames with near-duplicates removed for smoother browsing.
     /// The newest window keeps all stored frames so keyboard navigation tracks recent capture cadence.
-    func getFilteredFrames(hashThreshold: Int = 3, recentWindow: TimeInterval = 300) -> [StoredFrame] {
+    func getFilteredFrames(
+        hashThreshold: Int = 3,
+        recentWindow: TimeInterval = 300,
+        maximumAge: TimeInterval? = nil
+    ) -> [StoredFrame] {
         guard !frames.isEmpty else { return [] }
 
         let now = Date()
+        let candidateFrames: [StoredFrame]
+        if let maximumAge {
+            let cutoff = now.addingTimeInterval(-maximumAge)
+            candidateFrames = frames.filter { $0.timestamp >= cutoff }
+        } else {
+            candidateFrames = frames
+        }
+
         var filtered: [StoredFrame] = []
         var lastHash: UInt64?
 
-        for frame in frames {
+        for frame in candidateFrames {
             let age = now.timeIntervalSince(frame.timestamp)
 
             // Keep every stored frame in the recent window.
@@ -258,6 +271,11 @@ class FrameBuffer {
         startBackgroundOCRIndexingIfNeeded()
     }
 
+    func updateRetentionPolicy(_ policy: RetentionPolicy) async {
+        retentionManager.updatePolicy(policy)
+        await prune(force: true)
+    }
+
     func flushCaches() async {
         await frameStore.flushManifest()
         await textCache.save()
@@ -283,10 +301,16 @@ class FrameBuffer {
     }
 
     private func pruneIfNeeded() async {
+        await prune(force: false)
+    }
+
+    private func prune(force: Bool) async {
         guard !isPruningPaused else { return }
 
         let now = Date()
-        guard now.timeIntervalSince(lastPruneCheck) >= pruneInterval else { return }
+        if !force {
+            guard now.timeIntervalSince(lastPruneCheck) >= pruneInterval else { return }
+        }
         lastPruneCheck = now
 
         let toPrune = retentionManager.framesToPrune(frames: frames, currentTime: now)

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -5,53 +5,93 @@
 
 import Foundation
 
-struct RetentionTier {
-    let maxAge: TimeInterval      // Frames older than this get pruned to next tier
-    let keepEveryNth: Int         // Keep every Nth frame when in this tier
+struct RetentionTier: Sendable, Equatable {
+    let maxAge: TimeInterval
+    let minimumSpacing: TimeInterval
 }
 
-class RetentionManager {
-    // Retention policy: more recent = denser
-    // Tiers ordered by maxAge ascending; minInterval is seconds between kept frames
-    static let tiers: [RetentionTier] = [
-        RetentionTier(maxAge: 300, keepEveryNth: 1),     // 0-5m: keep all (for text recall)
-        RetentionTier(maxAge: 900, keepEveryNth: 5),     // 5-15m: ~5s intervals
-        RetentionTier(maxAge: 86400, keepEveryNth: 30),  // 15m-24h: ~30s intervals (archive)
-    ]
+struct RetentionPolicy: Sendable, Equatable {
+    let maximumAge: TimeInterval
+    let tiers: [RetentionTier]
 
-    /// Returns IDs of frames to delete based on time-based retention policy
+    static let default24Hours = rewindHistory(RewindHistoryOption.defaultValue)
+
+    static func rewindHistory(_ option: RewindHistoryOption) -> RetentionPolicy {
+        let maximumAge = option.retainedDuration
+
+        let tiers: [RetentionTier]
+        switch option {
+        case .thirtyMinutes:
+            tiers = [
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: option.duration, minimumSpacing: 15),
+                RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
+            ]
+        case .twoHours:
+            tiers = [
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: maximumAge, minimumSpacing: 20),
+            ]
+        case .eightHours:
+            tiers = [
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: maximumAge, minimumSpacing: 25),
+            ]
+        case .twentyFourHours:
+            tiers = [
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
+            ]
+        }
+
+        return RetentionPolicy(maximumAge: maximumAge, tiers: tiers)
+    }
+}
+
+@MainActor
+final class RetentionManager {
+    private var policy: RetentionPolicy
+
+    init(policy: RetentionPolicy = .default24Hours) {
+        self.policy = policy
+    }
+
+    func updatePolicy(_ policy: RetentionPolicy) {
+        self.policy = policy
+    }
+
     func framesToPrune(frames: [StoredFrame], currentTime: Date) -> Set<UUID> {
         var toKeep = Set<UUID>()
-        var lastKeptTime: [Int: Date] = [:]  // Last kept timestamp per tier
+        var lastKeptTime: [Int: Date] = [:]
 
-        // Process OLDEST to NEWEST so spacing is stable.
         for frame in frames.sorted(by: { $0.timestamp < $1.timestamp }) {
             let age = currentTime.timeIntervalSince(frame.timestamp)
 
-            // Find which tier this frame belongs to
-            guard let tierIndex = Self.tiers.firstIndex(where: { age <= $0.maxAge }) else {
-                // Too old, will be pruned
+            guard age <= policy.maximumAge else {
                 continue
             }
 
-            let tier = Self.tiers[tierIndex]
-            let minInterval = TimeInterval(tier.keepEveryNth)
+            guard let tierIndex = policy.tiers.firstIndex(where: { age <= $0.maxAge }) else {
+                continue
+            }
 
+            let tier = policy.tiers[tierIndex]
             if let lastTime = lastKeptTime[tierIndex] {
-                // Keep if enough time passed since last kept frame in this tier
-                if frame.timestamp.timeIntervalSince(lastTime) >= minInterval {
+                if frame.timestamp.timeIntervalSince(lastTime) >= tier.minimumSpacing {
                     toKeep.insert(frame.id)
                     lastKeptTime[tierIndex] = frame.timestamp
                 }
             } else {
-                // First frame in tier, always keep
                 toKeep.insert(frame.id)
                 lastKeptTime[tierIndex] = frame.timestamp
             }
         }
 
-        // Return IDs NOT in toKeep
-        let allIds = Set(frames.map { $0.id })
-        return allIds.subtracting(toKeep)
+        let allIDs = Set(frames.map { $0.id })
+        return allIDs.subtracting(toKeep)
     }
 }

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -23,26 +23,26 @@ struct RetentionPolicy: Sendable, Equatable {
         switch option {
         case .thirtyMinutes:
             tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
                 RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: option.duration, minimumSpacing: 15),
                 RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
             ]
         case .twoHours:
             tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
                 RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: maximumAge, minimumSpacing: 20),
             ]
         case .eightHours:
             tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
                 RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: maximumAge, minimumSpacing: 25),
             ]
         case .twentyFourHours:
             tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
                 RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
             ]
@@ -68,7 +68,7 @@ final class RetentionManager {
         var toKeep = Set<UUID>()
         var lastKeptTime: [Int: Date] = [:]
 
-        for frame in frames.sorted(by: { $0.timestamp < $1.timestamp }) {
+        for frame in frames {
             let age = currentTime.timeIntervalSince(frame.timestamp)
 
             guard age <= policy.maximumAge else {

--- a/JustNow/Storage/RewindHistoryOption.swift
+++ b/JustNow/Storage/RewindHistoryOption.swift
@@ -1,0 +1,71 @@
+//
+//  RewindHistoryOption.swift
+//  JustNow
+//
+
+import Foundation
+
+enum RewindHistoryOption: Double, CaseIterable, Identifiable {
+    case thirtyMinutes = 1800
+    case twoHours = 7200
+    case eightHours = 28800
+    case twentyFourHours = 86400
+
+    static let defaultValue: Self = .twentyFourHours
+
+    var id: Double { rawValue }
+
+    var duration: TimeInterval { rawValue }
+
+    /// Keep enough sparse archive for the dedicated 1-hour search scope even when the rewind window is shorter.
+    var retainedDuration: TimeInterval {
+        max(duration, 60 * 60)
+    }
+
+    var settingsLabel: String {
+        switch self {
+        case .thirtyMinutes:
+            return "30 min"
+        case .twoHours:
+            return "2 hr"
+        case .eightHours:
+            return "8 hr"
+        case .twentyFourHours:
+            return "24 hr"
+        }
+    }
+
+    var searchLabel: String {
+        switch self {
+        case .thirtyMinutes:
+            return "Last 30m"
+        case .twoHours:
+            return "Last 2h"
+        case .eightHours:
+            return "Last 8h"
+        case .twentyFourHours:
+            return "Last 24h"
+        }
+    }
+
+    var compactSearchLabel: String {
+        switch self {
+        case .thirtyMinutes:
+            return "30m"
+        case .twoHours:
+            return "2h"
+        case .eightHours:
+            return "8h"
+        case .twentyFourHours:
+            return "24h"
+        }
+    }
+
+    var retentionPolicy: RetentionPolicy {
+        .rewindHistory(self)
+    }
+
+    static func resolved(from rawValue: Double) -> Self {
+        Self(rawValue: rawValue) ?? .defaultValue
+    }
+}

--- a/JustNow/UI/KeyboardShortcutRecorder.swift
+++ b/JustNow/UI/KeyboardShortcutRecorder.swift
@@ -11,6 +11,10 @@ struct KeyboardShortcutRecorder: View {
     @Binding var keyCode: Int
     @Binding var modifiers: Int
 
+    var allowsBareKeys: Bool = false
+    var allowsEscapeShortcut: Bool = false
+    var placeholder: String = "Click to set"
+
     @State private var isRecording = false
     @FocusState private var isFocused: Bool
 
@@ -19,7 +23,10 @@ struct KeyboardShortcutRecorder: View {
             RecorderField(
                 keyCode: $keyCode,
                 modifiers: $modifiers,
-                isRecording: $isRecording
+                isRecording: $isRecording,
+                allowsBareKeys: allowsBareKeys,
+                allowsEscapeShortcut: allowsEscapeShortcut,
+                placeholder: placeholder
             )
             .frame(minWidth: 120, maxWidth: 200)
             .frame(height: 24)
@@ -51,13 +58,23 @@ struct RecorderField: NSViewRepresentable {
     @Binding var modifiers: Int
     @Binding var isRecording: Bool
 
+    var allowsBareKeys: Bool
+    var allowsEscapeShortcut: Bool
+    var placeholder: String
+
     func makeNSView(context: Context) -> RecorderNSView {
         let view = RecorderNSView()
         view.delegate = context.coordinator
+        view.allowsBareKeys = allowsBareKeys
+        view.allowsEscapeShortcut = allowsEscapeShortcut
+        view.placeholder = placeholder
         return view
     }
 
     func updateNSView(_ nsView: RecorderNSView, context: Context) {
+        nsView.allowsBareKeys = allowsBareKeys
+        nsView.allowsEscapeShortcut = allowsEscapeShortcut
+        nsView.placeholder = placeholder
         nsView.updateDisplay(keyCode: keyCode, modifiers: modifiers, isRecording: isRecording)
     }
 
@@ -98,6 +115,10 @@ protocol RecorderNSViewDelegate: AnyObject {
 
 class RecorderNSView: NSView {
     weak var delegate: RecorderNSViewDelegate?
+
+    var allowsBareKeys = false
+    var allowsEscapeShortcut = false
+    var placeholder = "Click to set"
 
     private var isRecording = false
     private var currentKeyCode: Int = -1
@@ -148,16 +169,18 @@ class RecorderNSView: NSView {
             return
         }
 
-        // Escape cancels recording
-        if event.keyCode == UInt16(kVK_Escape) {
+        // Escape cancels recording unless this recorder explicitly allows binding it.
+        if event.keyCode == UInt16(kVK_Escape) && !allowsEscapeShortcut {
             stopRecording()
             return
         }
 
         let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
-        // Require at least one modifier (cmd, opt, ctrl, or shift)
-        guard mods.contains(.command) || mods.contains(.option) || mods.contains(.control) || mods.contains(.shift) else {
+        let hasModifier = mods.contains(.command) || mods.contains(.option) || mods.contains(.control) || mods.contains(.shift)
+
+        // Require at least one modifier unless bare keys are explicitly allowed.
+        guard allowsBareKeys || hasModifier else {
             return
         }
 
@@ -226,7 +249,7 @@ class RecorderNSView: NSView {
 
     private func updateDisplayText() {
         if currentKeyCode == -1 {
-            textField.stringValue = "Click to set"
+            textField.stringValue = placeholder
             textField.textColor = .secondaryLabelColor
         } else {
             let mods = NSEvent.ModifierFlags(rawValue: UInt(currentModifiers))

--- a/JustNow/UI/KeyboardShortcutRecorder.swift
+++ b/JustNow/UI/KeyboardShortcutRecorder.swift
@@ -178,9 +178,11 @@ class RecorderNSView: NSView {
         let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
 
         let hasModifier = mods.contains(.command) || mods.contains(.option) || mods.contains(.control) || mods.contains(.shift)
+        let isEscape = event.keyCode == UInt16(kVK_Escape)
+        let hasModifierOrAllowedEscape = hasModifier || (isEscape && allowsEscapeShortcut)
 
         // Require at least one modifier unless bare keys are explicitly allowed.
-        guard allowsBareKeys || hasModifier else {
+        guard allowsBareKeys || hasModifierOrAllowedEscape else {
             return
         }
 

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -295,38 +295,53 @@ class OverlayViewModel {
     }
 
     func moveLeft() {
+        guard ensureDisplayedSelection() else { return }
         if selectedIndex > 0 {
             selectedIndex -= 1
         }
     }
 
     func moveRight() {
+        guard ensureDisplayedSelection() else { return }
         if selectedIndex < displayedFrameCount - 1 {
             selectedIndex += 1
         }
     }
 
     func jumpLeft() {
+        guard ensureDisplayedSelection() else { return }
         selectedIndex = max(0, selectedIndex - 10)
     }
 
     func jumpRight() {
+        guard ensureDisplayedSelection() else { return }
         selectedIndex = min(displayedFrameCount - 1, selectedIndex + 10)
     }
 
     func goToStart() {
+        guard ensureDisplayedSelection() else { return }
         selectedIndex = 0
     }
 
     func goToEnd() {
+        guard ensureDisplayedSelection() else { return }
         selectedIndex = max(0, displayedFrameCount - 1)
     }
 
     func scrollBy(_ delta: CGFloat) {
-        guard displayedFrameCount > 0 else { return }
+        guard ensureDisplayedSelection() else { return }
         let step = delta > 0 ? -1 : 1
         let newIndex = selectedIndex + step
         selectedIndex = max(0, min(displayedFrameCount - 1, newIndex))
+    }
+
+    private func ensureDisplayedSelection() -> Bool {
+        guard displayedFrameCount > 0 else {
+            selectedIndex = 0
+            return false
+        }
+        selectedIndex = max(0, min(displayedFrameCount - 1, selectedIndex))
+        return true
     }
 }
 

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -13,7 +13,7 @@ private let logger = Logger(subsystem: "sg.tk.JustNow", category: "OverlayView")
 enum SearchTimeScope: String, CaseIterable {
     case fiveMinutes
     case oneHour
-    case oneDay
+    case rewindHistory
     case all
 
     var label: String {
@@ -22,8 +22,8 @@ enum SearchTimeScope: String, CaseIterable {
             return "Last 5m"
         case .oneHour:
             return "Last 1h"
-        case .oneDay:
-            return "Last 24h"
+        case .rewindHistory:
+            return RewindHistoryOption.defaultValue.searchLabel
         case .all:
             return "All"
         }
@@ -35,21 +35,47 @@ enum SearchTimeScope: String, CaseIterable {
             return "5m"
         case .oneHour:
             return "1h"
-        case .oneDay:
-            return "24h"
+        case .rewindHistory:
+            return RewindHistoryOption.defaultValue.compactSearchLabel
         case .all:
             return "All"
         }
     }
 
-    func cutoff(from now: Date = Date()) -> Date? {
+    func label(using option: RewindHistoryOption) -> String {
+        switch self {
+        case .fiveMinutes:
+            return "Last 5m"
+        case .oneHour:
+            return "Last 1h"
+        case .rewindHistory:
+            return option.searchLabel
+        case .all:
+            return "All"
+        }
+    }
+
+    func compactLabel(using option: RewindHistoryOption) -> String {
+        switch self {
+        case .fiveMinutes:
+            return "5m"
+        case .oneHour:
+            return "1h"
+        case .rewindHistory:
+            return option.compactSearchLabel
+        case .all:
+            return "All"
+        }
+    }
+
+    func cutoff(using option: RewindHistoryOption, from now: Date = Date()) -> Date? {
         switch self {
         case .fiveMinutes:
             return now.addingTimeInterval(-5 * 60)
         case .oneHour:
             return now.addingTimeInterval(-60 * 60)
-        case .oneDay:
-            return now.addingTimeInterval(-24 * 60 * 60)
+        case .rewindHistory:
+            return now.addingTimeInterval(-option.duration)
         case .all:
             return nil
         }
@@ -60,8 +86,10 @@ enum SearchTimeScope: String, CaseIterable {
 @MainActor
 class OverlayViewModel {
     var selectedIndex: Int = 0
-    let frames: [StoredFrame]
+    let timelineFrames: [StoredFrame]
+    let searchableFrames: [StoredFrame]
     let frameBuffer: FrameBuffer
+    let rewindHistoryOption: RewindHistoryOption
     let timelineReferenceDate: Date
     let onDismiss: () -> Void
 
@@ -76,23 +104,31 @@ class OverlayViewModel {
 
     /// Frames to display (filtered if searching, all otherwise)
     var displayedFrames: [StoredFrame] {
-        isSearching && !searchQuery.isEmpty ? searchResults : frames
+        isSearching && !searchQuery.isEmpty ? searchResults : timelineFrames
     }
 
     var displayedFrameCount: Int {
         displayedFrames.count
     }
 
+    var hasAnyFrames: Bool {
+        !timelineFrames.isEmpty || !searchableFrames.isEmpty
+    }
+
     init(
-        frames: [StoredFrame],
+        timelineFrames: [StoredFrame],
+        searchableFrames: [StoredFrame],
         frameBuffer: FrameBuffer,
+        rewindHistoryOption: RewindHistoryOption,
         onDismiss: @escaping () -> Void
     ) {
-        self.frames = frames
+        self.timelineFrames = timelineFrames
+        self.searchableFrames = searchableFrames
         self.frameBuffer = frameBuffer
+        self.rewindHistoryOption = rewindHistoryOption
         self.timelineReferenceDate = Date()
         self.onDismiss = onDismiss
-        self.selectedIndex = max(0, frames.count - 1)
+        self.selectedIndex = max(0, timelineFrames.count - 1)
     }
 
     func toggleSearch() {
@@ -111,7 +147,7 @@ class OverlayViewModel {
         isSearchInProgress = false
         searchProgress = 0
         // Reset to end of full frames
-        selectedIndex = max(0, frames.count - 1)
+        selectedIndex = max(0, timelineFrames.count - 1)
     }
 
     func performSearch() {
@@ -123,8 +159,8 @@ class OverlayViewModel {
             return
         }
 
-        logger.info("Starting search for: '\(self.searchQuery)' in \(self.frames.count) frames")
-        print("[JustNow] Starting search for: '\(searchQuery)' in \(frames.count) frames")
+        logger.info("Starting search for: '\(self.searchQuery)' in \(self.searchableFrames.count) frames")
+        print("[JustNow] Starting search for: '\(searchQuery)' in \(searchableFrames.count) frames")
 
         isSearchInProgress = true
         searchProgress = 0
@@ -132,10 +168,10 @@ class OverlayViewModel {
 
         let query = searchQuery // Capture locally for task
         let scope = searchTimeScope
-        let searchCutoff = scope.cutoff()
+        let searchCutoff = scope.cutoff(using: rewindHistoryOption)
         let framesToSearch = searchCutoff.map { cutoff in
-            frames.filter { $0.timestamp >= cutoff }
-        } ?? frames
+            searchableFrames.filter { $0.timestamp >= cutoff }
+        } ?? searchableFrames
         let buffer = frameBuffer
         let cache = frameBuffer.textCache
         let searchStartedAt = Date()
@@ -312,7 +348,7 @@ struct OverlayView: View {
 
             CompatGlassEffectContainer(spacing: 40) {
                 ZStack {
-                    if viewModel.frames.isEmpty {
+                    if !viewModel.hasAnyFrames {
                         EmptyStateView()
                     } else {
                         ContentAreaView(viewModel: viewModel)
@@ -364,6 +400,18 @@ struct ContentAreaView: View {
                 FramePreviewView(frame: frame, frameBuffer: viewModel.frameBuffer)
                     .padding(.horizontal, 60)
                     .padding(.top, viewModel.isSearching ? 20 : 40)
+            } else if !viewModel.isSearching && viewModel.timelineFrames.isEmpty {
+                VStack(spacing: 12) {
+                    Image(systemName: "clock.badge.exclamationmark")
+                        .font(.system(size: 40))
+                        .foregroundStyle(.white.opacity(0.4))
+                    Text("No frames in this rewind window")
+                        .font(.headline)
+                        .foregroundStyle(.white.opacity(0.6))
+                    Text("Search can still look through the last hour.")
+                        .font(.subheadline)
+                        .foregroundStyle(.white.opacity(0.45))
+                }
             } else if viewModel.isSearching && displayedFrames.isEmpty && !viewModel.isSearchInProgress {
                 // No results state
                 VStack(spacing: 12) {
@@ -479,15 +527,15 @@ struct SearchBarView: View {
                         }
                     } label: {
                         if scope == viewModel.searchTimeScope {
-                            Label(scope.label, systemImage: "checkmark")
+                            Label(scope.label(using: viewModel.rewindHistoryOption), systemImage: "checkmark")
                         } else {
-                            Text(scope.label)
+                            Text(scope.label(using: viewModel.rewindHistoryOption))
                         }
                     }
                 }
             } label: {
                 HStack(spacing: 6) {
-                    Text(viewModel.searchTimeScope.compactLabel)
+                    Text(viewModel.searchTimeScope.compactLabel(using: viewModel.rewindHistoryOption))
                         .font(.caption)
                         .fontWeight(.medium)
                     Image(systemName: "chevron.down")
@@ -513,7 +561,6 @@ struct InstructionsOverlay: View {
             HStack {
                 Spacer()
                 HStack(spacing: 16) {
-                    Label("ESC", systemImage: "escape")
                     Label("← →", systemImage: "arrow.left.arrow.right")
                     Label("/", systemImage: "magnifyingglass")
                 }
@@ -1059,9 +1106,8 @@ private func timelineLandmarkMarkers(
 private func timelineMarkerTargets(upTo oldestAge: TimeInterval, now: Date) -> [TimelineMarkerTarget] {
     guard oldestAge > 0 else { return [] }
 
-    let dayLimit = min(oldestAge, 24 * 60 * 60)
     let relativeAges: [TimeInterval] = [5.0 * 60, 10.0 * 60, 30.0 * 60, 60.0 * 60, 2.0 * 60.0 * 60.0]
-        .filter { $0 <= dayLimit }
+        .filter { $0 <= oldestAge }
     var targets = relativeAges.enumerated().map { index, targetAge in
         TimelineMarkerTarget(
             targetAge: targetAge,
@@ -1071,18 +1117,18 @@ private func timelineMarkerTargets(upTo oldestAge: TimeInterval, now: Date) -> [
         )
     }
 
-    if dayLimit > 2 * 60 * 60 {
+    if oldestAge > 2 * 60 * 60 {
         let blockHours = [3, 4, 6, 8, 12, 16, 24]
         var priority = targets.count
         var seenDates: Set<TimeInterval> = Set(targets.map { $0.targetDate.timeIntervalSinceReferenceDate })
         for blockHour in blockHours {
-            guard blockHour <= Int(dayLimit / 3600) else { continue }
+            guard blockHour <= Int(oldestAge / 3600) else { continue }
             let rawTargetDate = now.addingTimeInterval(-TimeInterval(blockHour * 3600))
             let snappedTargetDate = snappedTimelineAbsoluteDate(rawTargetDate)
             let snappedAge = now.timeIntervalSince(snappedTargetDate)
 
             if snappedAge > 2 * 60 * 60,
-               snappedAge <= dayLimit,
+               snappedAge <= oldestAge,
                seenDates.insert(snappedTargetDate.timeIntervalSinceReferenceDate).inserted {
                 targets.append(
                     TimelineMarkerTarget(

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -5,33 +5,57 @@
 
 import AppKit
 import SwiftUI
+import Carbon.HIToolbox
 
 @MainActor
 class OverlayWindowController: NSObject {
     private var window: OverlayWindow?
     private let frameBuffer: FrameBuffer
     private let onVisibilityChanged: ((Bool) -> Void)?
+    private var dismissShortcutKeyCode: Int
+    private var dismissShortcutModifiers: Int
     private var keyEventMonitor: Any?
     private var scrollEventMonitor: Any?
     private var viewModel: OverlayViewModel?
 
-    init(frameBuffer: FrameBuffer, onVisibilityChanged: ((Bool) -> Void)? = nil) {
+    init(
+        frameBuffer: FrameBuffer,
+        dismissShortcutKeyCode: Int,
+        dismissShortcutModifiers: Int,
+        onVisibilityChanged: ((Bool) -> Void)? = nil
+    ) {
         self.frameBuffer = frameBuffer
+        self.dismissShortcutKeyCode = dismissShortcutKeyCode
+        self.dismissShortcutModifiers = dismissShortcutModifiers
         self.onVisibilityChanged = onVisibilityChanged
         super.init()
     }
 
-    func showOverlay(recentTimelineWindow: TimeInterval = RecentTimelineWindow.defaultValue.timeInterval) {
+    func updateDismissShortcut(keyCode: Int, modifiers: Int) {
+        dismissShortcutKeyCode = keyCode
+        dismissShortcutModifiers = modifiers
+    }
+
+    func showOverlay(
+        recentTimelineWindow: TimeInterval = RecentTimelineWindow.defaultValue.timeInterval,
+        rewindHistoryOption: RewindHistoryOption = .defaultValue
+    ) {
         guard window == nil, let screen = NSScreen.main else { return }
 
         // Pause pruning while overlay is visible
         frameBuffer.isPruningPaused = true
 
         // Get frames with near-duplicates filtered out for smoother browsing
-        let frames = frameBuffer.getFilteredFrames(recentWindow: recentTimelineWindow)
+        let timelineFrames = frameBuffer.getFilteredFrames(
+            recentWindow: recentTimelineWindow,
+            maximumAge: rewindHistoryOption.duration
+        )
+        let searchableFrames = frameBuffer.getFilteredFrames(recentWindow: recentTimelineWindow)
         let vm = OverlayViewModel(
-            frames: frames,
+            timelineFrames: timelineFrames,
+            searchableFrames: searchableFrames,
             frameBuffer: frameBuffer,
+            rewindHistoryOption: rewindHistoryOption,
             onDismiss: { [weak self] in
                 self?.hideOverlay()
             }
@@ -70,6 +94,16 @@ class OverlayWindowController: NSObject {
             guard let self = self, let vm = self.viewModel else { return event }
 
             print("[JustNow] Key pressed: keyCode=\(event.keyCode), chars='\(event.characters ?? "")'")
+
+            let pressedModifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+            let dismissModifiers = NSEvent.ModifierFlags(rawValue: UInt(self.dismissShortcutModifiers))
+                .intersection(.deviceIndependentFlagsMask)
+            let matchesDismissShortcut = Int(event.keyCode) == self.dismissShortcutKeyCode && pressedModifiers == dismissModifiers
+
+            if matchesDismissShortcut && event.keyCode != UInt16(kVK_Escape) {
+                self.hideOverlay()
+                return nil
+            }
 
             switch event.keyCode {
             case 53: // ESC
@@ -114,6 +148,10 @@ class OverlayWindowController: NSObject {
                 }
                 return nil
             default:
+                if matchesDismissShortcut {
+                    self.hideOverlay()
+                    return nil
+                }
                 return event
             }
         }

--- a/JustNow/UI/SettingsContext.swift
+++ b/JustNow/UI/SettingsContext.swift
@@ -10,17 +10,20 @@ import Sparkle
 @Observable
 final class SettingsContext {
     var frameBuffer: FrameBuffer?
+    var launchAtLoginManager: LaunchAtLoginManager?
     var updater: SPUUpdater?
     private let onCheckForUpdates: @MainActor () -> Void
     private let onShortcutChanged: @MainActor () -> Void
 
     init(
         frameBuffer: FrameBuffer? = nil,
+        launchAtLoginManager: LaunchAtLoginManager? = nil,
         updater: SPUUpdater? = nil,
         onCheckForUpdates: @escaping @MainActor () -> Void = {},
         onShortcutChanged: @escaping @MainActor () -> Void = {}
     ) {
         self.frameBuffer = frameBuffer
+        self.launchAtLoginManager = launchAtLoginManager
         self.updater = updater
         self.onCheckForUpdates = onCheckForUpdates
         self.onShortcutChanged = onShortcutChanged
@@ -32,5 +35,21 @@ final class SettingsContext {
 
     func notifyShortcutChanged() {
         onShortcutChanged()
+    }
+
+    var canConfigureLaunchAtLogin: Bool {
+        launchAtLoginManager?.canConfigure ?? false
+    }
+
+    func launchAtLoginEnabled() -> Bool {
+        launchAtLoginManager?.isEnabled ?? false
+    }
+
+    func setLaunchAtLoginEnabled(_ isEnabled: Bool) throws -> LaunchAtLoginManager.ChangeResult {
+        guard let launchAtLoginManager else {
+            throw LaunchAtLoginError.serviceUnavailable
+        }
+
+        return try launchAtLoginManager.setEnabled(isEnabled)
     }
 }

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -8,6 +8,8 @@ import Sparkle
 
 struct SettingsView: View {
     @AppStorage("captureInterval") private var captureInterval: Double = 0.5
+    @AppStorage("rewindHistorySeconds")
+    private var rewindHistorySeconds: Double = RewindHistoryOption.defaultValue.rawValue
     @AppStorage("recentTimelineWindowSeconds")
     private var recentTimelineWindowSeconds: Double = RecentTimelineWindow.defaultValue.rawValue
     @AppStorage("reduceCaptureOnBattery") private var reduceCaptureOnBattery: Bool = true
@@ -16,6 +18,8 @@ struct SettingsView: View {
     @AppStorage("backgroundSearchIndexingEnabled") private var backgroundSearchIndexingEnabled: Bool = true
     @AppStorage("shortcutKeyCode") private var shortcutKeyCode: Int = 38  // J key
     @AppStorage("shortcutModifiers") private var shortcutModifiers: Int = 1_572_864  // ⌘⌥
+    @AppStorage("overlayDismissKeyCode") private var overlayDismissKeyCode: Int = 53
+    @AppStorage("overlayDismissModifiers") private var overlayDismissModifiers: Int = 0
 
     var context: SettingsContext = SettingsContext()
 
@@ -27,38 +31,102 @@ struct SettingsView: View {
     @State private var automaticallyChecksForUpdates = false
     @State private var automaticallyDownloadsUpdates = false
     @State private var allowsAutomaticUpdates = false
+    @State private var launchAtLoginEnabled = false
+    @State private var launchAtLoginAlertMessage: String?
 
     var body: some View {
         Form {
             Section {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("Capture interval: \(String(format: "%.1f", captureInterval))s")
-                    Slider(value: $captureInterval, in: 0.5...5.0, step: 0.5)
+                Toggle("Launch on startup", isOn: launchAtLoginBinding)
+                    .disabled(!context.canConfigureLaunchAtLogin)
+
+                Text("If macOS asks for approval, enable JustNow in System Settings > General > Login Items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                HStack {
+                    Text("Show")
+                    Spacer()
+                    KeyboardShortcutRecorder(
+                        keyCode: $shortcutKeyCode,
+                        modifiers: $shortcutModifiers
+                    )
+                    .frame(maxWidth: 240)
+                    .onChange(of: shortcutKeyCode) { _, _ in context.notifyShortcutChanged() }
+                    .onChange(of: shortcutModifiers) { _, _ in context.notifyShortcutChanged() }
                 }
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Retention: up to 24 hours")
-                    Text("• Last 5m: every frame\n• 5–15m: every 5th\n• 15m–24h: every 30th")
+                HStack {
+                    Text("Hide")
+                    Spacer()
+                    KeyboardShortcutRecorder(
+                        keyCode: $overlayDismissKeyCode,
+                        modifiers: $overlayDismissModifiers,
+                        allowsBareKeys: true,
+                        allowsEscapeShortcut: true,
+                        placeholder: "Press key"
+                    )
+                    .frame(maxWidth: 240)
+                }
+            } header: {
+                Text("General")
+            }
+
+            Section {
+                LabeledContent {
+                    HStack(spacing: 8) {
+                        Slider(value: $captureInterval, in: 0.5...5.0, step: 0.5)
+                            .frame(width: 180)
+
+                        Text("\(captureInterval, specifier: "%.1f")s")
+                            .monospacedDigit()
+                            .foregroundStyle(.secondary)
+                    }
+                } label: {
+                    Text("Capture interval")
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    LabeledContent {
+                        Picker("", selection: $rewindHistorySeconds) {
+                            ForEach(RewindHistoryOption.allCases) { option in
+                                Text(option.settingsLabel).tag(option.rawValue)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .labelsHidden()
+                    } label: {
+                        Text("Rewind history")
+                    }
+
+                    Text("Recent history stays at full detail. Older history is compacted automatically.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text("Newest timeline detail")
-                    Picker(selection: $recentTimelineWindowSeconds) {
-                        ForEach(RecentTimelineWindow.allCases) { window in
-                            Text(window.label).tag(window.rawValue)
+                    LabeledContent {
+                        Picker(selection: $recentTimelineWindowSeconds) {
+                            ForEach(RecentTimelineWindow.allCases) { window in
+                                Text(window.label).tag(window.rawValue)
+                            }
+                        } label: {
+                            EmptyView()
                         }
+                        .pickerStyle(.segmented)
+                        .labelsHidden()
+                        .accessibilityLabel("Newest timeline detail")
+                        .frame(width: 220)
                     } label: {
-                        EmptyView()
+                        Text("Newest timeline detail")
                     }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                    .accessibilityLabel("Newest timeline detail")
 
                     Text("Keep every stored frame in the newest window, then collapse visually similar older history.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             } header: {
                 Text("Capture")
@@ -91,17 +159,20 @@ struct SettingsView: View {
                 Text("When enabled, JustNow can lower image quality and throttle background work on battery power, thermal pressure, or extended idle time. Capture cadence only changes if the setting below is off.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Toggle("Keep configured capture cadence on battery", isOn: $keepConfiguredCaptureCadenceOnBattery)
                     .disabled(!reduceCaptureOnBattery)
                 Text("Preserves the interval you chose when unplugged or in Low Power Mode. Battery savings come from lower image quality and background throttling instead.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Toggle("Background OCR indexing for search", isOn: $backgroundSearchIndexingEnabled)
                 Text("Indexes recent frames in the background so searches return faster. Automatically throttled on battery, low power mode, and thermal pressure.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             } header: {
                 Text("Battery")
             }
@@ -175,26 +246,9 @@ struct SettingsView: View {
                 Text("JustNow uses Sparkle to deliver signed updates from the public appcast at justnow.tk.sg.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             } header: {
                 Text("Software Update")
-            }
-
-            Section {
-                HStack {
-                    Text("Show Timeline")
-                    Spacer()
-                    KeyboardShortcutRecorder(
-                        keyCode: $shortcutKeyCode,
-                        modifiers: $shortcutModifiers
-                    )
-                    .onChange(of: shortcutKeyCode) { _, _ in context.notifyShortcutChanged() }
-                    .onChange(of: shortcutModifiers) { _, _ in context.notifyShortcutChanged() }
-                }
-                Text("Press **Escape** to dismiss the overlay")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } header: {
-                Text("Keyboard Shortcut")
             }
         }
         .formStyle(.grouped)
@@ -211,6 +265,11 @@ struct SettingsView: View {
                 syncUpdaterState()
             }
         }
+        .task(id: launchAtLoginIdentity) {
+            await MainActor.run {
+                syncLaunchAtLoginState()
+            }
+        }
         .task {
             await refreshTelemetryLoop()
         }
@@ -224,6 +283,13 @@ struct SettingsView: View {
             }
         } message: {
             Text("This will delete all captured frames. This cannot be undone.")
+        }
+        .alert("Launch on startup", isPresented: launchAtLoginAlertIsPresented) {
+            Button("OK", role: .cancel) {
+                launchAtLoginAlertMessage = nil
+            }
+        } message: {
+            Text(launchAtLoginAlertMessage ?? "")
         }
     }
 
@@ -243,6 +309,10 @@ struct SettingsView: View {
 
     private var updaterIdentity: ObjectIdentifier? {
         context.updater.map(ObjectIdentifier.init)
+    }
+
+    private var launchAtLoginIdentity: ObjectIdentifier? {
+        context.launchAtLoginManager.map(ObjectIdentifier.init)
     }
 
     private func refreshTelemetryLoop() async {
@@ -302,6 +372,43 @@ struct SettingsView: View {
         automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
         automaticallyDownloadsUpdates = updater.automaticallyDownloadsUpdates
         allowsAutomaticUpdates = updater.allowsAutomaticUpdates
+    }
+
+    private func syncLaunchAtLoginState() {
+        launchAtLoginEnabled = context.launchAtLoginEnabled()
+    }
+
+    private var launchAtLoginBinding: Binding<Bool> {
+        Binding(
+            get: { launchAtLoginEnabled },
+            set: { newValue in
+                let previousValue = launchAtLoginEnabled
+                launchAtLoginEnabled = newValue
+
+                do {
+                    let result = try context.setLaunchAtLoginEnabled(newValue)
+                    syncLaunchAtLoginState()
+
+                    if result == .requiresApproval {
+                        launchAtLoginAlertMessage = "macOS needs approval before JustNow can launch at startup. Enable JustNow in System Settings > General > Login Items."
+                    }
+                } catch {
+                    launchAtLoginEnabled = previousValue
+                    launchAtLoginAlertMessage = error.localizedDescription
+                }
+            }
+        )
+    }
+
+    private var launchAtLoginAlertIsPresented: Binding<Bool> {
+        Binding(
+            get: { launchAtLoginAlertMessage != nil },
+            set: { isPresented in
+                if !isPresented {
+                    launchAtLoginAlertMessage = nil
+                }
+            }
+        )
     }
 }
 

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -63,7 +63,6 @@ struct SettingsView: View {
                     KeyboardShortcutRecorder(
                         keyCode: $overlayDismissKeyCode,
                         modifiers: $overlayDismissModifiers,
-                        allowsBareKeys: true,
                         allowsEscapeShortcut: true,
                         placeholder: "Press key"
                     )

--- a/JustNow/Utilities/LaunchAtLoginManager.swift
+++ b/JustNow/Utilities/LaunchAtLoginManager.swift
@@ -1,0 +1,72 @@
+//
+//  LaunchAtLoginManager.swift
+//  JustNow
+//
+
+import ServiceManagement
+
+enum LaunchAtLoginError: LocalizedError {
+    case serviceUnavailable
+
+    var errorDescription: String? {
+        "Launch on startup is not available in this build."
+    }
+}
+
+@MainActor
+final class LaunchAtLoginManager {
+    enum ChangeResult {
+        case updated
+        case requiresApproval
+    }
+
+    private let service: SMAppService
+
+    init(service: SMAppService = .mainApp) {
+        self.service = service
+    }
+
+    var isEnabled: Bool {
+        switch service.status {
+        case .enabled, .requiresApproval:
+            true
+        case .notRegistered, .notFound:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    var canConfigure: Bool {
+        switch service.status {
+        case .enabled, .notRegistered, .requiresApproval:
+            true
+        case .notFound:
+            false
+        @unknown default:
+            false
+        }
+    }
+
+    func setEnabled(_ isEnabled: Bool) throws -> ChangeResult {
+        if isEnabled {
+            if service.status != .enabled {
+                try service.register()
+            }
+
+            return service.status == .requiresApproval ? .requiresApproval : .updated
+        }
+
+        switch service.status {
+        case .enabled, .requiresApproval:
+            try service.unregister()
+            return .updated
+        case .notRegistered:
+            return .updated
+        case .notFound:
+            throw LaunchAtLoginError.serviceUnavailable
+        @unknown default:
+            throw LaunchAtLoginError.serviceUnavailable
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ A native macOS menu bar app that continuously captures screenshots and lets you 
 5. Scroll horizontally or drag to navigate through time
 6. Press **Escape** to dismiss
 
+If you have just switched this Mac from an older dev-signed build to a Developer ID / notarised build and Screen Recording already appears enabled but JustNow still cannot capture, remove the `JustNow` entry from **System Settings → Privacy & Security → Screen Recording** once, then relaunch and grant access again. Later notarised updates signed with the same identity should keep working normally.
+
 ## Settings
 
 Access via menu bar icon → Settings:


### PR DESCRIPTION
## Summary
- stabilise Screen Recording permission recovery after signing and notarisation changes, and avoid stacking the app alert on top of the initial macOS TCC flow
- add settings for launch on startup, rewind history retention, recent timeline detail, and separate show/hide shortcuts for the overlay
- make overlay search scopes reflect the configured rewind window while keeping a sparse one-hour archive so `Last 1h` remains a real search scope
- let the hide shortcut recorder capture `Escape`, and disable the launch-on-startup toggle when login item registration is unavailable

## Validation
- built with `xcodebuild -scheme JustNow -configuration Release -derivedDataPath build`
- installed the built app to `/Applications/JustNow.app`
- launched the installed app from `/Applications`
