### PR TITLE
Harden capture and OCR concurrency lifecycle

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -98,6 +98,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private var isPausedForOverlay = false
     private var wasCapturingBeforeSession = false
     private var isPausedForSession = false
+    private var overlayPresentationTask: Task<Void, Never>?
+    private var setupCaptureTask: Task<Void, Never>?
+    private var pendingCaptureStartTask: Task<Void, Never>?
+    private var pendingCaptureStartGeneration = 0
+    private var isTerminationFlushInProgress = false
     private var idleTransitionTimer: Timer?
     private var didRequestScreenRecordingPermissionThisLaunch = false
     private var didShowPermissionAlertThisLaunch = false
@@ -174,9 +179,33 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         if let monitor = inputEventMonitor {
             NSEvent.removeMonitor(monitor)
         }
-        Task { @MainActor in
-            await frameBuffer?.flushCaches()
+    }
+
+    func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
+        guard !isTerminationFlushInProgress else { return .terminateLater }
+
+        isTerminationFlushInProgress = true
+        overlayPresentationTask?.cancel()
+        setupCaptureTask?.cancel()
+        cancelPendingCaptureStart()
+
+        Task { @MainActor [weak self] in
+            guard let self else {
+                sender.reply(toApplicationShouldTerminate: true)
+                return
+            }
+
+            defer {
+                self.isTerminationFlushInProgress = false
+                sender.reply(toApplicationShouldTerminate: true)
+            }
+
+            await self.setupCaptureTask?.value
+            await self.captureManager?.stopCapture()
+            await self.frameBuffer?.flushCaches()
         }
+
+        return .terminateLater
     }
 
     func applicationDidResignActive(_ notification: Notification) {
@@ -285,60 +314,92 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private func setupCapture() {
         captureManager = ScreenCaptureManager()
 
-        Task { @MainActor in
+        setupCaptureTask?.cancel()
+        setupCaptureTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.setupCaptureTask = nil }
+
             // Initialize frame buffer (loads persisted frames from disk)
             do {
-                let retentionPolicy = currentRetentionPolicy()
+                let retentionPolicy = self.currentRetentionPolicy()
                 let buffer = try await FrameBuffer(retentionPolicy: retentionPolicy)
-                frameBuffer = buffer
-                lastAppliedRetentionPolicy = retentionPolicy
-                settingsContext.frameBuffer = buffer
+                guard !Task.isCancelled else { return }
+
+                self.frameBuffer = buffer
+                self.lastAppliedRetentionPolicy = retentionPolicy
+                self.settingsContext.frameBuffer = buffer
 
                 let loadedCount = buffer.frameCount
                 if loadedCount > 0 {
                     print("Loaded \(loadedCount) frames from disk")
                 }
             } catch {
+                if error is CancellationError || Task.isCancelled {
+                    return
+                }
                 print("Failed to initialize frame buffer: \(error)")
                 // Show error but don't quit
-                showErrorAlert(error)
+                self.showErrorAlert(error)
                 return
             }
 
-            captureManager.delegate = self
-            let preflightPolicy = computeCapturePolicy()
-            captureManager.updateCaptureInterval(preflightPolicy.interval)
-            captureManager.updateCaptureScale(preflightPolicy.scale)
-            frameBuffer?.updateSaveOptions(
+            guard !Task.isCancelled else { return }
+
+            self.captureManager.delegate = self
+            let preflightPolicy = self.computeCapturePolicy()
+            self.captureManager.updateCaptureInterval(preflightPolicy.interval)
+            self.captureManager.updateCaptureScale(preflightPolicy.scale)
+            self.frameBuffer?.updateSaveOptions(
                 preflightPolicy.saveOptions,
                 duplicatePolicy: preflightPolicy.duplicatePolicy
             )
-            frameBuffer?.updateOCRIndexingPolicy(preflightPolicy.ocrIndexingPolicy)
+            self.frameBuffer?.updateOCRIndexingPolicy(preflightPolicy.ocrIndexingPolicy)
 
-            guard !isUserPaused else {
-                updateCaptureStatus("Paused (User)")
+            guard self.canStartCaptureNow() || self.isUserPaused else {
+                if self.isPausedForOverlay || self.overlayController?.isVisible == true {
+                    self.updateCaptureStatus("Paused (Overlay)")
+                } else if self.isPausedForSession {
+                    self.updateCaptureStatus("Session Inactive")
+                }
                 return
             }
 
-            switch resolveLaunchPermissionState() {
+            guard !self.isUserPaused else {
+                self.updateCaptureStatus("Paused (User)")
+                return
+            }
+
+            switch self.resolveLaunchPermissionState() {
             case .granted:
                 do {
-                    try await captureManager.startCapture()
-                    updateCaptureStatus("Active")
-                    lastAppliedPolicy = nil
-                    updateCapturePolicy()
+                    try await self.captureManager.startCapture()
+                    guard !Task.isCancelled else { return }
+                    guard self.canStartCaptureNow() else {
+                        await self.captureManager.stopCapture()
+                        if self.isPausedForOverlay || self.overlayController?.isVisible == true {
+                            self.updateCaptureStatus("Paused (Overlay)")
+                        } else if self.isPausedForSession {
+                            self.updateCaptureStatus("Session Inactive")
+                        }
+                        return
+                    }
+                    self.updateCaptureStatus("Active")
+                    self.lastAppliedPolicy = nil
+                    self.updateCapturePolicy()
+                } catch is CancellationError {
+                    return
                 } catch CaptureError.permissionDenied {
-                    updateCaptureStatus("No Permission")
-                    showPermissionAlert()
+                    self.updateCaptureStatus("No Permission")
+                    self.showPermissionAlert()
                 } catch {
-                    updateCaptureStatus("Error")
-                    showErrorAlert(error)
+                    self.updateCaptureStatus("Error")
+                    self.showErrorAlert(error)
                 }
             case .requestedThisLaunch:
-                updateCaptureStatus("Awaiting Permission")
+                self.updateCaptureStatus("Awaiting Permission")
             case .deniedPreviously:
-                updateCaptureStatus("No Permission")
-                showPermissionAlert()
+                self.updateCaptureStatus("No Permission")
+                self.showPermissionAlert()
             }
         }
     }
@@ -348,8 +409,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         // Re-evaluate capture policy periodically (battery, low power, thermal)
         capturePolicyTimer = Timer.scheduledTimer(withTimeInterval: 60.0, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.updateCapturePolicy()
+            guard let self else { return }
+            Task { @MainActor [self] in
+                self.updateCapturePolicy()
             }
         }
         capturePolicyTimer?.tolerance = 10.0
@@ -361,9 +423,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
-                self?.updateCapturePolicy()
-                await self?.updateRetentionPolicyIfNeeded()
+            guard let self else { return }
+            Task { @MainActor [self] in
+                self.updateCapturePolicy()
+                await self.updateRetentionPolicyIfNeeded()
             }
         }
 
@@ -372,8 +435,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
-                self?.updateCapturePolicy()
+            guard let self else { return }
+            Task { @MainActor [self] in
+                self.updateCapturePolicy()
             }
         }
     }
@@ -382,8 +446,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         inputEventMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel, .mouseMoved]
         ) { [weak self] _ in
-            Task { @MainActor in
-                self?.handleUserActivity()
+            guard let self else { return }
+            Task { @MainActor [self] in
+                self.handleUserActivity()
             }
         }
     }
@@ -438,6 +503,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     }
 
     @objc private func handleSleep() {
+        cancelPendingCaptureStart()
         Task { @MainActor in
             updateCaptureStatus("Sleeping...")
             await captureManager.stopCapture()
@@ -452,6 +518,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     }
 
     @objc private func handleScreenSleep() {
+        cancelPendingCaptureStart()
         Task { @MainActor in
             updateCaptureStatus("Screen Off")
             await captureManager.stopCapture()
@@ -475,10 +542,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     private func pauseCaptureForSession() {
         guard !isPausedForSession else { return }
+        let wasActivelyCapturing = captureManager.isCapturing
+        let shouldResumeCaptureAfterSession =
+            captureManager.isCapturing
+            || setupCaptureTask != nil
+            || pendingCaptureStartTask != nil
+            || (isPausedForOverlay && wasCapturingBeforeOverlay)
         isPausedForSession = true
-        wasCapturingBeforeSession = captureManager.isCapturing
+        wasCapturingBeforeSession = shouldResumeCaptureAfterSession
+        cancelPendingCaptureStart()
 
-        guard wasCapturingBeforeSession else { return }
+        guard wasActivelyCapturing else { return }
         Task { @MainActor in
             updateCaptureStatus("Session Inactive")
             await captureManager.stopCapture()
@@ -496,46 +570,118 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         resumeCapture(reason: "session active")
     }
 
+    private func cancelPendingCaptureStart() {
+        pendingCaptureStartGeneration += 1
+        pendingCaptureStartTask?.cancel()
+        pendingCaptureStartTask = nil
+    }
+
+    private func canStartCaptureNow() -> Bool {
+        !isUserPaused && !isPausedForOverlay && !isPausedForSession && overlayController?.isVisible != true
+    }
+
+    private func captureWasActiveOrPendingBeforeOverlayPause() -> Bool {
+        captureManager.isCapturing
+            || setupCaptureTask != nil
+            || pendingCaptureStartTask != nil
+            || (isPausedForSession && wasCapturingBeforeSession)
+    }
+
+    private func startCaptureIfAllowed(successMessage: String, failurePrefix: String, failureStatus: String) async -> Bool {
+        guard !Task.isCancelled, canStartCaptureNow() else { return false }
+
+        do {
+            try await captureManager.startCapture()
+            guard !Task.isCancelled, canStartCaptureNow() else {
+                await captureManager.stopCapture()
+                return false
+            }
+            updateCaptureStatus("Active")
+            lastAppliedPolicy = nil
+            updateCapturePolicy()
+            print(successMessage)
+            return true
+        } catch is CancellationError {
+            return false
+        } catch CaptureError.permissionDenied {
+            updateCaptureStatus("No Permission")
+            showPermissionAlert()
+            return false
+        } catch {
+            print("\(failurePrefix): \(error)")
+            updateCaptureStatus(failureStatus)
+            return false
+        }
+    }
+
     private func resumeCapture(reason: String) {
-        Task { @MainActor in
-            guard !isUserPaused else {
+        if setupCaptureTask != nil {
+            cancelPendingCaptureStart()
+            if isUserPaused {
                 updateCaptureStatus("Paused (User)")
-                return
-            }
-
-            guard overlayController?.isVisible != true else {
+            } else if isPausedForOverlay || overlayController?.isVisible == true {
                 updateCaptureStatus("Paused (Overlay)")
+            } else if isPausedForSession {
+                updateCaptureStatus("Session Inactive")
+            } else {
+                updateCaptureStatus("Resuming...")
+            }
+            return
+        }
+
+        cancelPendingCaptureStart()
+        let generation = pendingCaptureStartGeneration
+        pendingCaptureStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if generation == self.pendingCaptureStartGeneration {
+                    self.pendingCaptureStartTask = nil
+                }
+            }
+
+            guard self.canStartCaptureNow() else {
+                if self.isUserPaused {
+                    self.updateCaptureStatus("Paused (User)")
+                } else if self.isPausedForOverlay || self.overlayController?.isVisible == true {
+                    self.updateCaptureStatus("Paused (Overlay)")
+                } else if self.isPausedForSession {
+                    self.updateCaptureStatus("Session Inactive")
+                }
                 return
             }
 
-            updateCaptureStatus("Resuming...")
+            self.updateCaptureStatus("Resuming...")
 
             // Delay to let system stabilise
             try? await Task.sleep(for: .seconds(2))
 
-            do {
-                try await captureManager.startCapture()
-                updateCaptureStatus("Active")
-                lastAppliedPolicy = nil
-                updateCapturePolicy()
-                print("Capture resumed after \(reason)")
-            } catch {
-                print("Failed to resume capture after \(reason): \(error)")
-                updateCaptureStatus("Error")
-
-                // Retry once more after another delay
-                try? await Task.sleep(for: .seconds(3))
-                do {
-                    try await captureManager.startCapture()
-                    updateCaptureStatus("Active")
-                    lastAppliedPolicy = nil
-                    updateCapturePolicy()
-                    print("Capture resumed on retry")
-                } catch {
-                    print("Retry also failed: \(error)")
-                    updateCaptureStatus("Failed")
-                }
+            guard !Task.isCancelled,
+                  generation == self.pendingCaptureStartGeneration,
+                  self.canStartCaptureNow() else {
+                return
             }
+
+            let didStart = await self.startCaptureIfAllowed(
+                successMessage: "Capture resumed after \(reason)",
+                failurePrefix: "Failed to resume capture after \(reason)",
+                failureStatus: "Error"
+            )
+            guard !didStart else { return }
+
+            // Retry once more after another delay.
+            try? await Task.sleep(for: .seconds(3))
+
+            guard !Task.isCancelled,
+                  generation == self.pendingCaptureStartGeneration,
+                  self.canStartCaptureNow() else {
+                return
+            }
+
+            _ = await self.startCaptureIfAllowed(
+                successMessage: "Capture resumed on retry",
+                failurePrefix: "Retry also failed",
+                failureStatus: "Failed"
+            )
         }
     }
 
@@ -546,24 +692,34 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     }
 
     func captureManagerDidStop(_ manager: ScreenCaptureManager) {
-        guard overlayController?.isVisible != true, !isPausedForOverlay, !isUserPaused else { return }
+        guard overlayController?.isVisible != true, !isPausedForOverlay, !isPausedForSession, !isUserPaused else { return }
         print("Capture stopped unexpectedly, attempting restart...")
-        updateCaptureStatus("Restarting...")
         appNapPreventer.stopActivity()
+        cancelPendingCaptureStart()
+        let generation = pendingCaptureStartGeneration
+        pendingCaptureStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if generation == self.pendingCaptureStartGeneration {
+                    self.pendingCaptureStartTask = nil
+                }
+            }
 
-        Task { @MainActor in
+            guard self.canStartCaptureNow() else { return }
+            self.updateCaptureStatus("Restarting...")
             try? await Task.sleep(for: .seconds(2))
 
-            do {
-                try await captureManager.startCapture()
-                updateCaptureStatus("Active")
-                lastAppliedPolicy = nil
-                updateCapturePolicy()
-                print("Capture restarted successfully")
-            } catch {
-                print("Failed to restart capture: \(error)")
-                updateCaptureStatus("Stopped")
+            guard !Task.isCancelled,
+                  generation == self.pendingCaptureStartGeneration,
+                  self.canStartCaptureNow() else {
+                return
             }
+
+            _ = await self.startCaptureIfAllowed(
+                successMessage: "Capture restarted successfully",
+                failurePrefix: "Failed to restart capture",
+                failureStatus: "Stopped"
+            )
         }
     }
 
@@ -578,6 +734,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         }
 
         if isUserPaused {
+            cancelPendingCaptureStart()
             Task { @MainActor in
                 updateCaptureStatus("Paused (User)")
                 await captureManager.stopCapture()
@@ -593,7 +750,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     // MARK: - Actions
 
     @objc private func toggleOverlay() {
-        if let controller = overlayController, controller.isVisible {
+        if let overlayPresentationTask {
+            overlayPresentationTask.cancel()
+            self.overlayPresentationTask = nil
+        } else if let controller = overlayController, controller.isVisible {
             controller.hideOverlay()
         } else {
             showOverlay()
@@ -602,31 +762,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     @objc private func showOverlay() {
         guard let frameBuffer = frameBuffer else { return }
+        guard overlayPresentationTask == nil else { return }
 
-        Task { @MainActor in
+        overlayPresentationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.overlayPresentationTask = nil }
+
             // Capture a fresh frame immediately so the overlay has the latest state
-            if let image = await captureManager.captureNow() {
+            if let image = await self.captureManager.captureNow() {
+                guard !Task.isCancelled else { return }
                 await frameBuffer.addFrameSync(image, timestamp: Date())
             }
 
-            if overlayController == nil {
-                overlayController = OverlayWindowController(
+            guard !Task.isCancelled else { return }
+
+            if self.overlayController == nil {
+                self.overlayController = OverlayWindowController(
                     frameBuffer: frameBuffer,
-                    dismissShortcutKeyCode: overlayDismissKeyCode,
-                    dismissShortcutModifiers: overlayDismissModifiers,
+                    dismissShortcutKeyCode: self.overlayDismissKeyCode,
+                    dismissShortcutModifiers: self.overlayDismissModifiers,
                     onVisibilityChanged: { [weak self] isVisible in
                         self?.handleOverlayVisibilityChanged(isVisible: isVisible)
                     }
                 )
             } else {
-                overlayController?.updateDismissShortcut(
-                    keyCode: overlayDismissKeyCode,
-                    modifiers: overlayDismissModifiers
+                self.overlayController?.updateDismissShortcut(
+                    keyCode: self.overlayDismissKeyCode,
+                    modifiers: self.overlayDismissModifiers
                 )
             }
-            let recentTimelineWindow = RecentTimelineWindow.resolved(from: recentTimelineWindowSeconds)
-            let rewindHistoryOption = RewindHistoryOption.resolved(from: rewindHistorySeconds)
-            overlayController?.showOverlay(
+            let recentTimelineWindow = RecentTimelineWindow.resolved(from: self.recentTimelineWindowSeconds)
+            let rewindHistoryOption = RewindHistoryOption.resolved(from: self.rewindHistorySeconds)
+            self.overlayController?.showOverlay(
                 recentTimelineWindow: recentTimelineWindow.timeInterval,
                 rewindHistoryOption: rewindHistoryOption
             )
@@ -643,10 +810,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
     private func pauseCaptureForOverlay() {
         guard !isPausedForOverlay else { return }
+        let wasActivelyCapturing = captureManager.isCapturing
+        wasCapturingBeforeOverlay = captureWasActiveOrPendingBeforeOverlayPause()
         isPausedForOverlay = true
-        wasCapturingBeforeOverlay = captureManager.isCapturing
+        cancelPendingCaptureStart()
 
-        guard wasCapturingBeforeOverlay else { return }
+        guard wasActivelyCapturing else { return }
         Task { @MainActor in
             updateCaptureStatus("Paused (Overlay)")
             await captureManager.stopCapture()
@@ -660,17 +829,43 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         guard wasCapturingBeforeOverlay else { return }
         wasCapturingBeforeOverlay = false
 
-        Task { @MainActor in
-            updateCaptureStatus("Resuming...")
-            do {
-                try await captureManager.startCapture()
-                updateCaptureStatus("Active")
-                lastAppliedPolicy = nil
-                updateCapturePolicy()
-            } catch {
-                updateCaptureStatus("Error")
-                print("Failed to resume capture after overlay: \(error)")
+        if setupCaptureTask != nil {
+            cancelPendingCaptureStart()
+            if isUserPaused {
+                updateCaptureStatus("Paused (User)")
+            } else if isPausedForSession {
+                updateCaptureStatus("Session Inactive")
+            } else {
+                updateCaptureStatus("Resuming...")
             }
+            return
+        }
+
+        cancelPendingCaptureStart()
+        let generation = pendingCaptureStartGeneration
+        pendingCaptureStartTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer {
+                if generation == self.pendingCaptureStartGeneration {
+                    self.pendingCaptureStartTask = nil
+                }
+            }
+
+            guard self.canStartCaptureNow() else {
+                if self.isUserPaused {
+                    self.updateCaptureStatus("Paused (User)")
+                } else if self.isPausedForSession {
+                    self.updateCaptureStatus("Session Inactive")
+                }
+                return
+            }
+
+            self.updateCaptureStatus("Resuming...")
+            _ = await self.startCaptureIfAllowed(
+                successMessage: "Capture resumed after overlay",
+                failurePrefix: "Failed to resume capture after overlay",
+                failureStatus: "Error"
+            )
         }
     }
 
@@ -860,8 +1055,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         guard remaining > 0 else { return }
 
         idleTransitionTimer = Timer.scheduledTimer(withTimeInterval: remaining, repeats: false) { [weak self] _ in
-            Task { @MainActor in
-                self?.updateCapturePolicy()
+            guard let self else { return }
+            Task { @MainActor [self] in
+                self.updateCapturePolicy()
             }
         }
         idleTransitionTimer?.tolerance = min(remaining * 0.2, 5.0)

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -40,14 +40,29 @@ struct OCRIndexingPolicy: Sendable, Equatable {
     )
 }
 
+private enum SyncIngestResult {
+    case completed
+    case retryAfterClear
+}
+
+private enum ClearWaitResult {
+    case ready
+    case cancelled
+}
+
+private struct PendingIngest {
+    let cgImage: CGImage
+    let timestamp: Date
+    let generation: Int
+    let syncContinuation: CheckedContinuation<SyncIngestResult, Never>?
+}
+
 @MainActor
 class FrameBuffer {
     private var frames: [StoredFrame] = []
     private let frameStore: FrameStore
     private let retentionManager: RetentionManager
     private var blackFrameFilterUntil: Date?
-    private var lastStoredHash: UInt64?
-    private var lastStoredTimestamp: Date?
     private var saveOptions: FrameSaveOptions = .standard
     private var duplicatePolicy: DuplicateFramePolicy = .standard
     private var lastPruneCheck: Date = .distantPast
@@ -55,7 +70,20 @@ class FrameBuffer {
     private var ocrIndexingPolicy: OCRIndexingPolicy = .disabled
     private var ocrIndexQueue: [StoredFrame] = []
     private var queuedOCRFrameIDs: Set<UUID> = []
+    private var ocrPruningFrameIDs: Set<UUID> = []
     private var ocrIndexingTask: Task<Void, Never>?
+    /// Bounded backlog of captures waiting to hash and persist. Sync captures discard older async backlog rather than reordering processing, so dedupe stays chronological.
+    private var ingestQueue: [PendingIngest] = []
+    private var ingestProcessorTask: Task<Void, Never>?
+    /// Incremented when starting each ingest drain and when clearing the buffer so a superseded drain cannot clear `ingestProcessorTask` or restart incorrectly.
+    private var ingestProcessorSerial = 0
+    private let maxIngestBacklog = 6
+    /// Bumped in `clear()` so in-flight ingest work can drop results and avoid racing a reset buffer.
+    private var ingestGeneration = 0
+    /// While true, new captures are not queued and disk reset is in progress — avoids races with `frames.removeAll()` and ingest teardown.
+    private var isBufferClearing = false
+    private var activeClearOperationCount = 0
+    private var clearWaiters: [(id: UUID, continuation: CheckedContinuation<ClearWaitResult, Never>)] = []
     private let searchTelemetry = SearchTelemetry.shared
 
     // Pause pruning while overlay is open to prevent "Frame removed" issues
@@ -67,7 +95,7 @@ class FrameBuffer {
     // OCR text cache for faster subsequent searches
     let textCache = TextCache()
 
-    init(retentionPolicy: RetentionPolicy = .default24Hours) async throws {
+    init(retentionPolicy: RetentionPolicy) async throws {
         self.frameStore = try FrameStore()
         self.retentionManager = RetentionManager(policy: retentionPolicy)
         thumbnailCache.countLimit = 100
@@ -92,34 +120,7 @@ class FrameBuffer {
             return
         }
 
-        // Save to disk (skip near-duplicates to reduce churn)
-        // Hash computation runs concurrently on background thread
-        Task(priority: .utility) {
-            do {
-                // Compute perceptual hash on background thread (via @concurrent)
-                let hash = await PerceptualHash.compute(from: cgImage)
-                guard shouldStoreFrame(hash: hash, timestamp: timestamp) else { return }
-                let metadata = try await frameStore.saveFrame(
-                    cgImage,
-                    timestamp: timestamp,
-                    hash: hash,
-                    options: saveOptions
-                )
-
-                let frame = StoredFrame(
-                    id: metadata.id,
-                    timestamp: metadata.timestamp,
-                    hash: metadata.hash
-                )
-
-                recordStoredFrame(frame)
-                enqueueFrameForBackgroundOCR(frame)
-
-                await pruneIfNeeded()
-            } catch {
-                print("Failed to save frame: \(error)")
-            }
-        }
+        enqueueIngest(cgImage: cgImage, timestamp: timestamp, syncContinuation: nil, prioritiseSync: false)
     }
 
     /// Add a frame synchronously (awaits save completion). Used when opening overlay.
@@ -128,20 +129,34 @@ class FrameBuffer {
             return
         }
 
-        do {
-            let hash = await PerceptualHash.compute(from: cgImage)
-            guard shouldStoreFrame(hash: hash, timestamp: timestamp) else { return }
-            let metadata = try await frameStore.saveFrame(
-                cgImage,
-                timestamp: timestamp,
-                hash: hash,
-                options: saveOptions
-            )
-            let frame = StoredFrame(id: metadata.id, timestamp: metadata.timestamp, hash: metadata.hash)
-            recordStoredFrame(frame)
-            enqueueFrameForBackgroundOCR(frame)
-        } catch {
-            print("Failed to save frame: \(error)")
+        while !Task.isCancelled {
+            do {
+                try await waitUntilNotClearing()
+            } catch is CancellationError {
+                return
+            } catch {
+                return
+            }
+
+            guard !Task.isCancelled else { return }
+
+            let result = await withCheckedContinuation { continuation in
+                enqueueIngest(
+                    cgImage: cgImage,
+                    timestamp: timestamp,
+                    syncContinuation: continuation,
+                    prioritiseSync: true
+                )
+            }
+
+            guard !Task.isCancelled else { return }
+
+            switch result {
+            case .completed:
+                return
+            case .retryAfterClear:
+                continue
+            }
         }
     }
 
@@ -149,6 +164,22 @@ class FrameBuffer {
 
     func getFrames() -> [StoredFrame] {
         frames
+    }
+
+    func containsFrame(id: UUID) -> Bool {
+        frames.contains { $0.id == id }
+    }
+
+    func cacheOCRTextIfCurrent(_ text: String, for frame: StoredFrame) async -> Bool {
+        guard shouldContinueOCR(for: frame) else { return false }
+        await textCache.setText(text, for: frame.id, timestamp: frame.timestamp)
+
+        guard shouldContinueOCR(for: frame) else {
+            await textCache.removeText(for: frame.id)
+            return false
+        }
+
+        return true
     }
 
     /// Get frames with near-duplicates removed for smoother browsing.
@@ -240,11 +271,32 @@ class FrameBuffer {
     // MARK: - Management
 
     func clear() async throws {
+        activeClearOperationCount += 1
+        isBufferClearing = true
+        defer {
+            activeClearOperationCount -= 1
+            if activeClearOperationCount == 0 {
+                isBufferClearing = false
+                let waiters = clearWaiters
+                clearWaiters.removeAll()
+                for resume in waiters {
+                    resume.continuation.resume(returning: .ready)
+                }
+            }
+        }
+
+        ingestGeneration += 1
+        ingestProcessorSerial += 1
+        ingestProcessorTask?.cancel()
+        ingestProcessorTask = nil
+        let stuckSync = ingestQueue.compactMap { $0.syncContinuation }
+        ingestQueue.removeAll()
+        for resume in stuckSync {
+            resume.resume(returning: .retryAfterClear)
+        }
         cancelBackgroundOCRIndexing(clearQueue: true)
         try await frameStore.clear()
         frames.removeAll()
-        lastStoredHash = nil
-        lastStoredTimestamp = nil
         thumbnailCache.removeAllObjects()
         await textCache.clear()
     }
@@ -277,6 +329,9 @@ class FrameBuffer {
     }
 
     func flushCaches() async {
+        while let ingestProcessorTask {
+            await ingestProcessorTask.value
+        }
         await frameStore.flushManifest()
         await textCache.save()
     }
@@ -289,15 +344,156 @@ class FrameBuffer {
         frames = metadata
             .sorted { $0.timestamp < $1.timestamp }
             .map { StoredFrame(id: $0.id, timestamp: $0.timestamp, hash: $0.hash) }
-
-        if let lastFrame = frames.last, lastFrame.hash != 0 {
-            lastStoredHash = lastFrame.hash
-            lastStoredTimestamp = lastFrame.timestamp
-        }
     }
 
     func enableBlackFrameFilter(for seconds: TimeInterval) {
         blackFrameFilterUntil = Date().addingTimeInterval(seconds)
+    }
+
+    private func waitUntilNotClearing() async throws {
+        guard isBufferClearing else { return }
+
+        let waiterID = UUID()
+        let result = await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                clearWaiters.append((id: waiterID, continuation: continuation))
+                if Task.isCancelled {
+                    cancelClearWaiter(id: waiterID)
+                }
+            }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelClearWaiter(id: waiterID)
+            }
+        })
+
+        if case .cancelled = result {
+            throw CancellationError()
+        }
+    }
+
+    private func cancelClearWaiter(id: UUID) {
+        guard let index = clearWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let continuation = clearWaiters.remove(at: index).continuation
+        continuation.resume(returning: .cancelled)
+    }
+
+    private func enqueueIngest(
+        cgImage: CGImage,
+        timestamp: Date,
+        syncContinuation: CheckedContinuation<SyncIngestResult, Never>?,
+        prioritiseSync: Bool
+    ) {
+        if isBufferClearing {
+            syncContinuation?.resume(returning: .retryAfterClear)
+            return
+        }
+
+        let pending = PendingIngest(
+            cgImage: cgImage,
+            timestamp: timestamp,
+            generation: ingestGeneration,
+            syncContinuation: syncContinuation
+        )
+
+        if prioritiseSync {
+            ingestQueue.removeAll { $0.syncContinuation == nil }
+        }
+
+        ingestQueue.append(pending)
+        trimIngestQueueIfNeeded()
+        startIngestProcessorIfNeeded()
+    }
+
+    /// Drops oldest async-only pending captures until at most `maxIngestBacklog` remain.
+    private func trimIngestQueueIfNeeded() {
+        while ingestQueue.count > maxIngestBacklog,
+              let dropIndex = ingestQueue.firstIndex(where: { $0.syncContinuation == nil }) {
+            ingestQueue.remove(at: dropIndex)
+        }
+    }
+
+    private func startIngestProcessorIfNeeded() {
+        guard ingestProcessorTask == nil, !ingestQueue.isEmpty else { return }
+        ingestProcessorSerial += 1
+        let processorSerial = ingestProcessorSerial
+        ingestProcessorTask = Task(priority: .utility) { [weak self] in
+            guard let self else { return }
+            await self.drainIngestQueueOnMainActor(processorSerial: processorSerial)
+        }
+    }
+
+    private func drainIngestQueueOnMainActor(processorSerial: Int) async {
+        while !Task.isCancelled {
+            guard let work = dequeueIngestWork() else { break }
+            let hash = await PerceptualHash.compute(from: work.cgImage)
+            await processHashedIngest(work, hash: hash)
+        }
+        guard processorSerial == ingestProcessorSerial else { return }
+        ingestProcessorTask = nil
+        if !ingestQueue.isEmpty {
+            startIngestProcessorIfNeeded()
+        }
+    }
+
+    private func dequeueIngestWork() -> PendingIngest? {
+        guard !ingestQueue.isEmpty else { return nil }
+        return ingestQueue.removeFirst()
+    }
+
+    private func processHashedIngest(_ work: PendingIngest, hash: UInt64) async {
+        let result: SyncIngestResult
+        if !matchesIngestGeneration(work.generation) {
+            result = .retryAfterClear
+        } else {
+            result = await persistIngestedFrame(
+                cgImage: work.cgImage,
+                timestamp: work.timestamp,
+                hash: hash,
+                ingestGeneration: work.generation
+            )
+        }
+        work.syncContinuation?.resume(returning: result)
+    }
+
+    private func matchesIngestGeneration(_ generation: Int) -> Bool {
+        generation == ingestGeneration
+    }
+
+    private func persistIngestedFrame(
+        cgImage: CGImage,
+        timestamp: Date,
+        hash: UInt64,
+        ingestGeneration generation: Int
+    ) async -> SyncIngestResult {
+        guard generation == ingestGeneration else { return .retryAfterClear }
+        guard shouldStoreFrame(hash: hash, timestamp: timestamp) else { return .completed }
+        do {
+            let metadata = try await frameStore.saveFrame(
+                cgImage,
+                timestamp: timestamp,
+                hash: hash,
+                options: saveOptions
+            )
+            guard generation == ingestGeneration else {
+                try? await frameStore.pruneFrames(ids: [metadata.id])
+                return .retryAfterClear
+            }
+            let frame = StoredFrame(
+                id: metadata.id,
+                timestamp: metadata.timestamp,
+                hash: metadata.hash
+            )
+            recordStoredFrame(frame)
+            enqueueFrameForBackgroundOCR(frame)
+            await pruneIfNeeded()
+            return .completed
+        } catch is CancellationError {
+            return .retryAfterClear
+        } catch {
+            print("Failed to save frame: \(error)")
+            return .completed
+        }
     }
 
     private func pruneIfNeeded() async {
@@ -316,6 +512,11 @@ class FrameBuffer {
         let toPrune = retentionManager.framesToPrune(frames: frames, currentTime: now)
         guard !toPrune.isEmpty else { return }
 
+        ocrPruningFrameIDs.formUnion(toPrune)
+        defer {
+            ocrPruningFrameIDs.subtract(toPrune)
+        }
+
         do {
             try await frameStore.pruneFrames(ids: toPrune)
             frames.removeAll { toPrune.contains($0.id) }
@@ -329,42 +530,39 @@ class FrameBuffer {
     }
 
     private func shouldStoreFrame(hash: UInt64, timestamp: Date) -> Bool {
-        guard let lastHash = lastStoredHash, let lastTime = lastStoredTimestamp else {
+        let insertionIndex = frameInsertionIndex(for: timestamp)
+        guard insertionIndex > 0 else {
             return true
         }
 
-        let timeSinceLast = timestamp.timeIntervalSince(lastTime)
+        let previousFrame = frames[insertionIndex - 1]
+        guard previousFrame.hash != 0 else { return true }
+
+        let timeSinceLast = timestamp.timeIntervalSince(previousFrame.timestamp)
         guard timeSinceLast < duplicatePolicy.minimumSpacing else { return true }
 
-        let distance = PerceptualHash.hammingDistance(hash, lastHash)
+        let distance = PerceptualHash.hammingDistance(hash, previousFrame.hash)
         return distance > duplicatePolicy.hashThreshold
     }
 
-    private func recordStoredFrame(_ frame: StoredFrame) {
-        if let last = frames.last, frame.timestamp >= last.timestamp {
-            frames.append(frame)
-        } else if frames.isEmpty {
-            frames.append(frame)
-        } else {
-            var low = 0
-            var high = frames.count
-            while low < high {
-                let mid = (low + high) / 2
-                if frames[mid].timestamp <= frame.timestamp {
-                    low = mid + 1
-                } else {
-                    high = mid
-                }
+    private func frameInsertionIndex(for timestamp: Date) -> Int {
+        var low = 0
+        var high = frames.count
+
+        while low < high {
+            let mid = (low + high) / 2
+            if frames[mid].timestamp <= timestamp {
+                low = mid + 1
+            } else {
+                high = mid
             }
-            frames.insert(frame, at: low)
         }
-        if frame.hash != 0 {
-            lastStoredHash = frame.hash
-            lastStoredTimestamp = frame.timestamp
-        } else {
-            lastStoredHash = nil
-            lastStoredTimestamp = frame.timestamp
-        }
+
+        return low
+    }
+
+    private func recordStoredFrame(_ frame: StoredFrame) {
+        frames.insert(frame, at: frameInsertionIndex(for: frame.timestamp))
     }
 
     private func enqueueFrameForBackgroundOCR(_ frame: StoredFrame) {
@@ -445,6 +643,13 @@ class FrameBuffer {
         return frame
     }
 
+    private func shouldContinueOCR(for frame: StoredFrame) -> Bool {
+        guard !Task.isCancelled else { return false }
+        guard !isBufferClearing else { return false }
+        guard !ocrPruningFrameIDs.contains(frame.id) else { return false }
+        return containsFrame(id: frame.id)
+    }
+
     private func runBackgroundOCRIndexingLoop() async {
         defer {
             ocrIndexingTask = nil
@@ -461,6 +666,10 @@ class FrameBuffer {
                 continue
             }
 
+            guard shouldContinueOCR(for: frame) else {
+                continue
+            }
+
             if await textCache.hasCachedText(for: frame.id) {
                 continue
             }
@@ -469,7 +678,9 @@ class FrameBuffer {
                 let startedAt = Date()
                 let image = try await frameStore.loadFullImage(id: frame.id)
                 let text = await TextRecognitionManager.extractText(from: image)
-                await textCache.setText(text, for: frame.id, timestamp: frame.timestamp)
+                guard await cacheOCRTextIfCurrent(text, for: frame) else {
+                    continue
+                }
 
                 let duration = Date().timeIntervalSince(startedAt)
                 let lag = Date().timeIntervalSince(frame.timestamp)

--- a/JustNow/Capture/PerceptualHash.swift
+++ b/JustNow/Capture/PerceptualHash.swift
@@ -10,8 +10,11 @@ nonisolated struct PerceptualHash {
     /// Compute a 64-bit perceptual hash from a CGImage
     /// Uses average hash algorithm: resize to 8x8, convert to grayscale, threshold by mean
     /// Runs on background thread to keep main actor responsive
+    @concurrent
     @Sendable
     static func compute(from cgImage: CGImage) async -> UInt64 {
+        guard !Task.isCancelled else { return 0 }
+
         // Create an 8x8 grayscale bitmap context
         let width = 8
         let height = 8
@@ -36,6 +39,8 @@ nonisolated struct PerceptualHash {
         // Calculate mean
         let sum = pixelData.reduce(0) { $0 + Int($1) }
         let mean = UInt8(sum / (width * height))
+
+        guard !Task.isCancelled else { return 0 }
 
         // Build hash: 1 if pixel > mean, else 0
         var hash: UInt64 = 0

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -11,6 +11,11 @@ enum CaptureError: Error {
     case noDisplay
 }
 
+private enum CaptureTurnWaitResult {
+    case acquired
+    case cancelled
+}
+
 @MainActor
 protocol ScreenCaptureDelegate: AnyObject {
     func captureManager(_ manager: ScreenCaptureManager, didCaptureFrame image: CGImage, at timestamp: Date)
@@ -25,7 +30,6 @@ extension ScreenCaptureDelegate {
 /// This avoids the persistent purple "sharing" indicator in the menu bar.
 @MainActor
 class ScreenCaptureManager: NSObject {
-    private var captureTimer: Timer?
     private var filter: SCContentFilter?
     private var config: SCStreamConfiguration?
     private var displayDimensions: (width: Int, height: Int)?
@@ -34,6 +38,19 @@ class ScreenCaptureManager: NSObject {
     weak var delegate: ScreenCaptureDelegate?
     private(set) var isCapturing = false
     private(set) var captureInterval: TimeInterval = 1.0
+
+    /// Serial loop: each capture completes before the next is scheduled.
+    private var captureLoopTask: Task<Void, Never>?
+    /// Bumped on stop and on each new loop so a superseded loop cannot clear `captureLoopTask`.
+    private var captureLoopSerial = 0
+    /// Bumped whenever the desired cadence changes so the live loop can adopt a new deadline without restarting.
+    private var captureScheduleRevision = 0
+    private var nextCaptureAt: Date?
+    private var captureWakeTask: Task<Void, Never>?
+    private var captureWakeContinuation: CheckedContinuation<Void, Never>?
+    /// Global gate so periodic capture and overlay refreshes never issue overlapping screenshot requests.
+    private var isCaptureRequestInFlight = false
+    private var captureRequestWaiters: [(id: UUID, continuation: CheckedContinuation<CaptureTurnWaitResult, Never>)] = []
 
     static func hasScreenRecordingPermission() -> Bool {
         CGPreflightScreenCaptureAccess()
@@ -45,7 +62,9 @@ class ScreenCaptureManager: NSObject {
 
     func startCapture() async throws {
         // Stop any existing capture
-        stopCaptureSync()
+        let previousLoop = stopCaptureLoop()
+        await previousLoop?.value
+        try Task.checkCancellation()
 
         // Permission requests are handled by the app launch flow so we do not
         // trigger a second overlapping prompt while starting capture.
@@ -54,43 +73,64 @@ class ScreenCaptureManager: NSObject {
         }
 
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        try Task.checkCancellation()
         guard let display = content.displays.first else {
             throw CaptureError.noDisplay
         }
 
-        filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
+        let dimensions = (width: display.width, height: display.height)
+        let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
 
         let cfg = SCStreamConfiguration()
-        displayDimensions = (width: display.width, height: display.height)
-        applyCaptureScale(to: cfg)
+        applyCaptureScale(to: cfg, dimensions: dimensions)
         cfg.showsCursor = true
         cfg.capturesAudio = false
+        try Task.checkCancellation()
+
+        self.filter = filter
+        displayDimensions = dimensions
         config = cfg
 
-        // Capture immediately, then start timer
-        captureOneFrame()
-        startTimer()
-
         isCapturing = true
+        captureScheduleRevision += 1
+        nextCaptureAt = Date()
+        scheduleCaptureLoop()
+
         print("Capture started successfully (one-shot mode)")
     }
 
     func stopCapture() async {
-        stopCaptureSync()
+        let previousLoop = stopCaptureLoop()
+        await previousLoop?.value
     }
 
-    private func stopCaptureSync() {
-        captureTimer?.invalidate()
-        captureTimer = nil
+    private func stopCaptureLoop() -> Task<Void, Never>? {
+        let previousLoop = captureLoopTask
+        let wasCapturing = isCapturing || previousLoop != nil
+        captureLoopSerial += 1
+        captureScheduleRevision += 1
         isCapturing = false
-        print("Capture stopped")
+        nextCaptureAt = nil
+        captureLoopTask = nil
+        previousLoop?.cancel()
+        cancelQueuedCaptureRequests()
+        wakeCaptureLoop()
+        if wasCapturing {
+            print("Capture stopped")
+        }
+        return previousLoop
     }
 
     func updateCaptureInterval(_ interval: TimeInterval) {
         captureInterval = interval
         guard isCapturing else { return }
-        // Restart timer with new interval
-        startTimer()
+        captureScheduleRevision += 1
+        nextCaptureAt = Date().addingTimeInterval(interval)
+        if captureLoopTask == nil {
+            scheduleCaptureLoop()
+        } else {
+            wakeCaptureLoop()
+        }
     }
 
     func updateCaptureScale(_ scale: Int) {
@@ -101,44 +141,181 @@ class ScreenCaptureManager: NSObject {
 
     /// Capture a single frame immediately and return it (for overlay open).
     func captureNow() async -> CGImage? {
-        guard let filter, let config else { return nil }
-        return try? await SCScreenshotManager.captureImage(contentFilter: filter, configuration: config)
+        let requestLoopSerial = captureLoopSerial
+        guard isCapturing else { return nil }
+        return try? await captureImageSerially(expectedLoopSerial: requestLoopSerial)
     }
 
     // MARK: - Private
 
-    private func startTimer() {
-        captureTimer?.invalidate()
-        captureTimer = Timer.scheduledTimer(withTimeInterval: captureInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.captureOneFrame()
-            }
+    private func scheduleCaptureLoop() {
+        guard isCapturing else { return }
+        guard captureLoopTask == nil else { return }
+        captureLoopSerial += 1
+        let serial = captureLoopSerial
+        captureLoopTask = Task { [weak self] in
+            guard let self else { return }
+            await self.runPeriodicCaptureLoop(loopSerial: serial)
         }
-        captureTimer?.tolerance = min(captureInterval * 0.2, 1.0)
     }
 
-    private func captureOneFrame() {
-        guard let filter, let config else { return }
-
-        Task {
-            do {
-                let image = try await SCScreenshotManager.captureImage(
-                    contentFilter: filter,
-                    configuration: config
-                )
-                let timestamp = Date()
-                await MainActor.run {
-                    self.delegate?.captureManager(self, didCaptureFrame: image, at: timestamp)
-                }
-            } catch {
-                print("Screenshot capture failed: \(error)")
+    private func runPeriodicCaptureLoop(loopSerial: Int) async {
+        while !Task.isCancelled, isCapturing {
+            let now = Date()
+            let deadline = nextCaptureAt ?? now
+            if deadline > now {
+                await waitForCaptureWake(until: deadline)
+                continue
             }
+
+            let tickStart = now
+            let scheduleRevision = captureScheduleRevision
+            await captureSingleFrameAndDeliver(loopSerial: loopSerial)
+            guard isCapturing, !Task.isCancelled else { break }
+
+            if captureScheduleRevision == scheduleRevision {
+                nextCaptureAt = tickStart.addingTimeInterval(captureInterval)
+            } else if let nextCaptureAt, nextCaptureAt <= Date() {
+                self.nextCaptureAt = Date().addingTimeInterval(captureInterval)
+            }
+        }
+        guard loopSerial == captureLoopSerial else { return }
+        wakeCaptureLoop()
+        nextCaptureAt = nil
+        captureLoopTask = nil
+    }
+
+    private func waitForCaptureWake(until deadline: Date) async {
+        let delay = deadline.timeIntervalSinceNow
+        guard delay > 0 else { return }
+
+        await withCheckedContinuation { continuation in
+            guard isCapturing else {
+                continuation.resume()
+                return
+            }
+
+            captureWakeContinuation = continuation
+            captureWakeTask?.cancel()
+            captureWakeTask = Task { [weak self] in
+                guard let self else { return }
+                try? await Task.sleep(for: .seconds(delay))
+                guard !Task.isCancelled else { return }
+                self.resumeCaptureWakeIfNeeded()
+            }
+        }
+    }
+
+    private func wakeCaptureLoop() {
+        captureWakeTask?.cancel()
+        captureWakeTask = nil
+        resumeCaptureWakeIfNeeded()
+    }
+
+    private func resumeCaptureWakeIfNeeded() {
+        captureWakeTask = nil
+        guard let continuation = captureWakeContinuation else { return }
+        captureWakeContinuation = nil
+        continuation.resume()
+    }
+
+    private func acquireCaptureTurn() async throws {
+        if !isCaptureRequestInFlight {
+            isCaptureRequestInFlight = true
+            return
+        }
+
+        let waiterID = UUID()
+        let result = await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                captureRequestWaiters.append((id: waiterID, continuation: continuation))
+                if Task.isCancelled {
+                    cancelCaptureRequestWaiter(id: waiterID)
+                }
+            }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelCaptureRequestWaiter(id: waiterID)
+            }
+        })
+
+        if case .cancelled = result {
+            throw CancellationError()
+        }
+    }
+
+    private func cancelCaptureRequestWaiter(id: UUID) {
+        guard let index = captureRequestWaiters.firstIndex(where: { $0.id == id }) else { return }
+        let continuation = captureRequestWaiters.remove(at: index).continuation
+        continuation.resume(returning: .cancelled)
+    }
+
+    private func cancelQueuedCaptureRequests() {
+        let waiters = captureRequestWaiters
+        captureRequestWaiters.removeAll()
+        for waiter in waiters {
+            waiter.continuation.resume(returning: .cancelled)
+        }
+    }
+
+    private func releaseCaptureTurn() {
+        guard !captureRequestWaiters.isEmpty else {
+            isCaptureRequestInFlight = false
+            return
+        }
+
+        let continuation = captureRequestWaiters.removeFirst().continuation
+        continuation.resume(returning: .acquired)
+    }
+
+    private func captureImageSerially(expectedLoopSerial: Int? = nil) async throws -> CGImage {
+        try await acquireCaptureTurn()
+        defer { releaseCaptureTurn() }
+
+        try Task.checkCancellation()
+        guard let filter, let config else {
+            throw CancellationError()
+        }
+        if let expectedLoopSerial {
+            guard isCapturing, captureLoopSerial == expectedLoopSerial else {
+                throw CancellationError()
+            }
+        }
+
+        let image = try await SCScreenshotManager.captureImage(
+            contentFilter: filter,
+            configuration: config
+        )
+        try Task.checkCancellation()
+        if let expectedLoopSerial {
+            guard isCapturing, captureLoopSerial == expectedLoopSerial else {
+                throw CancellationError()
+            }
+        }
+        return image
+    }
+
+    private func captureSingleFrameAndDeliver(loopSerial: Int) async {
+        guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
+        do {
+            let image = try await captureImageSerially(expectedLoopSerial: loopSerial)
+            guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
+            let timestamp = Date()
+            delegate?.captureManager(self, didCaptureFrame: image, at: timestamp)
+        } catch is CancellationError {
+            // Expected when stopping capture.
+        } catch {
+            print("Screenshot capture failed: \(error)")
         }
     }
 
     private func applyCaptureScale(to config: SCStreamConfiguration) {
         guard let displayDimensions else { return }
-        config.width = displayDimensions.width * captureScale
-        config.height = displayDimensions.height * captureScale
+        applyCaptureScale(to: config, dimensions: displayDimensions)
+    }
+
+    private func applyCaptureScale(to config: SCStreamConfiguration, dimensions: (width: Int, height: Int)) {
+        config.width = dimensions.width * captureScale
+        config.height = dimensions.height * captureScale
     }
 }

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -30,6 +30,8 @@ extension ScreenCaptureDelegate {
 /// This avoids the persistent purple "sharing" indicator in the menu bar.
 @MainActor
 class ScreenCaptureManager: NSObject {
+    private let maximumConsecutiveCaptureFailures = 3
+
     private var filter: SCContentFilter?
     private var config: SCStreamConfiguration?
     private var displayDimensions: (width: Int, height: Int)?
@@ -51,6 +53,7 @@ class ScreenCaptureManager: NSObject {
     /// Global gate so periodic capture and overlay refreshes never issue overlapping screenshot requests.
     private var isCaptureRequestInFlight = false
     private var captureRequestWaiters: [(id: UUID, continuation: CheckedContinuation<CaptureTurnWaitResult, Never>)] = []
+    private var consecutiveCaptureFailures = 0
 
     static func hasScreenRecordingPermission() -> Bool {
         CGPreflightScreenCaptureAccess()
@@ -91,6 +94,7 @@ class ScreenCaptureManager: NSObject {
         displayDimensions = dimensions
         config = cfg
 
+        consecutiveCaptureFailures = 0
         isCapturing = true
         captureScheduleRevision += 1
         nextCaptureAt = Date()
@@ -110,6 +114,7 @@ class ScreenCaptureManager: NSObject {
         captureLoopSerial += 1
         captureScheduleRevision += 1
         isCapturing = false
+        consecutiveCaptureFailures = 0
         nextCaptureAt = nil
         captureLoopTask = nil
         previousLoop?.cancel()
@@ -300,13 +305,27 @@ class ScreenCaptureManager: NSObject {
         do {
             let image = try await captureImageSerially(expectedLoopSerial: loopSerial)
             guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
+            consecutiveCaptureFailures = 0
             let timestamp = Date()
             delegate?.captureManager(self, didCaptureFrame: image, at: timestamp)
         } catch is CancellationError {
             // Expected when stopping capture.
         } catch {
-            print("Screenshot capture failed: \(error)")
+            handleCaptureFailure(error, loopSerial: loopSerial)
         }
+    }
+
+    private func handleCaptureFailure(_ error: Error, loopSerial: Int) {
+        guard isCapturing, loopSerial == captureLoopSerial else { return }
+
+        consecutiveCaptureFailures += 1
+        let failureCount = consecutiveCaptureFailures
+        print("Screenshot capture failed (\(failureCount)/\(maximumConsecutiveCaptureFailures)): \(error)")
+
+        guard failureCount >= maximumConsecutiveCaptureFailures else { return }
+
+        _ = stopCaptureLoop()
+        delegate?.captureManagerDidStop(self)
     }
 
     private func applyCaptureScale(to config: SCStreamConfiguration) {

--- a/JustNow/Storage/FrameMetadata.swift
+++ b/JustNow/Storage/FrameMetadata.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-struct FrameMetadata: Codable, Identifiable, Sendable {
+nonisolated struct FrameMetadata: Codable, Identifiable, Sendable {
     let id: UUID
     let timestamp: Date
     let hash: UInt64
@@ -14,7 +14,7 @@ struct FrameMetadata: Codable, Identifiable, Sendable {
     let fileSize: Int64
 }
 
-struct FrameManifest: Codable, Sendable {
+nonisolated struct FrameManifest: Codable, Sendable {
     var version: Int = 1
     var frames: [FrameMetadata] = []
     var lastModified: Date = Date()

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -14,7 +14,7 @@ enum FrameStoreError: Error {
     case manifestCorrupted
 }
 
-struct FrameSaveOptions: Sendable, Equatable {
+nonisolated struct FrameSaveOptions: Sendable, Equatable {
     let quality: CGFloat
     let thumbnailQuality: CGFloat
     let generateThumbnail: Bool

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -5,12 +5,12 @@
 
 import Foundation
 
-struct RetentionTier: Sendable, Equatable {
+nonisolated struct RetentionTier: Sendable, Equatable {
     let maxAge: TimeInterval
     let minimumSpacing: TimeInterval
 }
 
-struct RetentionPolicy: Sendable, Equatable {
+nonisolated struct RetentionPolicy: Sendable, Equatable {
     let maximumAge: TimeInterval
     let tiers: [RetentionTier]
 

--- a/JustNow/Storage/RewindHistoryOption.swift
+++ b/JustNow/Storage/RewindHistoryOption.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-enum RewindHistoryOption: Double, CaseIterable, Identifiable {
+nonisolated enum RewindHistoryOption: Double, CaseIterable, Identifiable {
     case thirtyMinutes = 1800
     case twoHours = 7200
     case eightHours = 28800

--- a/JustNow/Storage/TextCache.swift
+++ b/JustNow/Storage/TextCache.swift
@@ -7,14 +7,13 @@ import Foundation
 import SQLite3
 import os.log
 
-private let logger = Logger(subsystem: "sg.tk.JustNow", category: "TextCache")
-
 enum TextCacheError: Error {
     case sqlite(String)
 }
 
 /// Caches OCR-extracted text for frames to speed up subsequent searches
 actor TextCache {
+    nonisolated private static let logger = Logger(subsystem: "sg.tk.JustNow", category: "TextCache")
     private let databaseURL: URL
     private let legacyCacheURL: URL
     private var db: OpaquePointer?
@@ -34,13 +33,13 @@ actor TextCache {
             db = connection
             try Self.createSchema(on: connection)
             try Self.repairIndex(on: connection)
-            logger.info("Text cache ready with \(Self.countRows(in: connection)) entries")
+            Self.logger.info("Text cache ready with \(Self.countRows(in: connection)) entries")
 
             Task { [weak self] in
                 await self?.migrateLegacyCacheIfNeeded()
             }
         } catch {
-            logger.error("Failed to initialise text cache: \(error.localizedDescription)")
+            Self.logger.error("Failed to initialise text cache: \(error.localizedDescription)")
             if let db {
                 sqlite3_close(db)
                 self.db = nil
@@ -116,7 +115,15 @@ actor TextCache {
                 }
             }
         } catch {
-            logger.error("Failed to cache OCR text: \(error.localizedDescription)")
+            Self.logger.error("Failed to cache OCR text: \(error.localizedDescription)")
+        }
+    }
+
+    func removeText(for frameID: UUID) {
+        do {
+            try delete(frameIDs: [frameID])
+        } catch {
+            Self.logger.error("Failed to remove OCR text: \(error.localizedDescription)")
         }
     }
 
@@ -291,9 +298,9 @@ actor TextCache {
             guard !staleIDs.isEmpty else { return }
 
             try delete(frameIDs: staleIDs)
-            logger.info("Pruned \(staleIDs.count) stale OCR cache entries")
+            Self.logger.info("Pruned \(staleIDs.count) stale OCR cache entries")
         } catch {
-            logger.error("Failed to prune OCR cache: \(error.localizedDescription)")
+            Self.logger.error("Failed to prune OCR cache: \(error.localizedDescription)")
         }
     }
 
@@ -305,7 +312,7 @@ actor TextCache {
                 try execute("DELETE FROM frame_text;")
             }
         } catch {
-            logger.error("Failed to clear OCR cache: \(error.localizedDescription)")
+            Self.logger.error("Failed to clear OCR cache: \(error.localizedDescription)")
         }
     }
 
@@ -386,7 +393,7 @@ actor TextCache {
         do {
             try migrateLegacyJSONIfNeeded()
         } catch {
-            logger.error("Failed to migrate legacy OCR cache: \(error.localizedDescription)")
+            Self.logger.error("Failed to migrate legacy OCR cache: \(error.localizedDescription)")
         }
     }
 
@@ -439,7 +446,7 @@ actor TextCache {
             }
         }
 
-        logger.info("Migrated \(legacy.count) legacy OCR cache entries into SQLite")
+        Self.logger.info("Migrated \(legacy.count) legacy OCR cache entries into SQLite")
     }
 
     private func delete(frameIDs: [UUID]) throws {

--- a/JustNow/Storage/ThumbnailGenerator.swift
+++ b/JustNow/Storage/ThumbnailGenerator.swift
@@ -7,7 +7,7 @@ import CoreGraphics
 import ImageIO
 import UniformTypeIdentifiers
 
-enum ImageEncoder {
+nonisolated enum ImageEncoder {
     static let thumbnailMaxSize: CGFloat = 200
     static let thumbnailQuality: CGFloat = 0.7
     static let fullImageQuality: CGFloat = 0.85

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -10,6 +10,12 @@ import os.log
 
 private let logger = Logger(subsystem: "sg.tk.JustNow", category: "OverlayView")
 
+nonisolated enum SearchOCRBatchResult: Sendable {
+    case ocrPersisted
+    case frameLoadFailed
+    case skipped
+}
+
 enum SearchTimeScope: String, CaseIterable {
     case fiveMinutes
     case oneHour
@@ -217,33 +223,36 @@ class OverlayViewModel {
                 let batch = Array(uncachedFrames[batchStart..<batchEnd])
 
                 // Process batch in parallel
-                await withTaskGroup(of: Bool.self) { group in
+                await withTaskGroup(of: SearchOCRBatchResult.self) { group in
                     for frame in batch {
                         group.addTask {
                             guard !Task.isCancelled else {
-                                return false
+                                return .skipped
                             }
 
                             guard let image = try? await buffer.getFullImage(for: frame) else {
-                                return false
+                                return .frameLoadFailed
                             }
 
                             let text = await TextRecognitionManager.extractText(from: image)
 
                             guard !Task.isCancelled else {
-                                return false
+                                return .skipped
                             }
 
                             // Persist OCR text to indexed cache
-                            return await buffer.cacheOCRTextIfCurrent(text, for: frame)
+                            return await buffer.cacheOCRTextIfCurrent(text, for: frame) ? .ocrPersisted : .skipped
                         }
                     }
 
-                    for await didOCR in group {
-                        if didOCR {
+                    for await result in group {
+                        switch result {
+                        case .ocrPersisted:
                             ocrRuns += 1
-                        } else {
+                        case .frameLoadFailed:
                             loadFailures += 1
+                        case .skipped:
+                            break
                         }
                     }
                 }

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -145,6 +145,7 @@ class OverlayViewModel {
 
     func clearSearch() {
         searchTask?.cancel()
+        searchTask = nil
         searchQuery = ""
         searchResults = []
         isSearchInProgress = false
@@ -156,6 +157,7 @@ class OverlayViewModel {
     func performSearch() {
         print("[JustNow] performSearch() called with query: '\(searchQuery)'")
         searchTask?.cancel()
+        searchTask = nil
         guard !searchQuery.isEmpty else {
             print("[JustNow] Query is empty, returning")
             searchResults = []
@@ -218,14 +220,22 @@ class OverlayViewModel {
                 await withTaskGroup(of: Bool.self) { group in
                     for frame in batch {
                         group.addTask {
+                            guard !Task.isCancelled else {
+                                return false
+                            }
+
                             guard let image = try? await buffer.getFullImage(for: frame) else {
                                 return false
                             }
+
                             let text = await TextRecognitionManager.extractText(from: image)
 
+                            guard !Task.isCancelled else {
+                                return false
+                            }
+
                             // Persist OCR text to indexed cache
-                            await cache.setText(text, for: frame.id, timestamp: frame.timestamp)
-                            return true
+                            return await buffer.cacheOCRTextIfCurrent(text, for: frame)
                         }
                     }
 
@@ -649,11 +659,17 @@ struct FramePreviewView: View {
             image = nil
 
             do {
-                image = try await frameBuffer.getFullImage(for: frame)
+                let loadedImage = try await frameBuffer.getFullImage(for: frame)
+                guard !Task.isCancelled else { return }
+                image = loadedImage
+            } catch is CancellationError {
+                return
             } catch {
+                guard !Task.isCancelled else { return }
                 loadFailed = true
             }
 
+            guard !Task.isCancelled else { return }
             isLoading = false
         }
     }

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -37,8 +37,8 @@ class OverlayWindowController: NSObject {
     }
 
     func showOverlay(
-        recentTimelineWindow: TimeInterval = RecentTimelineWindow.defaultValue.timeInterval,
-        rewindHistoryOption: RewindHistoryOption = .defaultValue
+        recentTimelineWindow: TimeInterval,
+        rewindHistoryOption: RewindHistoryOption
     ) {
         guard window == nil, let screen = NSScreen.main else { return }
 
@@ -177,6 +177,7 @@ class OverlayWindowController: NSObject {
     func hideOverlay() {
         // Resume pruning
         frameBuffer.isPruningPaused = false
+        viewModel?.clearSearch()
 
         if let monitor = keyEventMonitor {
             NSEvent.removeMonitor(monitor)

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -260,14 +260,10 @@ struct SettingsView: View {
             await updateStorageInfo()
         }
         .task(id: updaterIdentity) {
-            await MainActor.run {
-                syncUpdaterState()
-            }
+            syncUpdaterState()
         }
         .task(id: launchAtLoginIdentity) {
-            await MainActor.run {
-                syncLaunchAtLoginState()
-            }
+            syncLaunchAtLoginState()
         }
         .task {
             await refreshTelemetryLoop()
@@ -294,7 +290,10 @@ struct SettingsView: View {
 
     private func updateStorageInfo() async {
         if let buffer = context.frameBuffer {
-            storageSize = await buffer.totalStorageSize()
+            let bufferIdentity = ObjectIdentifier(buffer)
+            let totalStorageSize = await buffer.totalStorageSize()
+            guard !Task.isCancelled, context.frameBuffer.map(ObjectIdentifier.init) == bufferIdentity else { return }
+            storageSize = totalStorageSize
             frameCount = buffer.frameCount
         } else {
             storageSize = 0
@@ -317,9 +316,8 @@ struct SettingsView: View {
     private func refreshTelemetryLoop() async {
         while !Task.isCancelled {
             let snapshot = await SearchTelemetry.shared.snapshot()
-            await MainActor.run {
-                telemetrySnapshot = snapshot
-            }
+            guard !Task.isCancelled else { return }
+            telemetrySnapshot = snapshot
             try? await Task.sleep(for: .seconds(2))
         }
     }

--- a/JustNow/Utilities/TextRecognitionManager.swift
+++ b/JustNow/Utilities/TextRecognitionManager.swift
@@ -6,14 +6,16 @@
 import Vision
 import os.log
 
-private let logger = Logger(subsystem: "sg.tk.JustNow", category: "TextRecognition")
-
 /// Performs on-demand OCR using Vision framework
-enum TextRecognitionManager {
+nonisolated enum TextRecognitionManager {
+    private static let logger = Logger(subsystem: "sg.tk.JustNow", category: "TextRecognition")
 
     /// Extracts text from a CGImage using VNRecognizeTextRequest
+    @concurrent
     @Sendable
     static func extractText(from image: CGImage) async -> String {
+        guard !Task.isCancelled else { return "" }
+
         let request = VNRecognizeTextRequest()
         request.recognitionLevel = .fast  // Much faster than .accurate
         request.usesLanguageCorrection = false  // Skip for speed
@@ -23,12 +25,14 @@ enum TextRecognitionManager {
         do {
             try handler.perform([request])
         } catch {
-            logger.error("Vision request failed: \(error.localizedDescription)")
+            Self.logger.error("Vision request failed: \(error.localizedDescription)")
             return ""
         }
 
+        guard !Task.isCancelled else { return "" }
+
         guard let observations = request.results else {
-            logger.debug("No observations returned")
+            Self.logger.debug("No observations returned")
             return ""
         }
 
@@ -37,7 +41,7 @@ enum TextRecognitionManager {
             .compactMap { $0.topCandidates(1).first?.string }
             .joined(separator: " ")
 
-        logger.debug("Extracted \(text.count) chars from image")
+        Self.logger.debug("Extracted \(text.count) chars from image")
         print("[JustNow OCR] Extracted \(text.count) chars")
         if !text.isEmpty {
             print("[JustNow OCR] Sample: \(String(text.prefix(100)))")
@@ -46,11 +50,12 @@ enum TextRecognitionManager {
     }
 
     /// Searches for text in a frame, returns true if found
+    @concurrent
     static func frameContainsText(_ searchText: String, in image: CGImage) async -> Bool {
         let extractedText = await extractText(from: image)
         let contains = extractedText.localizedCaseInsensitiveContains(searchText)
         if contains {
-            logger.info("Found '\(searchText)' in frame")
+            Self.logger.info("Found '\(searchText)' in frame")
         }
         return contains
     }


### PR DESCRIPTION
## Summary
- replace the timer-driven capture scheduling with a serial async loop and tracked startup/resume tasks so overlay, session, and termination transitions cannot revive stale capture work
- make frame ingest, duplicate suppression, clear/flush, and OCR indexing cancellation-safe so stale async work cannot reorder frames or persist outdated OCR results
- fix Swift 6.2 isolation issues and stale UI task updates in the overlay and settings flows

## Testing
- `xcodebuild -project "JustNow.xcodeproj" -scheme "JustNow" -destination "platform=macOS" test`
- `./Scripts/local-install-app.sh` (release build completed; the app was then reinstalled and launched manually from `/Applications/JustNow.app` after a `trash` AppleEvent timeout)
