### PR TITLE
Stabilise local signing for Screen Recording permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,14 @@ Do not create or move tags or publish releases unless explicitly requested by th
 ## Build And Run
 
 ```bash
+./Scripts/local-install-app.sh
+```
+
+Use the helper above for routine local reinstalls. It keeps the app at `/Applications/JustNow.app` and prefers the same Developer ID signing identity, which avoids Screen Recording permission churn when this machine has the local release credentials configured.
+
+If you only need a build artefact without installing it, you can still run:
+
+```bash
 xcodebuild -scheme JustNow -configuration Release -derivedDataPath build
 ```
 
@@ -67,6 +75,8 @@ This repo no longer uses GitHub Actions for release artefacts or public-site dep
 Local release credentials live in `.env.release.local` (gitignored). The local release scripts auto-load it if present, so future agents should check there first for `APPLE_SIGNING_IDENTITY`, `APPLE_TEAM_ID`, `APPLE_API_KEY_PATH`, `APPLE_API_KEY_ID`, and `APPLE_API_KEY_ISSUER_ID`.
 
 After every successful build, always install and launch from `/Applications/` before reporting completion. Screen Recording permission is tied to the app location.
+
+Prefer `./Scripts/local-install-app.sh` over manually copying a raw Xcode build whenever you are reinstalling the app locally. The helper refuses to replace an existing Developer ID-signed install with a differently signed build unless you explicitly reconfigure the signing inputs.
 
 If you switch a machine from older dev-signed/Xcode builds to Developer ID or notarised builds, macOS may keep a stale Screen Recording entry that still appears enabled. If capture fails in that state, remove the `JustNow` entry from **System Settings → Privacy & Security → Screen Recording** once and relaunch so TCC can recreate it for the new signing identity.
 

--- a/Docs/release-and-distribution.md
+++ b/Docs/release-and-distribution.md
@@ -55,6 +55,14 @@ Local notarisation prerequisites:
 - the Developer Team ID
 - the issuer ID for Team API keys
 
+For day-to-day local reinstalls on a maintainer machine, prefer:
+
+```bash
+./Scripts/local-install-app.sh
+```
+
+The helper installs to `/Applications/JustNow.app`, auto-selects the configured Developer ID identity when possible, and refuses to overwrite an existing Developer ID install with a differently signed build. That keeps macOS TCC from treating the reinstall as a different Screen Recording client.
+
 If you are switching a machine from older Xcode/dev-signed `JustNow` builds to Developer ID / notarised builds, macOS can keep a stale Screen Recording entry that still looks enabled but no longer matches the app's current signing requirement. If capture still fails after the switch, remove the `JustNow` entry from **System Settings → Privacy & Security → Screen Recording** once and relaunch so macOS can recreate it. Later updates signed with the same Developer ID identity should retain the permission normally.
 
 ## Local publish flow

--- a/README.md
+++ b/README.md
@@ -48,7 +48,15 @@ ScreenCaptureKit → Perceptual Hash Filter → Ring Buffer (RAM)
 
 ## Building
 
-Open `JustNow.xcodeproj` in Xcode and build (⌘B), or:
+For routine local reinstalls, use:
+
+```bash
+./Scripts/local-install-app.sh
+```
+
+That helper keeps the app at `/Applications/JustNow.app` and prefers a stable Developer ID signature when available, which helps macOS retain the existing Screen Recording permission record across reinstalls.
+
+If you only need to build without installing, open `JustNow.xcodeproj` in Xcode and build (⌘B), or:
 
 ```bash
 xcodebuild -scheme JustNow -configuration Release -derivedDataPath build

--- a/Scripts/local-install-app.sh
+++ b/Scripts/local-install-app.sh
@@ -33,6 +33,11 @@ Developer ID signature so macOS can keep the same Screen Recording permission re
 EOF
 }
 
+die() {
+  echo "$*" >&2
+  exit 1
+}
+
 installed_leaf_authority() {
   if [ ! -e "${INSTALL_PATH}" ]; then
     return 0
@@ -124,6 +129,14 @@ if [ -n "${SIGNING_IDENTITY}" ] && [ -z "${DEVELOPMENT_TEAM}" ]; then
   DEVELOPMENT_TEAM="$(team_from_identity "${SIGNING_IDENTITY}")"
 fi
 
+if [ "${USE_NOTARIZATION}" = "true" ]; then
+  [ -n "${SIGNING_IDENTITY}" ] || die "Notarisation requires a Developer ID signing identity. Set APPLE_SIGNING_IDENTITY in ${RELEASE_ENV_FILE}, or pass --identity explicitly."
+  [ -n "${DEVELOPMENT_TEAM}" ] || die "Notarisation requires a Developer ID team. Set APPLE_TEAM_ID in ${RELEASE_ENV_FILE}, or pass --team explicitly."
+  [ -n "${API_KEY_PATH}" ] || die "Notarisation requires an App Store Connect API key path. Set APPLE_API_KEY_PATH in ${RELEASE_ENV_FILE}, or pass --api-key explicitly."
+  [ -n "${API_KEY_ID}" ] || die "Notarisation requires an App Store Connect API key ID. Set APPLE_API_KEY_ID in ${RELEASE_ENV_FILE}, or pass --api-key-id explicitly."
+  [ -f "${API_KEY_PATH}" ] || die "App Store Connect API key not found at: ${API_KEY_PATH}"
+fi
+
 if [ -z "${SIGNING_IDENTITY}" ] || [ -z "${DEVELOPMENT_TEAM}" ]; then
   if [[ "${INSTALLED_AUTHORITY}" == Developer\ ID\ Application:* ]]; then
     cat >&2 <<EOF
@@ -153,6 +166,8 @@ if [ ! -d "${APP_PATH}" ]; then
   echo "Built app not found at ${APP_PATH}" >&2
   exit 1
 fi
+
+[ -x "$(command -v trash)" ] || die "The 'trash' CLI is required to replace ${INSTALL_PATH} safely. Install it first, then rerun this helper."
 
 pkill -x "${SCHEME}" 2>/dev/null || true
 if [ -e "${INSTALL_PATH}" ]; then

--- a/Scripts/local-install-app.sh
+++ b/Scripts/local-install-app.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RELEASE_ENV_FILE="${RELEASE_ENV_FILE:-.env.release.local}"
+if [ -f "${RELEASE_ENV_FILE}" ]; then
+  set -a
+  # shellcheck disable=SC1090
+  . "${RELEASE_ENV_FILE}"
+  set +a
+fi
+
+SCHEME="${SCHEME:-JustNow}"
+CONFIGURATION="${CONFIGURATION:-Release}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-build}"
+APP_PATH="${DERIVED_DATA_PATH}/Build/Products/${CONFIGURATION}/${SCHEME}.app"
+INSTALL_PATH="/Applications/${SCHEME}.app"
+VERSION="local"
+VERSION_SET="false"
+USE_NOTARIZATION="false"
+SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"
+DEVELOPMENT_TEAM="${APPLE_TEAM_ID:-}"
+API_KEY_PATH="${APPLE_API_KEY_PATH:-}"
+API_KEY_ID="${APPLE_API_KEY_ID:-}"
+API_ISSUER_ID="${APPLE_API_KEY_ISSUER_ID:-}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  ./Scripts/local-install-app.sh [version] [--notarize] [--identity "Developer ID Application: Name (TEAMID)"] [--team TEAMID] [--api-key /path/to/AuthKey.p8] [--api-key-id KEYID] [--api-issuer ISSUER-UUID]
+
+This helper keeps local installs at /Applications/JustNow.app and prefers a stable
+Developer ID signature so macOS can keep the same Screen Recording permission record.
+EOF
+}
+
+installed_leaf_authority() {
+  if [ ! -e "${INSTALL_PATH}" ]; then
+    return 0
+  fi
+
+  codesign -dv --verbose=4 "${INSTALL_PATH}" 2>&1 | sed -n 's/^Authority=//p' | head -n 1
+}
+
+team_from_identity() {
+  local identity="$1"
+  sed -n 's/.*(\([A-Z0-9]\{10\}\)).*/\1/p' <<<"${identity}"
+}
+
+discover_developer_identities() {
+  security find-identity -v -p codesigning 2>/dev/null | sed -n 's/.*"\(Developer ID Application: [^"]*\)".*/\1/p'
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --notarize|--notarise)
+      USE_NOTARIZATION="true"
+      shift
+      ;;
+    --identity)
+      [[ -n "${2:-}" ]] || { echo "--identity requires a value" >&2; usage; exit 1; }
+      SIGNING_IDENTITY="$2"
+      shift 2
+      ;;
+    --team)
+      [[ -n "${2:-}" ]] || { echo "--team requires a value" >&2; usage; exit 1; }
+      DEVELOPMENT_TEAM="$2"
+      shift 2
+      ;;
+    --api-key)
+      [[ -n "${2:-}" ]] || { echo "--api-key requires a value" >&2; usage; exit 1; }
+      API_KEY_PATH="$2"
+      shift 2
+      ;;
+    --api-key-id)
+      [[ -n "${2:-}" ]] || { echo "--api-key-id requires a value" >&2; usage; exit 1; }
+      API_KEY_ID="$2"
+      shift 2
+      ;;
+    --api-issuer)
+      [[ -n "${2:-}" ]] || { echo "--api-issuer requires a value" >&2; usage; exit 1; }
+      API_ISSUER_ID="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [ "${VERSION_SET}" = "false" ]; then
+        VERSION="$1"
+        VERSION_SET="true"
+        shift
+      else
+        echo "Unknown argument: $1" >&2
+        usage
+        exit 1
+      fi
+      ;;
+  esac
+done
+
+INSTALLED_AUTHORITY="$(installed_leaf_authority)"
+
+if [ -z "${SIGNING_IDENTITY}" ]; then
+  developer_identities=()
+  while IFS= read -r identity; do
+    [ -n "${identity}" ] || continue
+    developer_identities+=("${identity}")
+  done < <(discover_developer_identities)
+
+  if [ "${#developer_identities[@]}" -eq 1 ]; then
+    SIGNING_IDENTITY="${developer_identities[0]}"
+  elif [ "${#developer_identities[@]}" -gt 1 ] && [ -n "${INSTALLED_AUTHORITY}" ]; then
+    for identity in "${developer_identities[@]}"; do
+      if [ "${identity}" = "${INSTALLED_AUTHORITY}" ]; then
+        SIGNING_IDENTITY="${identity}"
+        break
+      fi
+    done
+  fi
+fi
+
+if [ -n "${SIGNING_IDENTITY}" ] && [ -z "${DEVELOPMENT_TEAM}" ]; then
+  DEVELOPMENT_TEAM="$(team_from_identity "${SIGNING_IDENTITY}")"
+fi
+
+if [ -z "${SIGNING_IDENTITY}" ] || [ -z "${DEVELOPMENT_TEAM}" ]; then
+  if [[ "${INSTALLED_AUTHORITY}" == Developer\ ID\ Application:* ]]; then
+    cat >&2 <<EOF
+Refusing to replace the existing Developer ID-signed ${INSTALL_PATH} with a different signing mode.
+
+Set APPLE_SIGNING_IDENTITY and APPLE_TEAM_ID in ${RELEASE_ENV_FILE}, or pass --identity and --team explicitly.
+This keeps Screen Recording permission attached to the same app identity.
+EOF
+    exit 1
+  fi
+
+  echo "No Developer ID identity configured; falling back to Xcode's default signing." >&2
+  echo "If you later switch this install to a Developer ID build, macOS may ask for Screen Recording permission again." >&2
+  xcodebuild -scheme "${SCHEME}" -configuration "${CONFIGURATION}" -derivedDataPath "${DERIVED_DATA_PATH}"
+else
+  BUILD_CMD=(./Scripts/local-release-build.sh "${VERSION}" --distribution --identity "${SIGNING_IDENTITY}" --team "${DEVELOPMENT_TEAM}")
+  if [ "${USE_NOTARIZATION}" = "true" ]; then
+    BUILD_CMD+=(--notarize --api-key "${API_KEY_PATH}" --api-key-id "${API_KEY_ID}")
+    if [ -n "${API_ISSUER_ID}" ]; then
+      BUILD_CMD+=(--api-issuer "${API_ISSUER_ID}")
+    fi
+  fi
+  "${BUILD_CMD[@]}"
+fi
+
+if [ ! -d "${APP_PATH}" ]; then
+  echo "Built app not found at ${APP_PATH}" >&2
+  exit 1
+fi
+
+pkill -x "${SCHEME}" 2>/dev/null || true
+if [ -e "${INSTALL_PATH}" ]; then
+  trash "${INSTALL_PATH}"
+fi
+
+cp -R "${APP_PATH}" /Applications/
+open "${INSTALL_PATH}" || echo "open failed; launch ${INSTALL_PATH} manually." >&2
+
+echo "Installed ${INSTALL_PATH}"
+codesign -dv --verbose=4 "${INSTALL_PATH}" 2>&1 | sed -n 's/^Identifier=/Identifier: /p; s/^Authority=/Authority: /p' | head -n 4

--- a/Scripts/local-release-build.sh
+++ b/Scripts/local-release-build.sh
@@ -48,6 +48,14 @@ Options:
 EOF
 }
 
+remove_signature_if_present() {
+  local target="$1"
+
+  if codesign --display --verbose=1 "${target}" >/dev/null 2>&1; then
+    codesign --remove-signature "${target}"
+  fi
+}
+
 sign_sparkle_support_binaries() {
   local app_bundle_path="$1"
   local framework_path="${app_bundle_path}/Contents/Frameworks/Sparkle.framework"
@@ -63,16 +71,20 @@ sign_sparkle_support_binaries() {
   local autoupdate_binary="${version_path}/Autoupdate"
 
   if [ -e "${autoupdate_binary}" ]; then
+    remove_signature_if_present "${autoupdate_binary}"
     codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" "${autoupdate_binary}"
   fi
 
   for nested_bundle in "${downloader_xpc}" "${installer_xpc}" "${updater_app}"; do
     if [ -d "${nested_bundle}" ]; then
+      remove_signature_if_present "${nested_bundle}"
       codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" "${nested_bundle}"
     fi
   done
 
+  remove_signature_if_present "${version_path}"
   codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" "${version_path}"
+  remove_signature_if_present "${framework_path}"
   codesign --force --options runtime --timestamp --sign "${SIGNING_IDENTITY}" "${framework_path}"
 }
 
@@ -222,8 +234,10 @@ rm -f "${ZIP_PATH}" "${DMG_PATH}"
 
 if [ "${USE_DISTRIBUTION_SIGNING}" = "true" ]; then
   echo "Signing distribution artifacts with ${SIGNING_IDENTITY}"
+  remove_signature_if_present "${APP_EXECUTABLE_PATH}"
   codesign --force --options runtime --timestamp --entitlements "${ENTITLEMENTS_PATH}" --sign "${SIGNING_IDENTITY}" "${APP_EXECUTABLE_PATH}"
   sign_sparkle_support_binaries "${APP_PATH}"
+  remove_signature_if_present "${APP_PATH}"
   codesign --force --options runtime --timestamp --entitlements "${ENTITLEMENTS_PATH}" --sign "${SIGNING_IDENTITY}" "${APP_PATH}"
   codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
 fi


### PR DESCRIPTION
## Summary
- add a `local-install-app.sh` helper for routine local reinstalls to keep `/Applications/JustNow.app` on a stable Developer ID signing path
- update local release signing to remove stale nested and app signatures before re-signing so the designated requirement matches the Developer ID identity
- document the stable local reinstall flow in `AGENTS.md`, `README.md`, and `Docs/release-and-distribution.md`

## Verification
- ran `./Scripts/local-install-app.sh` repeatedly and confirmed the install kept `Authority: Developer ID Application: Tinkertanker (PQ6U5ESLN2)`
- verified `/Applications/JustNow.app` now keeps the designated requirement `certificate leaf[subject.OU] = PQ6U5ESLN2` across reinstalls
- confirmed the app relaunches after install
