### PR TITLE
feat: pause hotkey, menu shortcut coordination, and DMG build resilience

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -10,6 +10,132 @@ import HotKey
 import Carbon.HIToolbox
 import Sparkle
 
+private final class StatusMenuActionItemView: NSView {
+    private let titleField = NSTextField(labelWithString: "")
+    private let accessoryImageView = NSImageView()
+    private var trackingArea: NSTrackingArea?
+    private var isHovered = false {
+        didSet {
+            needsDisplay = true
+            updateAppearance()
+        }
+    }
+
+    weak var menuItem: NSMenuItem?
+
+    override var isFlipped: Bool { true }
+
+    init(width: CGFloat = 220) {
+        super.init(frame: NSRect(x: 0, y: 0, width: width, height: 28))
+        setup()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(title: String, accessorySystemImageName: String) {
+        titleField.stringValue = title
+        accessoryImageView.image = NSImage(
+            systemSymbolName: accessorySystemImageName,
+            accessibilityDescription: title
+        )
+        accessoryImageView.image?.isTemplate = true
+        updateAppearance()
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+
+        if isHovered || enclosingMenuItem?.isHighlighted == true {
+            NSColor.selectedContentBackgroundColor.setFill()
+            dirtyRect.fill()
+        }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+
+        let trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        self.trackingArea = trackingArea
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        let location = convert(event.locationInWindow, from: nil)
+        guard bounds.contains(location),
+              let menuItem,
+              let action = menuItem.action else {
+            return
+        }
+
+        isHovered = false
+        let target = menuItem.target ?? NSApp.target(forAction: action, to: nil, from: menuItem)
+        menuItem.menu?.cancelTracking()
+        NSApp.sendAction(action, to: target, from: menuItem)
+    }
+
+    private func setup() {
+        titleField.lineBreakMode = .byTruncatingTail
+        titleField.font = .menuFont(ofSize: 0)
+
+        accessoryImageView.symbolConfiguration = .init(pointSize: 12, weight: .semibold)
+        accessoryImageView.imageScaling = .scaleProportionallyDown
+
+        let spacer = NSView()
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let stackView = NSStackView(views: [titleField, spacer, accessoryImageView])
+        stackView.orientation = .horizontal
+        stackView.alignment = .centerY
+        stackView.distribution = .fill
+        stackView.spacing = 8
+        stackView.edgeInsets = NSEdgeInsets(top: 5, left: 12, bottom: 5, right: 12)
+
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            accessoryImageView.widthAnchor.constraint(equalToConstant: 14)
+        ])
+
+        titleField.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        titleField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        accessoryImageView.setContentHuggingPriority(.required, for: .horizontal)
+        accessoryImageView.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        let isHighlighted = isHovered || enclosingMenuItem?.isHighlighted == true
+        titleField.textColor = isHighlighted ? .selectedMenuItemTextColor : .labelColor
+        accessoryImageView.contentTintColor = isHighlighted ? .selectedMenuItemTextColor : .secondaryLabelColor
+    }
+}
+
 enum FeatureFlags {
     /// Temporary kill switch while in-app search is hidden from release builds.
     static let isSearchEnabled = false
@@ -51,7 +177,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     private var captureManager: ScreenCaptureManager!
     private var frameBuffer: FrameBuffer?
     private var overlayController: OverlayWindowController?
-    private var hotKey: HotKey?
+    private var overlayHotKey: HotKey?
+    private var capturePauseHotKey: HotKey?
     private lazy var updaterController = SPUStandardUpdaterController(
         startingUpdater: false,
         updaterDelegate: nil,
@@ -66,7 +193,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
             self?.checkForUpdates(nil)
         },
         onShortcutChanged: { [weak self] in
-            self?.registerHotKey()
+            self?.keyboardShortcutsDidChange()
         }
     )
     private lazy var settingsWindowCoordinator = SettingsWindowCoordinator(
@@ -86,6 +213,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
     @AppStorage("reduceCaptureOnBattery") private var reduceCaptureOnBattery: Bool = true
     @AppStorage("shortcutKeyCode") private var shortcutKeyCode: Int = 38  // J key
     @AppStorage("shortcutModifiers") private var shortcutModifiers: Int = 1_572_864  // ⌘⌥
+    @AppStorage("capturePauseShortcutKeyCode") private var capturePauseShortcutKeyCode: Int = 38  // J key
+    @AppStorage("capturePauseShortcutModifiers") private var capturePauseShortcutModifiers: Int = 1_703_936  // ⌘⌥⇧
     @AppStorage("overlayDismissKeyCode") private var overlayDismissKeyCode: Int = 53
     @AppStorage("overlayDismissModifiers") private var overlayDismissModifiers: Int = 0
     private var capturePolicyTimer: Timer?
@@ -155,6 +284,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         static let captureStatus = 101
         static let pauseToggle = 102
         static let permissionHelp = 103
+        static let showTimeline = 104
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -229,12 +359,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         let showItem = NSMenuItem(title: "Show Timeline", action: #selector(showOverlay), keyEquivalent: "")
         showItem.target = self
+        showItem.tag = MenuItemTag.showTimeline
         showItem.keyEquivalentModifierMask = [.command, .option]
+        showItem.view = makeMenuActionView(for: showItem)
         menu.addItem(showItem)
 
         let pauseItem = NSMenuItem(title: "Pause Recording", action: #selector(toggleCapturePause), keyEquivalent: "")
         pauseItem.target = self
         pauseItem.tag = MenuItemTag.pauseToggle
+        pauseItem.view = makeMenuActionView(for: pauseItem)
         menu.addItem(pauseItem)
 
         menu.addItem(NSMenuItem.separator())
@@ -281,6 +414,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
 
         menu.delegate = self
         statusItem.menu = menu
+        updateShowTimelineMenuItem()
         updatePauseMenuItem()
     }
 
@@ -288,24 +422,55 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         registerHotKey()
     }
 
+    private func keyboardShortcutsDidChange() {
+        registerHotKey()
+        overlayController?.updateDismissShortcut(
+            keyCode: overlayDismissKeyCode,
+            modifiers: overlayDismissModifiers
+        )
+    }
+
     func registerHotKey() {
-        // Clear existing hotkey
-        hotKey = nil
+        overlayHotKey = nil
+        capturePauseHotKey = nil
 
-        // Don't register if no shortcut set
-        guard shortcutKeyCode != -1 else { return }
-
-        // Convert stored modifiers to NSEvent.ModifierFlags
-        let flags = NSEvent.ModifierFlags(rawValue: UInt(shortcutModifiers))
-        var carbonMods: UInt32 = 0
-        if flags.contains(.command) { carbonMods |= UInt32(cmdKey) }
-        if flags.contains(.option) { carbonMods |= UInt32(optionKey) }
-        if flags.contains(.control) { carbonMods |= UInt32(controlKey) }
-        if flags.contains(.shift) { carbonMods |= UInt32(shiftKey) }
-
-        hotKey = HotKey(carbonKeyCode: UInt32(shortcutKeyCode), carbonModifiers: carbonMods)
-        hotKey?.keyDownHandler = { [weak self] in
+        // Global Carbon hotkeys: at most one registration per key+modifier pair. Open rewind wins over pause
+        // when they match. Pause is also skipped if it matches the close rewind shortcut, which is handled
+        // locally while the overlay is open—otherwise both handlers could fire for one key press.
+        overlayHotKey = makeHotKey(
+            keyCode: shortcutKeyCode,
+            modifiers: shortcutModifiers
+        ) { [weak self] in
             self?.toggleOverlay()
+        }
+
+        guard capturePauseShortcutKeyCode != -1 else { return }
+
+        if shortcutsConflict(
+            capturePauseShortcutKeyCode,
+            capturePauseShortcutModifiers,
+            shortcutKeyCode,
+            shortcutModifiers
+        ) {
+            print("Skipping pause hotkey registration because it matches the open rewind shortcut")
+            return
+        }
+
+        if shortcutsConflict(
+            capturePauseShortcutKeyCode,
+            capturePauseShortcutModifiers,
+            overlayDismissKeyCode,
+            overlayDismissModifiers
+        ) {
+            print("Skipping pause hotkey registration because it matches the close rewind shortcut")
+            return
+        }
+
+        capturePauseHotKey = makeHotKey(
+            keyCode: capturePauseShortcutKeyCode,
+            modifiers: capturePauseShortcutModifiers
+        ) { [weak self] in
+            self?.toggleCapturePause()
         }
     }
 
@@ -1078,7 +1243,54 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate, NSMen
         guard let menu = statusItem.menu,
               let item = menu.item(withTag: MenuItemTag.pauseToggle) else { return }
         item.title = isUserPaused ? "Resume Recording" : "Pause Recording"
-        item.state = isUserPaused ? .on : .off
+        item.state = .off
+        item.image = nil
+        (item.view as? StatusMenuActionItemView)?.configure(
+            title: item.title,
+            accessorySystemImageName: isUserPaused ? "play.fill" : "pause.fill"
+        )
+    }
+
+    private func updateShowTimelineMenuItem() {
+        guard let menu = statusItem.menu,
+              let item = menu.item(withTag: MenuItemTag.showTimeline) else { return }
+        item.image = nil
+        (item.view as? StatusMenuActionItemView)?.configure(
+            title: item.title,
+            accessorySystemImageName: "backward.fill"
+        )
+    }
+
+    private func makeHotKey(
+        keyCode: Int,
+        modifiers: Int,
+        handler: @escaping () -> Void
+    ) -> HotKey? {
+        guard keyCode != -1 else { return nil }
+
+        let flags = NSEvent.ModifierFlags(rawValue: UInt(modifiers))
+        var carbonMods: UInt32 = 0
+        if flags.contains(.command) { carbonMods |= UInt32(cmdKey) }
+        if flags.contains(.option) { carbonMods |= UInt32(optionKey) }
+        if flags.contains(.control) { carbonMods |= UInt32(controlKey) }
+        if flags.contains(.shift) { carbonMods |= UInt32(shiftKey) }
+
+        let hotKey = HotKey(carbonKeyCode: UInt32(keyCode), carbonModifiers: carbonMods)
+        hotKey.keyDownHandler = handler
+        return hotKey
+    }
+
+    private func shortcutsConflict(_ lhsKeyCode: Int, _ lhsModifiers: Int, _ rhsKeyCode: Int, _ rhsModifiers: Int) -> Bool {
+        lhsKeyCode != -1
+            && rhsKeyCode != -1
+            && lhsKeyCode == rhsKeyCode
+            && lhsModifiers == rhsModifiers
+    }
+
+    private func makeMenuActionView(for item: NSMenuItem) -> StatusMenuActionItemView {
+        let view = StatusMenuActionItemView()
+        view.menuItem = item
+        return view
     }
 
     private func updateStatusItemButtonAppearance() {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -45,12 +45,27 @@ private final class StatusMenuActionItemView: NSView {
         updateAppearance()
     }
 
+    override func viewWillDraw() {
+        super.viewWillDraw()
+        // Menu keyboard navigation updates `enclosingMenuItem.isHighlighted` without toggling hover;
+        // refresh label and symbol colours whenever AppKit is about to draw this row.
+        updateAppearance()
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
 
         if isHovered || enclosingMenuItem?.isHighlighted == true {
             NSColor.selectedContentBackgroundColor.setFill()
             dirtyRect.fill()
+        }
+    }
+
+    override func viewWillMove(toWindow newWindow: NSWindow?) {
+        super.viewWillMove(toWindow: newWindow)
+        // If the menu dismisses while the pointer is still over this row, AppKit may not send mouseExited.
+        if newWindow == nil {
+            isHovered = false
         }
     }
 

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -16,6 +16,8 @@ struct SettingsView: View {
     @AppStorage("reduceCaptureOnBattery") private var reduceCaptureOnBattery: Bool = true
     @AppStorage("shortcutKeyCode") private var shortcutKeyCode: Int = 38  // J key
     @AppStorage("shortcutModifiers") private var shortcutModifiers: Int = 1_572_864  // ⌘⌥
+    @AppStorage("capturePauseShortcutKeyCode") private var capturePauseShortcutKeyCode: Int = 38  // J key
+    @AppStorage("capturePauseShortcutModifiers") private var capturePauseShortcutModifiers: Int = 1_703_936  // ⌘⌥⇧
     @AppStorage("overlayDismissKeyCode") private var overlayDismissKeyCode: Int = 53
     @AppStorage("overlayDismissModifiers") private var overlayDismissModifiers: Int = 0
     @AppStorage("textGrabSoundEnabled") private var textGrabSoundEnabled: Bool = true
@@ -48,10 +50,12 @@ struct SettingsView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
+            } header: {
+                Text("General")
+            }
 
-                HStack {
-                    Text("Show")
-                    Spacer()
+            Section {
+                shortcutRow("Open rewind") {
                     KeyboardShortcutRecorder(
                         keyCode: $shortcutKeyCode,
                         modifiers: $shortcutModifiers
@@ -61,9 +65,17 @@ struct SettingsView: View {
                     .onChange(of: shortcutModifiers) { _, _ in context.notifyShortcutChanged() }
                 }
 
-                HStack {
-                    Text("Hide")
-                    Spacer()
+                shortcutRow("Pause or resume recording") {
+                    KeyboardShortcutRecorder(
+                        keyCode: $capturePauseShortcutKeyCode,
+                        modifiers: $capturePauseShortcutModifiers
+                    )
+                    .frame(maxWidth: 240)
+                    .onChange(of: capturePauseShortcutKeyCode) { _, _ in context.notifyShortcutChanged() }
+                    .onChange(of: capturePauseShortcutModifiers) { _, _ in context.notifyShortcutChanged() }
+                }
+
+                shortcutRow("Close rewind") {
                     KeyboardShortcutRecorder(
                         keyCode: $overlayDismissKeyCode,
                         modifiers: $overlayDismissModifiers,
@@ -71,9 +83,23 @@ struct SettingsView: View {
                         placeholder: "Press key"
                     )
                     .frame(maxWidth: 240)
+                    .onChange(of: overlayDismissKeyCode) { _, _ in context.notifyShortcutChanged() }
+                    .onChange(of: overlayDismissModifiers) { _, _ in context.notifyShortcutChanged() }
+                }
+
+                Text("These shortcuts work across macOS while JustNow is running. Keep each action on a distinct shortcut.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                if let shortcutConflictMessage {
+                    Text(shortcutConflictMessage)
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             } header: {
-                Text("General")
+                Text("Keyboard Shortcuts")
             }
 
             Section {
@@ -413,6 +439,42 @@ struct SettingsView: View {
                 }
             }
         )
+    }
+
+    @ViewBuilder
+    private func shortcutRow<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        HStack(alignment: .center, spacing: 16) {
+            Text(title)
+            Spacer(minLength: 16)
+            content()
+                .frame(width: 240, alignment: .trailing)
+        }
+    }
+
+    private var shortcutConflictMessage: String? {
+        let shortcuts: [(label: String, keyCode: Int, modifiers: Int)] = [
+            ("Open rewind", shortcutKeyCode, shortcutModifiers),
+            ("Pause or resume recording", capturePauseShortcutKeyCode, capturePauseShortcutModifiers),
+            ("Close rewind", overlayDismissKeyCode, overlayDismissModifiers)
+        ]
+
+        for index in shortcuts.indices {
+            let current = shortcuts[index]
+            guard current.keyCode != -1 else { continue }
+
+            guard index + 1 < shortcuts.count else { continue }
+
+            for comparisonIndex in (index + 1)..<shortcuts.count {
+                let comparison = shortcuts[comparisonIndex]
+                guard comparison.keyCode != -1 else { continue }
+
+                if current.keyCode == comparison.keyCode && current.modifiers == comparison.modifiers {
+                    return "\(current.label) and \(comparison.label) should not share the same shortcut."
+                }
+            }
+        }
+
+        return nil
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ JustNow is a native macOS menu bar app that keeps a rolling record of your recen
 1. Download and open JustNow.
 2. Grant Screen Recording permission when macOS asks.
 3. Let it run in the menu bar.
-4. Press `⌘⌥J` to open the rewind timeline.
+4. Press `⌘⌥J` to open the rewind timeline, or `⌘⌥⇧J` to pause or resume recording.
 5. Scroll or drag to move through recent history.
 6. Drag over visible text in the current frame to copy it from OCR.
 7. Press `Escape` to close the overlay.
@@ -41,7 +41,7 @@ You can adjust:
 - show a text-grab debug preview of the OCR crop
 - automatic power saving behaviour
 - launch on startup
-- show and hide shortcuts
+- open, pause or resume, and close shortcuts
 
 ## Building From Source
 

--- a/Scripts/local-release-build.sh
+++ b/Scripts/local-release-build.sh
@@ -250,33 +250,28 @@ create_applications_alias "${STAGING_DIR}"
 ditto -c -k --sequesterRsrc --keepParent "${APP_PATH}" "${ZIP_PATH}"
 
 if command -v create-dmg >/dev/null 2>&1; then
+  CREATE_DMG_ARGS=(
+    --window-pos 200 120
+    --window-size 560 360
+    --icon-size 120
+    --text-size 12
+    --icon "${APP_NAME}.app" "${APP_ICON_X}" "${APP_ICON_Y}"
+    --icon "Applications" "${APPS_ICON_X}" "${APPS_ICON_Y}"
+    --hide-extension "${APP_NAME}.app"
+    --no-internet-enable
+    --volname "${APP_NAME}"
+  )
+
   if [ -f "${BG_PATH}" ]; then
-    create-dmg \
-      --window-pos 200 120 \
-      --window-size 560 360 \
-      --icon-size 120 \
-      --text-size 12 \
-      --icon "${APP_NAME}.app" "${APP_ICON_X}" "${APP_ICON_Y}" \
-      --icon "Applications" "${APPS_ICON_X}" "${APPS_ICON_Y}" \
-      --hide-extension "${APP_NAME}.app" \
-      --no-internet-enable \
-      --volname "${APP_NAME}" \
-      --background "${BG_PATH}" \
-      "${DMG_PATH}" \
-      "${STAGING_DIR}/"
-  else
-    create-dmg \
-      --window-pos 200 120 \
-      --window-size 560 360 \
-      --icon-size 120 \
-      --text-size 12 \
-      --icon "${APP_NAME}.app" "${APP_ICON_X}" "${APP_ICON_Y}" \
-      --icon "Applications" "${APPS_ICON_X}" "${APPS_ICON_Y}" \
-      --hide-extension "${APP_NAME}.app" \
-      --no-internet-enable \
-      --volname "${APP_NAME}" \
-      "${DMG_PATH}" \
-      "${STAGING_DIR}/"
+    CREATE_DMG_ARGS+=(--background "${BG_PATH}")
+  fi
+
+  CREATE_DMG_ARGS+=("${DMG_PATH}" "${STAGING_DIR}/")
+
+  if ! create-dmg "${CREATE_DMG_ARGS[@]}"; then
+    echo "create-dmg failed; retrying without Finder AppleScript prettifying (--skip-jenkins)." >&2
+    rm -f "${DMG_PATH}"
+    create-dmg --skip-jenkins "${CREATE_DMG_ARGS[@]}"
   fi
 else
   echo "create-dmg not found; skipping .dmg creation. Install with: brew install create-dmg"


### PR DESCRIPTION
## Summary

Adds a dedicated global shortcut for pausing or resuming capture, polishes the status menu action rows, tightens hotkey conflict handling, and makes local DMG creation more reliable.

## App

- **Pause or resume recording**: new `@AppStorage` keys and Settings row (default `⌘⌥⇧J`), wired through `HotKey` alongside the existing open-rewind shortcut.
- **Status menu**: custom rows for Show Timeline and Pause/Resume with trailing SF Symbols; label left, symbol right.
- **Conflicts**: pause hotkey is not registered when it matches open rewind or the close-rewind shortcut (close is handled locally while the overlay is open).
- **Live updates**: changing any shortcut (including close rewind) calls `keyboardShortcutsDidChange()`, which re-registers global hotkeys and updates `OverlayWindowController` dismiss binding when the overlay exists.

## Docs

- README quick start mentions the default pause shortcut.

## Build script

- `create-dmg` invocation refactored to share args; on failure, retry with `--skip-jenkins` after removing the partial DMG.

## Testing

- Built locally with `xcodebuild -scheme JustNow -configuration Debug`.

Made with [Cursor](https://cursor.com)