### PR TITLE
Fix timeline detail window mismatch

### DIFF
--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -89,6 +89,7 @@ class OverlayViewModel {
     let timelineFrames: [StoredFrame]
     let searchableFrames: [StoredFrame]
     let frameBuffer: FrameBuffer
+    let recentTimelineWindow: TimeInterval
     let rewindHistoryOption: RewindHistoryOption
     let timelineReferenceDate: Date
     let onDismiss: () -> Void
@@ -119,12 +120,14 @@ class OverlayViewModel {
         timelineFrames: [StoredFrame],
         searchableFrames: [StoredFrame],
         frameBuffer: FrameBuffer,
+        recentTimelineWindow: TimeInterval,
         rewindHistoryOption: RewindHistoryOption,
         onDismiss: @escaping () -> Void
     ) {
         self.timelineFrames = timelineFrames
         self.searchableFrames = searchableFrames
         self.frameBuffer = frameBuffer
+        self.recentTimelineWindow = recentTimelineWindow
         self.rewindHistoryOption = rewindHistoryOption
         self.timelineReferenceDate = Date()
         self.onDismiss = onDismiss
@@ -665,16 +668,20 @@ private struct TimelineSlider: View {
         guard !(viewModel.isSearching && !viewModel.searchQuery.isEmpty) else { return [] }
         return timelineLandmarkMarkers(
             frames: displayedFrames,
+            recentWindow: viewModel.recentTimelineWindow,
             now: viewModel.timelineReferenceDate
         )
     }
 
     private var colourSegments: [TimelineZoneFill] {
-        // Use the 5min marker's exact position so the colour border aligns perfectly
-        let fiveMinPosition = timelineMarkers.first(where: { $0.targetAge == 5 * 60 })?.position
+        let recentWindowPosition = resolveTimelineWindowStartIndex(
+            frames: displayedFrames,
+            targetAge: viewModel.recentTimelineWindow,
+            now: viewModel.timelineReferenceDate
+        ).map { CGFloat($0) / CGFloat(displayedFrames.count - 1) }
         return timelineColourSegments(
             frames: displayedFrames,
-            borderPosition: fiveMinPosition
+            borderPosition: recentWindowPosition
         )
     }
 
@@ -1077,12 +1084,17 @@ private func resolveTimelineWindowStartIndex(
 
 private func timelineLandmarkMarkers(
     frames: [StoredFrame],
+    recentWindow: TimeInterval,
     now: Date = Date()
 ) -> [TimelineMarker] {
     guard frames.count > 1, let oldest = frames.first?.timestamp else { return [] }
 
     let oldestAge = now.timeIntervalSince(oldest)
-    let targets = timelineMarkerTargets(upTo: oldestAge, now: now)
+    let targets = timelineMarkerTargets(
+        upTo: oldestAge,
+        recentWindow: recentWindow,
+        now: now
+    )
     var markersByFrameIndex: [Int: TimelineMarker] = [:]
 
     for target in targets {
@@ -1118,11 +1130,19 @@ private func timelineLandmarkMarkers(
     return markersByFrameIndex.values.sorted { $0.position < $1.position }
 }
 
-private func timelineMarkerTargets(upTo oldestAge: TimeInterval, now: Date) -> [TimelineMarkerTarget] {
+private func timelineMarkerTargets(
+    upTo oldestAge: TimeInterval,
+    recentWindow: TimeInterval,
+    now: Date
+) -> [TimelineMarkerTarget] {
     guard oldestAge > 0 else { return [] }
 
-    let relativeAges: [TimeInterval] = [5.0 * 60, 10.0 * 60, 30.0 * 60, 60.0 * 60, 2.0 * 60.0 * 60.0]
+    let markerAges = [5.0 * 60, 10.0 * 60, 30.0 * 60, 60.0 * 60, 2.0 * 60.0 * 60.0]
+    let preferredAges = ([recentWindow] + markerAges)
         .filter { $0 <= oldestAge }
+
+    var seenAges: Set<Int> = []
+    let relativeAges = preferredAges.filter { seenAges.insert(Int($0)).inserted }
     var targets = relativeAges.enumerated().map { index, targetAge in
         TimelineMarkerTarget(
             targetAge: targetAge,

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -674,11 +674,13 @@ private struct TimelineSlider: View {
     }
 
     private var colourSegments: [TimelineZoneFill] {
-        let recentWindowPosition = resolveTimelineWindowStartIndex(
-            frames: displayedFrames,
-            targetAge: viewModel.recentTimelineWindow,
-            now: viewModel.timelineReferenceDate
-        ).map { CGFloat($0) / CGFloat(displayedFrames.count - 1) }
+        let recentWindowPosition =
+            timelineMarkers.first(where: { $0.targetAge == viewModel.recentTimelineWindow })?.position
+            ?? resolveTimelineMarkerPosition(
+                frames: displayedFrames,
+                targetAge: viewModel.recentTimelineWindow,
+                now: viewModel.timelineReferenceDate
+            )
         return timelineColourSegments(
             frames: displayedFrames,
             borderPosition: recentWindowPosition
@@ -1071,15 +1073,20 @@ private func resolveTimelineMarkerFrameIndex(
     }
 }
 
-private func resolveTimelineWindowStartIndex(
+private func resolveTimelineMarkerPosition(
     frames: [StoredFrame],
     targetAge: TimeInterval,
     now: Date = Date()
-) -> Int? {
+) -> CGFloat? {
     guard frames.count > 1 else { return nil }
 
     let targetDate = now.addingTimeInterval(-targetAge)
-    return frames.firstIndex(where: { $0.timestamp >= targetDate })
+    guard let frameIndex = resolveTimelineMarkerFrameIndex(
+        frames: frames,
+        targetDate: targetDate
+    ) else { return nil }
+
+    return CGFloat(frameIndex) / CGFloat(frames.count - 1)
 }
 
 private func timelineLandmarkMarkers(

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -674,6 +674,10 @@ private struct TimelineSlider: View {
     }
 
     private var colourSegments: [TimelineZoneFill] {
+        guard !(viewModel.isSearching && !viewModel.searchQuery.isEmpty) else {
+            return timelineColourSegments(frames: displayedFrames, borderPosition: nil)
+        }
+
         let recentWindowPosition =
             timelineMarkers.first(where: { $0.targetAge == viewModel.recentTimelineWindow })?.position
             ?? resolveTimelineMarkerPosition(

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -55,6 +55,7 @@ class OverlayWindowController: NSObject {
             timelineFrames: timelineFrames,
             searchableFrames: searchableFrames,
             frameBuffer: frameBuffer,
+            recentTimelineWindow: recentTimelineWindow,
             rewindHistoryOption: rewindHistoryOption,
             onDismiss: { [weak self] in
                 self?.hideOverlay()

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -116,13 +116,13 @@ struct SettingsView: View {
                         }
                         .pickerStyle(.segmented)
                         .labelsHidden()
-                        .accessibilityLabel("Newest timeline detail")
+                        .accessibilityLabel("Full-detail window")
                         .frame(width: 220)
                     } label: {
-                        Text("Newest timeline detail")
+                        Text("Full-detail window")
                     }
 
-                    Text("Keep every stored frame in the newest window, then collapse visually similar older history.")
+                    Text("Keep every stored frame in this most recent window, then collapse visually similar older history.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary
- align the overlay timeline border and markers with the configured full-detail window
- rename the setting from "Newest timeline detail" to "Full-detail window" for clearer copy

## Testing
- xcodebuild -scheme JustNow -configuration Release -derivedDataPath build
- installed and relaunched /Applications/JustNow.app
