### PR TITLE
Hide search behind a feature flag

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -10,6 +10,11 @@ import HotKey
 import Carbon.HIToolbox
 import Sparkle
 
+enum FeatureFlags {
+    /// Temporary kill switch while in-app search is hidden from release builds.
+    static let isSearchEnabled = false
+}
+
 enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
     case oneMinute = 60
     case twoMinutes = 120
@@ -941,7 +946,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         var scale = 2
         var saveOptions = FrameSaveOptions.standard
         var duplicatePolicy = DuplicateFramePolicy.exact(atMostEvery: captureInterval)
-        var ocrIndexEnabled = backgroundSearchIndexingEnabled
+        var ocrIndexEnabled = FeatureFlags.isSearchEnabled && backgroundSearchIndexingEnabled
         var ocrIndexInterval = ocrIndexBaseInterval
         var ocrIndexQueueDepth = ocrIndexBaseQueueDepth
         var ocrIndexMaxAge = ocrIndexMaxFrameAge

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -109,9 +109,13 @@ class OverlayViewModel {
     var searchProgress: Double = 0
     private var searchTask: Task<Void, Never>?
 
+    var isSearchAvailable: Bool {
+        FeatureFlags.isSearchEnabled
+    }
+
     /// Frames to display (filtered if searching, all otherwise)
     var displayedFrames: [StoredFrame] {
-        isSearching && !searchQuery.isEmpty ? searchResults : timelineFrames
+        isSearchAvailable && isSearching && !searchQuery.isEmpty ? searchResults : timelineFrames
     }
 
     var displayedFrameCount: Int {
@@ -141,6 +145,10 @@ class OverlayViewModel {
     }
 
     func toggleSearch() {
+        guard isSearchAvailable else {
+            clearSearch()
+            return
+        }
         print("[JustNow] toggleSearch called, isSearching was: \(isSearching)")
         isSearching.toggle()
         print("[JustNow] isSearching is now: \(isSearching)")
@@ -152,6 +160,7 @@ class OverlayViewModel {
     func clearSearch() {
         searchTask?.cancel()
         searchTask = nil
+        isSearching = false
         searchQuery = ""
         searchResults = []
         isSearchInProgress = false
@@ -161,6 +170,10 @@ class OverlayViewModel {
     }
 
     func performSearch() {
+        guard isSearchAvailable else {
+            clearSearch()
+            return
+        }
         print("[JustNow] performSearch() called with query: '\(searchQuery)'")
         searchTask?.cancel()
         searchTask = nil
@@ -424,7 +437,7 @@ struct ContentAreaView: View {
     var body: some View {
         VStack(spacing: 0) {
             // Search bar
-            if viewModel.isSearching {
+            if viewModel.isSearchAvailable && viewModel.isSearching {
                 SearchBarView(viewModel: viewModel)
                     .padding(.top, 60)
                     .padding(.horizontal, 200)
@@ -436,7 +449,7 @@ struct ContentAreaView: View {
             if let frame = displayedFrames[safe: viewModel.selectedIndex] {
                 FramePreviewView(frame: frame, frameBuffer: viewModel.frameBuffer)
                     .padding(.horizontal, 60)
-                    .padding(.top, viewModel.isSearching ? 20 : 40)
+                    .padding(.top, viewModel.isSearchAvailable && viewModel.isSearching ? 20 : 40)
             } else if !viewModel.isSearching && viewModel.timelineFrames.isEmpty {
                 VStack(spacing: 12) {
                     Image(systemName: "clock.badge.exclamationmark")
@@ -445,11 +458,15 @@ struct ContentAreaView: View {
                     Text("No frames in this rewind window")
                         .font(.headline)
                         .foregroundStyle(.white.opacity(0.6))
-                    Text("Search can still look through the last hour.")
+                    Text(
+                        viewModel.isSearchAvailable
+                            ? "Search can still look through the last hour."
+                            : "Increase rewind history in Settings to keep older frames visible here."
+                    )
                         .font(.subheadline)
                         .foregroundStyle(.white.opacity(0.45))
                 }
-            } else if viewModel.isSearching && displayedFrames.isEmpty && !viewModel.isSearchInProgress {
+            } else if viewModel.isSearchAvailable && viewModel.isSearching && displayedFrames.isEmpty && !viewModel.isSearchInProgress {
                 // No results state
                 VStack(spacing: 12) {
                     Image(systemName: "magnifyingglass")
@@ -468,7 +485,7 @@ struct ContentAreaView: View {
                 .padding(.horizontal, 40)
                 .padding(.bottom, 50)
         }
-        .animation(.easeInOut(duration: 0.2), value: viewModel.isSearching)
+        .animation(.easeInOut(duration: 0.2), value: viewModel.isSearchAvailable && viewModel.isSearching)
     }
 }
 
@@ -546,7 +563,6 @@ struct SearchBarView: View {
 
             Button {
                 viewModel.clearSearch()
-                viewModel.isSearching = false
             }
             label: {
                 Label("Clear search", systemImage: "xmark.circle.fill")
@@ -599,7 +615,9 @@ struct InstructionsOverlay: View {
                 Spacer()
                 HStack(spacing: 16) {
                     Label("← →", systemImage: "arrow.left.arrow.right")
-                    Label("/", systemImage: "magnifyingglass")
+                    if FeatureFlags.isSearchEnabled {
+                        Label("/", systemImage: "magnifyingglass")
+                    }
                 }
                 .labelStyle(CompactInstructionLabelStyle())
                 .font(.system(size: 11, weight: .medium))

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -50,7 +50,9 @@ class OverlayWindowController: NSObject {
             recentWindow: recentTimelineWindow,
             maximumAge: rewindHistoryOption.duration
         )
-        let searchableFrames = frameBuffer.getFilteredFrames(recentWindow: recentTimelineWindow)
+        let searchableFrames = FeatureFlags.isSearchEnabled
+            ? frameBuffer.getFilteredFrames(recentWindow: recentTimelineWindow)
+            : []
         let vm = OverlayViewModel(
             timelineFrames: timelineFrames,
             searchableFrames: searchableFrames,
@@ -108,28 +110,28 @@ class OverlayWindowController: NSObject {
 
             switch event.keyCode {
             case 53: // ESC
-                if vm.isSearching {
+                if vm.isSearchAvailable && vm.isSearching {
                     vm.clearSearch()
-                    vm.isSearching = false
                 } else {
                     self.hideOverlay()
                 }
                 return nil
             case 44: // "/" key - toggle search
+                guard vm.isSearchAvailable else { return nil }
                 if !vm.isSearching {
                     vm.toggleSearch()
                     return nil
                 }
                 return event // Pass through if already searching (for typing)
             case 36: // Return key - trigger search
-                if vm.isSearching && !vm.searchQuery.isEmpty {
+                if vm.isSearchAvailable && vm.isSearching && !vm.searchQuery.isEmpty {
                     print("[JustNow] Return key pressed, triggering search")
                     vm.performSearch()
                     return nil
                 }
                 return event
             case 123: // Left arrow
-                if vm.isSearching { return event } // Let text field handle it
+                if vm.isSearchAvailable && vm.isSearching { return event } // Let text field handle it
                 if event.modifierFlags.contains(.command) {
                     vm.goToStart()
                 } else if event.modifierFlags.contains(.option) {
@@ -139,7 +141,7 @@ class OverlayWindowController: NSObject {
                 }
                 return nil
             case 124: // Right arrow
-                if vm.isSearching { return event } // Let text field handle it
+                if vm.isSearchAvailable && vm.isSearching { return event } // Let text field handle it
                 if event.modifierFlags.contains(.command) {
                     vm.goToEnd()
                 } else if event.modifierFlags.contains(.option) {

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -34,6 +34,10 @@ struct SettingsView: View {
     @State private var launchAtLoginEnabled = false
     @State private var launchAtLoginAlertMessage: String?
 
+    private var isSearchEnabled: Bool {
+        FeatureFlags.isSearchEnabled
+    }
+
     var body: some View {
         Form {
             Section {
@@ -167,67 +171,71 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
 
-                Toggle("Background OCR indexing for search", isOn: $backgroundSearchIndexingEnabled)
-                Text("Indexes recent frames in the background so searches return faster. Automatically throttled on battery, low power mode, and thermal pressure.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                if isSearchEnabled {
+                    Toggle("Background OCR indexing for search", isOn: $backgroundSearchIndexingEnabled)
+                    Text("Indexes recent frames in the background so searches return faster. Automatically throttled on battery, low power mode, and thermal pressure.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } header: {
                 Text("Battery")
             }
 
-            Section {
-                DisclosureGroup(isExpanded: $isSearchDiagnosticsExpanded) {
-                    VStack(spacing: 10) {
-                        HStack {
-                            Text("Index queue")
-                            Spacer()
-                            Text("\(telemetrySnapshot.queueDepth) / \(telemetrySnapshot.queueCapacity)")
+            if isSearchEnabled {
+                Section {
+                    DisclosureGroup(isExpanded: $isSearchDiagnosticsExpanded) {
+                        VStack(spacing: 10) {
+                            HStack {
+                                Text("Index queue")
+                                Spacer()
+                                Text("\(telemetrySnapshot.queueDepth) / \(telemetrySnapshot.queueCapacity)")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack {
+                                Text("OCR throughput")
+                                Spacer()
+                                Text("\(formatRate(telemetrySnapshot.ocrPerSecond))")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack {
+                                Text("OCR duration (avg/p95)")
+                                Spacer()
+                                Text("\(formatSeconds(telemetrySnapshot.averageOCRDuration)) / \(formatSeconds(telemetrySnapshot.p95OCRDuration))")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack {
+                                Text("Index lag (avg/p95)")
+                                Spacer()
+                                Text("\(formatSeconds(telemetrySnapshot.averageIndexLag)) / \(formatSeconds(telemetrySnapshot.p95IndexLag))")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack {
+                                Text("Warm search p50")
+                                Spacer()
+                                Text("\(formatSeconds(telemetrySnapshot.warmSearchP50)) · n=\(telemetrySnapshot.warmSearchCount)")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            HStack {
+                                Text("Cold search p50")
+                                Spacer()
+                                Text("\(formatSeconds(telemetrySnapshot.coldSearchP50)) · n=\(telemetrySnapshot.coldSearchCount)")
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text("These numbers update every 2 seconds from local telemetry.")
+                                .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
-
-                        HStack {
-                            Text("OCR throughput")
-                            Spacer()
-                            Text("\(formatRate(telemetrySnapshot.ocrPerSecond))")
-                                .foregroundStyle(.secondary)
-                        }
-
-                        HStack {
-                            Text("OCR duration (avg/p95)")
-                            Spacer()
-                            Text("\(formatSeconds(telemetrySnapshot.averageOCRDuration)) / \(formatSeconds(telemetrySnapshot.p95OCRDuration))")
-                                .foregroundStyle(.secondary)
-                        }
-
-                        HStack {
-                            Text("Index lag (avg/p95)")
-                            Spacer()
-                            Text("\(formatSeconds(telemetrySnapshot.averageIndexLag)) / \(formatSeconds(telemetrySnapshot.p95IndexLag))")
-                                .foregroundStyle(.secondary)
-                        }
-
-                        HStack {
-                            Text("Warm search p50")
-                            Spacer()
-                            Text("\(formatSeconds(telemetrySnapshot.warmSearchP50)) · n=\(telemetrySnapshot.warmSearchCount)")
-                                .foregroundStyle(.secondary)
-                        }
-
-                        HStack {
-                            Text("Cold search p50")
-                            Spacer()
-                            Text("\(formatSeconds(telemetrySnapshot.coldSearchP50)) · n=\(telemetrySnapshot.coldSearchCount)")
-                                .foregroundStyle(.secondary)
-                        }
-
-                        Text("These numbers update every 2 seconds from local telemetry.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
+                        .padding(.top, 6)
+                    } label: {
+                        Text("Search Diagnostics")
                     }
-                    .padding(.top, 6)
-                } label: {
-                    Text("Search Diagnostics")
                 }
             }
 
@@ -265,7 +273,11 @@ struct SettingsView: View {
         .task(id: launchAtLoginIdentity) {
             syncLaunchAtLoginState()
         }
-        .task {
+        .task(id: isSearchEnabled) {
+            guard isSearchEnabled else {
+                telemetrySnapshot = .empty
+                return
+            }
             await refreshTelemetryLoop()
         }
         .alert("Clear History?", isPresented: $showClearConfirmation) {


### PR DESCRIPTION
## Summary
- add a single feature flag that disables search by default
- gate the overlay search UI and keyboard entry points behind that flag
- hide search-related Settings controls and disable background OCR indexing when search is off

## Testing
- `./Scripts/local-install-app.sh` (release build succeeded; I then reinstalled and launched the app from `/Applications/JustNow.app` after the helper's DMG AppleScript step failed)
- `xcodebuild test -scheme JustNow -derivedDataPath build-test CODE_SIGN_STYLE=Manual CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`
