### PR TITLE
Support multiple displays

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -44,13 +44,13 @@ enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
 }
 
 @MainActor
-class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
+class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     private var isRunningUnderXCTest: Bool {
         ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
     }
 
     private var statusItemController: StatusItemController!
-    private var captureManager: ScreenCaptureManager!
+    private var captureCoordinator: CaptureCoordinator!
     private var frameBuffer: FrameBuffer?
     private var overlayController: OverlayWindowController?
     private lazy var updaterController = SPUStandardUpdaterController(
@@ -115,7 +115,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
     private lazy var captureStopController = CaptureStopController(
         updateStatus: { [weak self] in self?.updateCaptureStatus($0) },
         stopCapture: { [weak self] in
-            await self?.captureManager.stopCapture()
+            await self?.captureCoordinator.stopCapture()
         },
         endForegroundActivity: { [weak self] in
             self?.appNapPreventer.stopActivity()
@@ -134,8 +134,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             }
 
             return CaptureEventContext(
-                hasCaptureManager: self.captureManager != nil,
-                isCapturing: self.captureManager?.isCapturing == true,
+                hasCaptureManager: self.captureCoordinator != nil,
+                isCapturing: self.captureCoordinator?.isCapturing == true,
                 isSetupCaptureInProgress: self.setupCaptureTask != nil,
                 hasPendingStart: self.captureStartController.hasPendingStart,
                 isOverlayVisible: self.isOverlayVisible
@@ -198,7 +198,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             }
 
             await self.setupCaptureTask?.value
-            await self.captureManager?.stopCapture()
+            await self.captureCoordinator?.stopCapture()
             await self.frameBuffer?.flushCaches()
         }
 
@@ -256,7 +256,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
     }
 
     private func setupCapture() {
-        captureManager = ScreenCaptureManager()
+        captureCoordinator = CaptureCoordinator()
 
         setupCaptureTask?.cancel()
         setupCaptureTask = Task { @MainActor [weak self] in
@@ -289,10 +289,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
 
             guard !Task.isCancelled else { return }
 
-            self.captureManager.delegate = self
+            self.captureCoordinator.delegate = self
             let preflightPolicy = self.currentCapturePolicy()
-            self.captureManager.updateCaptureInterval(preflightPolicy.interval)
-            self.captureManager.updateCaptureScale(preflightPolicy.scale)
+            self.captureCoordinator.updateCaptureInterval(preflightPolicy.interval)
+            self.captureCoordinator.updateCaptureScale(preflightPolicy.scale)
             self.frameBuffer?.updateSaveOptions(
                 preflightPolicy.saveOptions,
                 duplicatePolicy: preflightPolicy.duplicatePolicy
@@ -309,10 +309,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             switch self.resolveLaunchPermissionState() {
             case .granted:
                 do {
-                    try await self.captureManager.startCapture()
+                    try await self.captureCoordinator.startCapture()
                     guard !Task.isCancelled else { return }
                     guard self.captureEventController.canStartCapture() else {
-                        await self.captureManager.stopCapture()
+                        await self.captureCoordinator.stopCapture()
                         if let blockedStatus = self.captureEventController.blockedStatus() {
                             self.updateCaptureStatus(blockedStatus)
                         }
@@ -470,10 +470,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
         guard !Task.isCancelled, captureEventController.canStartCapture() else { return false }
 
         do {
-            try await captureManager.startCapture()
+            try await captureCoordinator.startCapture()
             guard !Task.isCancelled,
                   captureEventController.canStartCapture() else {
-                await captureManager.stopCapture()
+                await captureCoordinator.stopCapture()
                 return false
             }
             updateCaptureStatus("Active")
@@ -521,11 +521,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
 
     // MARK: - Capture Delegate
 
-    func captureManager(_ manager: ScreenCaptureManager, didCaptureFrame image: CGImage, at timestamp: Date) {
-        frameBuffer?.addFrame(image, timestamp: timestamp)
+    func captureCoordinator(
+        _ coordinator: CaptureCoordinator,
+        didCaptureFrame image: CGImage,
+        at timestamp: Date,
+        from display: DisplayInfo
+    ) {
+        frameBuffer?.addFrame(image, timestamp: timestamp, display: display)
     }
 
-    func captureManagerDidStop(_ manager: ScreenCaptureManager) {
+    func captureCoordinatorDidStopUnexpectedly(_ coordinator: CaptureCoordinator) {
         captureEventController.handleUnexpectedStop()
     }
 
@@ -554,10 +559,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             guard let self else { return }
             defer { self.overlayPresentationTask = nil }
 
-            // Capture a fresh frame immediately so the overlay has the latest state
-            if let image = await self.captureManager.captureNow() {
+            // Pick the display the user is looking at — the overlay opens there
+            // and its timeline is seeded with that display's frames.
+            let targetDisplay = self.resolveOverlayTargetDisplay()
+
+            // Capture a fresh frame for the targeted display so the overlay opens with the latest state.
+            if let target = targetDisplay,
+               let snapshot = await self.captureCoordinator.captureNow(displayID: target.id) {
                 guard !Task.isCancelled else { return }
-                await frameBuffer.addFrameSync(image, timestamp: Date())
+                await frameBuffer.addFrameSync(snapshot.image, timestamp: Date(), display: snapshot.display)
             }
 
             guard !Task.isCancelled else { return }
@@ -580,11 +590,38 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             }
             let recentTimelineWindow = RecentTimelineWindow.resolved(from: self.recentTimelineWindowSeconds)
             let rewindHistoryOption = RewindHistoryOption.resolved(from: self.rewindHistorySeconds)
+            let availableDisplays = self.mergedDisplays(frameBuffer: frameBuffer)
             self.overlayController?.showOverlay(
                 recentTimelineWindow: recentTimelineWindow.timeInterval,
-                rewindHistoryOption: rewindHistoryOption
+                rewindHistoryOption: rewindHistoryOption,
+                activeDisplay: targetDisplay,
+                availableDisplays: availableDisplays
             )
         }
+    }
+
+    /// Live displays first, then any historical displays present in the frame
+    /// buffer that aren't currently connected. Disconnected entries have a nil
+    /// `displayID` so callers can treat them as non-interactive.
+    private func mergedDisplays(frameBuffer: FrameBuffer) -> [DisplayInfo] {
+        var seen: Set<UUID> = []
+        var result: [DisplayInfo] = []
+        for display in captureCoordinator.activeDisplays where seen.insert(display.id).inserted {
+            result.append(display)
+        }
+        for historical in frameBuffer.knownDisplays() where seen.insert(historical.id).inserted {
+            result.append(DisplayInfo(id: historical.id, displayID: nil, name: historical.name))
+        }
+        return result
+    }
+
+    private func resolveOverlayTargetDisplay() -> DisplayInfo? {
+        if let screen = DisplayIdentity.screenContainingMouse(),
+           let cgID = DisplayIdentity.displayID(for: screen),
+           let info = captureCoordinator.display(forDisplayID: cgID) {
+            return info
+        }
+        return captureCoordinator.activeDisplays.first
     }
 
     @objc private func showSettings() {
@@ -616,14 +653,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
     }
 
     private func updateCapturePolicy() {
-        guard captureManager != nil else { return }
+        guard captureCoordinator != nil else { return }
         capturePolicyController.applyIfNeeded(
             settings: currentCapturePolicySettings(),
             environment: currentCapturePolicyEnvironment(),
-            isCapturing: captureManager.isCapturing,
+            isCapturing: captureCoordinator.isCapturing,
             applier: CapturePolicyApplier(
-                updateCaptureInterval: { [weak self] in self?.captureManager.updateCaptureInterval($0) },
-                updateCaptureScale: { [weak self] in self?.captureManager.updateCaptureScale($0) },
+                updateCaptureInterval: { [weak self] in self?.captureCoordinator.updateCaptureInterval($0) },
+                updateCaptureScale: { [weak self] in self?.captureCoordinator.updateCaptureScale($0) },
                 updateFramePersistence: { [weak self] saveOptions, duplicatePolicy in
                     self?.frameBuffer?.updateSaveOptions(saveOptions, duplicatePolicy: duplicatePolicy)
                 },

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -1,0 +1,197 @@
+//
+//  CaptureCoordinator.swift
+//  JustNow
+//
+
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+@MainActor
+protocol CaptureCoordinatorDelegate: AnyObject {
+    func captureCoordinator(
+        _ coordinator: CaptureCoordinator,
+        didCaptureFrame image: CGImage,
+        at timestamp: Date,
+        from display: DisplayInfo
+    )
+    func captureCoordinatorDidStopUnexpectedly(_ coordinator: CaptureCoordinator)
+    func captureCoordinatorDidUpdateDisplays(_ coordinator: CaptureCoordinator)
+}
+
+extension CaptureCoordinatorDelegate {
+    func captureCoordinatorDidUpdateDisplays(_ coordinator: CaptureCoordinator) {}
+}
+
+/// Owns one ScreenCaptureManager per physical display and fans capture
+/// lifecycle across them. Hot-plug is handled via the AppKit screen
+/// parameters notification.
+@MainActor
+final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
+    private struct ManagedDisplay {
+        let info: DisplayInfo
+        let manager: ScreenCaptureManager
+    }
+
+    weak var delegate: CaptureCoordinatorDelegate?
+
+    private var managed: [UUID: ManagedDisplay] = [:]
+    private var captureInterval: TimeInterval = 1.0
+    private var captureScale: Int = 2
+    private var isRunning = false
+    private var screenParamsObserver: NSObjectProtocol?
+    private var reconcileTask: Task<Void, Never>?
+
+    override init() {
+        super.init()
+        screenParamsObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.scheduleReconcile()
+            }
+        }
+    }
+
+    deinit {
+        if let observer = screenParamsObserver {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    var isCapturing: Bool {
+        managed.values.contains { $0.manager.isCapturing }
+    }
+
+    var activeDisplays: [DisplayInfo] {
+        managed.values
+            .map(\.info)
+            .sorted { lhs, rhs in
+                // Built-in first, then alphabetical by name — keeps the UI ordering stable.
+                let lBuiltIn = lhs.displayID.map { CGDisplayIsBuiltin($0) != 0 } ?? false
+                let rBuiltIn = rhs.displayID.map { CGDisplayIsBuiltin($0) != 0 } ?? false
+                if lBuiltIn != rBuiltIn { return lBuiltIn }
+                return lhs.name < rhs.name
+            }
+    }
+
+    func startCapture() async throws {
+        isRunning = true
+        try await reconcileDisplays(startNewManagers: true)
+        if managed.isEmpty {
+            throw CaptureError.noDisplay
+        }
+    }
+
+    func stopCapture() async {
+        isRunning = false
+        reconcileTask?.cancel()
+        reconcileTask = nil
+        let snapshot = Array(managed.values)
+        managed.removeAll()
+        for entry in snapshot {
+            await entry.manager.stopCapture()
+        }
+        delegate?.captureCoordinatorDidUpdateDisplays(self)
+    }
+
+    func updateCaptureInterval(_ interval: TimeInterval) {
+        captureInterval = interval
+        for entry in managed.values {
+            entry.manager.updateCaptureInterval(interval)
+        }
+    }
+
+    func updateCaptureScale(_ scale: Int) {
+        captureScale = scale
+        for entry in managed.values {
+            entry.manager.updateCaptureScale(scale)
+        }
+    }
+
+    /// One-shot capture for a specific display. Used when opening the overlay
+    /// so the freshest frame lands in the buffer.
+    func captureNow(displayID: UUID) async -> (image: CGImage, display: DisplayInfo)? {
+        guard let entry = managed[displayID] else { return nil }
+        guard let image = await entry.manager.captureNow() else { return nil }
+        return (image, entry.info)
+    }
+
+    func display(forDisplayID displayID: CGDirectDisplayID) -> DisplayInfo? {
+        managed.values.first(where: { $0.info.displayID == displayID })?.info
+    }
+
+    // MARK: - Hot-plug
+
+    private func scheduleReconcile() {
+        guard isRunning else { return }
+        reconcileTask?.cancel()
+        reconcileTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            try? await self.reconcileDisplays(startNewManagers: true)
+            self.reconcileTask = nil
+        }
+    }
+
+    private func reconcileDisplays(startNewManagers: Bool) async throws {
+        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        try Task.checkCancellation()
+
+        var desired: [UUID: DisplayInfo] = [:]
+        for display in content.displays {
+            let info = DisplayIdentity.info(for: display)
+            desired[info.id] = info
+        }
+
+        // Remove managers for displays that are no longer connected.
+        let removedIDs = managed.keys.filter { desired[$0] == nil }
+        for id in removedIDs {
+            if let entry = managed.removeValue(forKey: id) {
+                await entry.manager.stopCapture()
+                print("Capture stopped for removed display: \(entry.info.name)")
+            }
+        }
+
+        // Start managers for newly seen displays.
+        if startNewManagers {
+            for (id, info) in desired where managed[id] == nil {
+                guard let physicalDisplayID = info.displayID else { continue }
+                let manager = ScreenCaptureManager(targetDisplayID: physicalDisplayID)
+                manager.delegate = self
+                manager.updateCaptureInterval(captureInterval)
+                manager.updateCaptureScale(captureScale)
+                managed[id] = ManagedDisplay(info: info, manager: manager)
+                do {
+                    try await manager.startCapture()
+                    print("Capture started for display: \(info.name)")
+                } catch {
+                    print("Failed to start capture for \(info.name): \(error)")
+                    managed.removeValue(forKey: id)
+                    if error is CaptureError, case CaptureError.permissionDenied = error {
+                        throw error
+                    }
+                }
+            }
+        }
+
+        delegate?.captureCoordinatorDidUpdateDisplays(self)
+    }
+
+    // MARK: - ScreenCaptureDelegate
+
+    func captureManager(_ manager: ScreenCaptureManager, didCaptureFrame image: CGImage, at timestamp: Date) {
+        guard let entry = managed.values.first(where: { $0.manager === manager }) else { return }
+        delegate?.captureCoordinator(self, didCaptureFrame: image, at: timestamp, from: entry.info)
+    }
+
+    func captureManagerDidStop(_ manager: ScreenCaptureManager) {
+        // A single display dropped. If we're supposed to be running, ask the
+        // delegate to treat this as an unexpected stop and let the normal
+        // restart flow re-enter reconcileDisplays.
+        guard isRunning else { return }
+        delegate?.captureCoordinatorDidStopUnexpectedly(self)
+    }
+}

--- a/JustNow/Capture/DisplayIdentity.swift
+++ b/JustNow/Capture/DisplayIdentity.swift
@@ -1,0 +1,93 @@
+//
+//  DisplayIdentity.swift
+//  JustNow
+//
+
+import AppKit
+import CoreGraphics
+import Foundation
+import ScreenCaptureKit
+
+/// Stable identifier + friendly name for a physical display.
+///
+/// `id` is derived from `CGDisplayCreateUUIDFromDisplayID` so it survives
+/// unplug/replug during the retention window. `displayID` is the per-session
+/// `CGDirectDisplayID` used to talk to CoreGraphics and match `NSScreen`.
+struct DisplayInfo: Sendable, Equatable, Hashable {
+    let id: UUID
+    /// CoreGraphics display ID for the physical display, or nil when this
+    /// DisplayInfo represents a historical display that isn't currently
+    /// connected.
+    let displayID: CGDirectDisplayID?
+    let name: String
+
+    var isConnected: Bool { displayID != nil }
+}
+
+enum DisplayIdentity {
+    static func info(for scDisplay: SCDisplay) -> DisplayInfo {
+        info(for: scDisplay.displayID)
+    }
+
+    static func info(for displayID: CGDirectDisplayID) -> DisplayInfo {
+        DisplayInfo(
+            id: stableUUID(for: displayID) ?? fallbackUUID(for: displayID),
+            displayID: displayID,
+            name: friendlyName(for: displayID)
+        )
+    }
+
+    static func displayID(for screen: NSScreen) -> CGDirectDisplayID? {
+        (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as? NSNumber)?.uint32Value
+    }
+
+    static func screen(for displayID: CGDirectDisplayID) -> NSScreen? {
+        NSScreen.screens.first { Self.displayID(for: $0) == displayID }
+    }
+
+    /// Returns the screen currently under the mouse, falling back to the main screen.
+    static func screenContainingMouse() -> NSScreen? {
+        let mouseLocation = NSEvent.mouseLocation
+        return NSScreen.screens.first { $0.frame.contains(mouseLocation) } ?? NSScreen.main
+    }
+
+    private static func stableUUID(for displayID: CGDirectDisplayID) -> UUID? {
+        guard let cfUUID = CGDisplayCreateUUIDFromDisplayID(displayID)?.takeRetainedValue() else {
+            return nil
+        }
+        guard let string = CFUUIDCreateString(nil, cfUUID) as String? else { return nil }
+        return UUID(uuidString: string)
+    }
+
+    /// Deterministic fallback keyed off the CGDirectDisplayID, used only when
+    /// CoreGraphics refuses to provide a stable UUID (very rare).
+    private static func fallbackUUID(for displayID: CGDirectDisplayID) -> UUID {
+        var bytes: [UInt8] = [
+            0x4A, 0x75, 0x73, 0x74, 0x4E, 0x6F, 0x77, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        ]
+        let big = displayID.bigEndian
+        withUnsafeBytes(of: big) { buf in
+            for index in 0..<4 {
+                bytes[12 + index] = buf[index]
+            }
+        }
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3],
+            bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11],
+            bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+
+    private static func friendlyName(for displayID: CGDirectDisplayID) -> String {
+        if let screen = screen(for: displayID) {
+            let name = screen.localizedName
+            if !name.isEmpty { return name }
+        }
+        if CGDisplayIsBuiltin(displayID) != 0 {
+            return "Built-in Display"
+        }
+        return "Display \(displayID)"
+    }
+}

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -11,6 +11,8 @@ struct StoredFrame: Identifiable, Sendable {
     let id: UUID
     let timestamp: Date
     let hash: UInt64
+    let displayID: UUID?
+    let displayName: String?
 }
 
 struct DuplicateFramePolicy: Sendable, Equatable {
@@ -70,6 +72,8 @@ private struct PendingIngest {
     let cgImage: CGImage
     let timestamp: Date
     let generation: Int
+    let displayID: UUID?
+    let displayName: String?
     let syncContinuation: CheckedContinuation<SyncIngestResult, Never>?
 }
 
@@ -117,7 +121,7 @@ class FrameBuffer {
     var isPruningPaused: Bool = false
 
     // Thumbnail cache for quick access
-    private let thumbnailCache = NSCache<NSUUID, NSImage>()
+    private let thumbnailCache = NSCache<NSUUID, CachedCGImageBox>()
     private let fullImageCache = NSCache<NSUUID, CachedCGImageBox>()
     private var inFlightFullImageLoads: [UUID: Task<CachedCGImageBox, Error>] = [:]
 
@@ -143,18 +147,24 @@ class FrameBuffer {
 
     // MARK: - Capture
 
-    func addFrame(_ cgImage: CGImage, timestamp: Date) {
+    func addFrame(_ cgImage: CGImage, timestamp: Date, display: DisplayInfo?) {
         // Skip black frames only during sleep/wake transitions.
         if shouldCheckBlackFrame(at: timestamp) && blackFrameDetector.isBlackFrame(cgImage) {
             print("Skipping black frame")
             return
         }
 
-        enqueueIngest(cgImage: cgImage, timestamp: timestamp, syncContinuation: nil, prioritiseSync: false)
+        enqueueIngest(
+            cgImage: cgImage,
+            timestamp: timestamp,
+            display: display,
+            syncContinuation: nil,
+            prioritiseSync: false
+        )
     }
 
     /// Add a frame synchronously (awaits save completion). Used when opening overlay.
-    func addFrameSync(_ cgImage: CGImage, timestamp: Date) async {
+    func addFrameSync(_ cgImage: CGImage, timestamp: Date, display: DisplayInfo?) async {
         if shouldCheckBlackFrame(at: timestamp) && blackFrameDetector.isBlackFrame(cgImage) {
             return
         }
@@ -174,6 +184,7 @@ class FrameBuffer {
                 enqueueIngest(
                     cgImage: cgImage,
                     timestamp: timestamp,
+                    display: display,
                     syncContinuation: continuation,
                     prioritiseSync: true
                 )
@@ -214,20 +225,33 @@ class FrameBuffer {
 
     /// Get frames with near-duplicates removed for smoother browsing.
     /// The newest window keeps all stored frames so keyboard navigation tracks recent capture cadence.
+    /// When `displayID` is set, frames are filtered to that display. Pass
+    /// `includeLegacyFrames` for the primary-display slot so pre-multi-display
+    /// captures remain visible.
     func getFilteredFrames(
         hashThreshold: Int = 3,
         recentWindow: TimeInterval = 300,
-        maximumAge: TimeInterval? = nil
+        maximumAge: TimeInterval? = nil,
+        displayID: UUID? = nil,
+        includeLegacyFrames: Bool = false
     ) -> [StoredFrame] {
         guard !frames.isEmpty else { return [] }
 
         let now = Date()
-        let candidateFrames: [StoredFrame]
+        var candidateFrames: [StoredFrame]
         if let maximumAge {
             let cutoff = now.addingTimeInterval(-maximumAge)
             candidateFrames = frames.filter { $0.timestamp >= cutoff }
         } else {
             candidateFrames = frames
+        }
+        if let displayID {
+            candidateFrames = candidateFrames.filter { frame in
+                if let frameDisplayID = frame.displayID {
+                    return frameDisplayID == displayID
+                }
+                return includeLegacyFrames
+            }
         }
 
         var filtered: [StoredFrame] = []
@@ -267,6 +291,25 @@ class FrameBuffer {
     func getRecentFrames(within seconds: TimeInterval) -> [StoredFrame] {
         let cutoff = Date().addingTimeInterval(-seconds)
         return frames.filter { $0.timestamp >= cutoff }
+    }
+
+    /// Displays that have at least one frame in the buffer. Ordered by most
+    /// recent capture first so the overlay can surface active displays before
+    /// ones that have gone quiet.
+    func knownDisplays() -> [(id: UUID, name: String)] {
+        var seen: Set<UUID> = []
+        var ordered: [(id: UUID, name: String)] = []
+        for frame in frames.reversed() {
+            guard let id = frame.displayID else { continue }
+            if seen.insert(id).inserted {
+                ordered.append((id, frame.displayName ?? "Display"))
+            }
+        }
+        return ordered
+    }
+
+    var hasLegacyFrames: Bool {
+        frames.contains { $0.displayID == nil }
     }
 
     var frameCount: Int {
@@ -324,23 +367,19 @@ class FrameBuffer {
     }
 
     /// Get thumbnail, with caching
-    func getThumbnail(for frame: StoredFrame) async -> NSImage? {
+    func getThumbnail(for frame: StoredFrame) async -> CGImage? {
         let key = frame.id as NSUUID
 
         if let cached = thumbnailCache.object(forKey: key) {
-            return cached
+            return cached.image
         }
 
         guard let cgImage = await frameStore.loadThumbnail(id: frame.id) else {
             return nil
         }
 
-        let nsImage = NSImage(
-            cgImage: cgImage,
-            size: NSSize(width: cgImage.width, height: cgImage.height)
-        )
-        thumbnailCache.setObject(nsImage, forKey: key)
-        return nsImage
+        thumbnailCache.setObject(CachedCGImageBox(cgImage), forKey: key)
+        return cgImage
     }
 
     // MARK: - Management
@@ -420,7 +459,15 @@ class FrameBuffer {
 
         frames = metadata
             .sorted { $0.timestamp < $1.timestamp }
-            .map { StoredFrame(id: $0.id, timestamp: $0.timestamp, hash: $0.hash) }
+            .map {
+                StoredFrame(
+                    id: $0.id,
+                    timestamp: $0.timestamp,
+                    hash: $0.hash,
+                    displayID: $0.displayID,
+                    displayName: $0.displayName
+                )
+            }
     }
 
     func enableBlackFrameFilter(for seconds: TimeInterval) {
@@ -486,6 +533,7 @@ class FrameBuffer {
     private func enqueueIngest(
         cgImage: CGImage,
         timestamp: Date,
+        display: DisplayInfo?,
         syncContinuation: CheckedContinuation<SyncIngestResult, Never>?,
         prioritiseSync: Bool
     ) {
@@ -498,6 +546,8 @@ class FrameBuffer {
             cgImage: cgImage,
             timestamp: timestamp,
             generation: ingestGeneration,
+            displayID: display?.id,
+            displayName: display?.name,
             syncContinuation: syncContinuation
         )
 
@@ -555,6 +605,8 @@ class FrameBuffer {
                 cgImage: work.cgImage,
                 timestamp: work.timestamp,
                 hash: hash,
+                displayID: work.displayID,
+                displayName: work.displayName,
                 ingestGeneration: work.generation
             )
         }
@@ -569,15 +621,19 @@ class FrameBuffer {
         cgImage: CGImage,
         timestamp: Date,
         hash: UInt64,
+        displayID: UUID?,
+        displayName: String?,
         ingestGeneration generation: Int
     ) async -> SyncIngestResult {
         guard generation == ingestGeneration else { return .retryAfterClear }
-        guard shouldStoreFrame(hash: hash, timestamp: timestamp) else { return .completed }
+        guard shouldStoreFrame(hash: hash, timestamp: timestamp, displayID: displayID) else { return .completed }
         do {
             let metadata = try await frameStore.saveFrame(
                 cgImage,
                 timestamp: timestamp,
                 hash: hash,
+                displayID: displayID,
+                displayName: displayName,
                 options: saveOptions
             )
             guard generation == ingestGeneration else {
@@ -587,7 +643,9 @@ class FrameBuffer {
             let frame = StoredFrame(
                 id: metadata.id,
                 timestamp: metadata.timestamp,
-                hash: metadata.hash
+                hash: metadata.hash,
+                displayID: metadata.displayID,
+                displayName: metadata.displayName
             )
             recordStoredFrame(frame)
             enqueueFrameForBackgroundOCR(frame)
@@ -634,20 +692,21 @@ class FrameBuffer {
         }
     }
 
-    private func shouldStoreFrame(hash: UInt64, timestamp: Date) -> Bool {
+    private func shouldStoreFrame(hash: UInt64, timestamp: Date, displayID: UUID?) -> Bool {
         let insertionIndex = frameInsertionIndex(for: timestamp)
-        guard insertionIndex > 0 else {
-            return true
+        var index = insertionIndex - 1
+        while index >= 0 {
+            let candidate = frames[index]
+            if candidate.displayID == displayID {
+                guard candidate.hash != 0 else { return true }
+                let timeSinceLast = timestamp.timeIntervalSince(candidate.timestamp)
+                guard timeSinceLast < duplicatePolicy.minimumSpacing else { return true }
+                let distance = PerceptualHash.hammingDistance(hash, candidate.hash)
+                return distance > duplicatePolicy.hashThreshold
+            }
+            index -= 1
         }
-
-        let previousFrame = frames[insertionIndex - 1]
-        guard previousFrame.hash != 0 else { return true }
-
-        let timeSinceLast = timestamp.timeIntervalSince(previousFrame.timestamp)
-        guard timeSinceLast < duplicatePolicy.minimumSpacing else { return true }
-
-        let distance = PerceptualHash.hammingDistance(hash, previousFrame.hash)
-        return distance > duplicatePolicy.hashThreshold
+        return true
     }
 
     private func frameInsertionIndex(for timestamp: Date) -> Int {

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -40,6 +40,12 @@ class ScreenCaptureManager: NSObject {
     weak var delegate: ScreenCaptureDelegate?
     private(set) var isCapturing = false
     private(set) var captureInterval: TimeInterval = 1.0
+    let targetDisplayID: CGDirectDisplayID
+
+    init(targetDisplayID: CGDirectDisplayID) {
+        self.targetDisplayID = targetDisplayID
+        super.init()
+    }
 
     /// Serial loop: each capture completes before the next is scheduled.
     private var captureLoopTask: Task<Void, Never>?
@@ -77,7 +83,8 @@ class ScreenCaptureManager: NSObject {
 
         let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
         try Task.checkCancellation()
-        guard let display = content.displays.first else {
+        guard let display = content.displays.first(where: { $0.displayID == targetDisplayID })
+            ?? content.displays.first else {
             throw CaptureError.noDisplay
         }
 

--- a/JustNow/Storage/FrameMetadata.swift
+++ b/JustNow/Storage/FrameMetadata.swift
@@ -12,10 +12,16 @@ nonisolated struct FrameMetadata: Codable, Identifiable, Sendable {
     let filename: String
     let thumbnailFilename: String
     let fileSize: Int64
+    /// Stable display identifier. Nil for frames captured before multi-display support;
+    /// treated as belonging to the primary display when surfaced.
+    let displayID: UUID?
+    /// Friendly name snapshotted at capture time, so the overlay can label
+    /// frames from a display that is no longer connected.
+    let displayName: String?
 }
 
 nonisolated struct FrameManifest: Codable, Sendable {
-    var version: Int = 1
+    var version: Int = 2
     var frames: [FrameMetadata] = []
     var lastModified: Date = Date()
 }

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -76,6 +76,8 @@ actor FrameStore {
         _ cgImage: CGImage,
         timestamp: Date,
         hash: UInt64,
+        displayID: UUID?,
+        displayName: String?,
         options: FrameSaveOptions = .standard
     ) throws -> FrameMetadata {
         let id = UUID()
@@ -106,7 +108,9 @@ actor FrameStore {
             hash: hash,
             filename: filename,
             thumbnailFilename: thumbnailFilename,
-            fileSize: Int64(fullData.count)
+            fileSize: Int64(fullData.count),
+            displayID: displayID,
+            displayName: displayName
         )
 
         manifest.frames.append(metadata)

--- a/JustNow/UI/OverlayFramePreviewView.swift
+++ b/JustNow/UI/OverlayFramePreviewView.swift
@@ -1,6 +1,21 @@
 import CoreGraphics
 import SwiftUI
 
+/// Draws a CGImage scaled into its frame. Uses a SwiftUI Canvas so no
+/// NSViewRepresentable-driven intrinsic size can leak up the layout tree —
+/// that feedback path grew the overlay unboundedly on macOS 26 when different
+/// displays produced frames with different pixel dimensions.
+private struct ScaledFrameImageView: View {
+    let image: CGImage
+
+    var body: some View {
+        Canvas { context, size in
+            let swiftUIImage = Image(decorative: image, scale: 1, orientation: .up)
+            context.draw(swiftUIImage, in: CGRect(origin: .zero, size: size))
+        }
+    }
+}
+
 struct FramePreviewView: View {
     let frame: StoredFrame
     let viewModel: OverlayViewModel
@@ -35,32 +50,31 @@ struct FramePreviewView: View {
     var body: some View {
         Group {
             if let image = image {
-                ZStack {
-                    Image(nsImage: imageFromCGImage(image))
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
+                GeometryReader { proxy in
+                    let fitted = fittedSize(for: image, in: proxy.size)
+                    ScaledFrameImageView(image: image)
+                        .frame(width: fitted.width, height: fitted.height)
                         .overlay {
-                            ZStack {
-                                if isShowingCurrentFrame, shouldShowSearchHighlights, let searchTextLayout {
-                                    SearchHighlightOverlay(
-                                        image: image,
-                                        layout: searchTextLayout,
-                                        query: viewModel.searchQuery
-                                    )
-                                    .allowsHitTesting(false)
-                                }
-
-                                if isShowingCurrentFrame {
-                                    TextGrabSelectionOverlay(
-                                        image: image,
-                                        viewModel: viewModel,
-                                        soundEnabled: textGrabSoundEnabled,
-                                        debugCaptureEnabled: textGrabDebugPreviewEnabled,
-                                        bannerState: $textGrabBannerState,
-                                        debugSnapshot: $textGrabDebugSnapshot
-                                    )
-                                    .id(frame.id)
-                                }
+                            if isShowingCurrentFrame, shouldShowSearchHighlights, let searchTextLayout {
+                                SearchHighlightOverlay(
+                                    image: image,
+                                    layout: searchTextLayout,
+                                    query: viewModel.searchQuery
+                                )
+                                .allowsHitTesting(false)
+                            }
+                        }
+                        .overlay {
+                            if isShowingCurrentFrame {
+                                TextGrabSelectionOverlay(
+                                    image: image,
+                                    viewModel: viewModel,
+                                    soundEnabled: textGrabSoundEnabled,
+                                    debugCaptureEnabled: textGrabDebugPreviewEnabled,
+                                    bannerState: $textGrabBannerState,
+                                    debugSnapshot: $textGrabDebugSnapshot
+                                )
+                                .id(frame.id)
                             }
                         }
                         .overlay(alignment: .bottomLeading) {
@@ -76,9 +90,11 @@ struct FramePreviewView: View {
                                     .fill(.black.opacity(0.045))
                             }
                         }
+                        .clipShape(.rect(cornerRadius: 16))
+                        .shadow(color: .black.opacity(0.5), radius: 30)
+                        .frame(width: proxy.size.width, height: proxy.size.height, alignment: .center)
                 }
-                .clipShape(.rect(cornerRadius: 16))
-                .shadow(color: .black.opacity(0.5), radius: 30)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             } else {
                 RoundedRectangle(cornerRadius: 16)
                     .fill(.white.opacity(0.05))
@@ -163,6 +179,23 @@ struct FramePreviewView: View {
             guard !Task.isCancelled else { return }
             searchTextLayout = layout
         }
+    }
+
+    private func aspectRatio(of image: CGImage) -> CGFloat {
+        let width = max(1, CGFloat(image.width))
+        let height = max(1, CGFloat(image.height))
+        return width / height
+    }
+
+    private func fittedSize(for image: CGImage, in available: CGSize) -> CGSize {
+        guard available.width > 0, available.height > 0 else { return .zero }
+        let aspect = aspectRatio(of: image)
+        if available.width / available.height > aspect {
+            let height = available.height
+            return CGSize(width: height * aspect, height: height)
+        }
+        let width = available.width
+        return CGSize(width: width, height: width / aspect)
     }
 }
 

--- a/JustNow/UI/OverlayKeyboardAction.swift
+++ b/JustNow/UI/OverlayKeyboardAction.swift
@@ -27,6 +27,8 @@ enum OverlayKeyboardAction: Equatable {
     case moveRight
     case jumpRight
     case goToEnd
+    case cycleDisplayForward
+    case cycleDisplayBackward
 }
 
 func resolveOverlayKeyboardAction(
@@ -82,6 +84,12 @@ func resolveOverlayKeyboardAction(
             return .jumpRight
         }
         return .moveRight
+
+    case UInt16(kVK_Tab):
+        if state.isSearchAvailable && state.isSearching {
+            return .passthrough
+        }
+        return pressedModifiers.contains(.shift) ? .cycleDisplayBackward : .cycleDisplayForward
 
     default:
         return matchesDismissShortcut ? .dismissOverlay : .passthrough

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -37,24 +37,22 @@ struct OverlayView: View {
             .accessibilityLabel("Dismiss overlay")
             .accessibilityHint("Closes the timeline overlay.")
 
-            CompatGlassEffectContainer(spacing: 40) {
-                ZStack {
-                    if !viewModel.hasAnyFrames {
-                        EmptyStateView()
-                    } else {
-                        ContentAreaView(viewModel: viewModel)
-                    }
-
-                    OverlayTopBar(viewModel: viewModel)
+            if !viewModel.hasAnyFrames {
+                CompatGlassEffectContainer(spacing: 40) {
+                    EmptyStateView()
                 }
+            } else {
+                ContentAreaView(viewModel: viewModel)
             }
+
+            OverlayTopBar(viewModel: viewModel)
         }
     }
 }
 
 private struct OverlayBackdropView: View {
     let viewModel: OverlayViewModel
-    @State private var backdropImage: NSImage?
+    @State private var backdropImage: CGImage?
 
     private var presentedFrame: StoredFrame? {
         viewModel.presentedFrame
@@ -63,13 +61,38 @@ private struct OverlayBackdropView: View {
     var body: some View {
         ZStack {
             if let backdropImage {
-                Image(nsImage: backdropImage)
-                    .resizable()
-                    .scaledToFill()
-                    .saturation(0.6)
-                    .blur(radius: 28)
-                    .opacity(0.15)
-                    .transition(.opacity)
+                // Canvas gives us explicit, intrinsic-free layout — avoids the
+                // Image.scaledToFill overflow that leaked image pixel dims
+                // up the hierarchy and grew the root layout on macOS 26.
+                Canvas { context, size in
+                    guard size.width > 0, size.height > 0 else { return }
+                    let imageAspect = CGFloat(backdropImage.width) / CGFloat(max(1, backdropImage.height))
+                    let frameAspect = size.width / size.height
+                    let drawRect: CGRect
+                    if imageAspect > frameAspect {
+                        let scaledWidth = size.height * imageAspect
+                        drawRect = CGRect(
+                            x: (size.width - scaledWidth) / 2,
+                            y: 0,
+                            width: scaledWidth,
+                            height: size.height
+                        )
+                    } else {
+                        let scaledHeight = size.width / imageAspect
+                        drawRect = CGRect(
+                            x: 0,
+                            y: (size.height - scaledHeight) / 2,
+                            width: size.width,
+                            height: scaledHeight
+                        )
+                    }
+                    context.draw(Image(decorative: backdropImage, scale: 1, orientation: .up), in: drawRect)
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .saturation(0.6)
+                .blur(radius: 28)
+                .opacity(0.15)
+                .transition(.opacity)
             }
         }
         .animation(.easeInOut(duration: 0.18), value: presentedFrame?.id)
@@ -119,72 +142,10 @@ struct ContentAreaView: View {
                     .transition(.move(edge: .top).combined(with: .opacity))
             }
 
-            Spacer()
-
-            if let frame = displayedFrames[safe: viewModel.selectedIndex] {
-                HStack(spacing: 20) {
-                    OverlayChromeButton(
-                        systemImage: "chevron.left",
-                        accessibilityLabel: "Previous frame",
-                        accessibilityHint: "Shows the next older captured frame.",
-                        toolTip: "Previous frame (Left Arrow)",
-                        isEnabled: viewModel.canMoveLeft,
-                        action: viewModel.moveLeft
-                    )
-
-                    FramePreviewView(
-                        frame: frame,
-                        viewModel: viewModel,
-                        frameBuffer: viewModel.frameBuffer,
-                        textGrabBannerState: $textGrabBannerState
-                    )
-                    .frame(maxWidth: .infinity)
-
-                    OverlayChromeButton(
-                        systemImage: "chevron.right",
-                        accessibilityLabel: "Next frame",
-                        accessibilityHint: "Shows the next newer captured frame.",
-                        toolTip: "Next frame (Right Arrow)",
-                        isEnabled: viewModel.canMoveRight,
-                        action: viewModel.moveRight
-                    )
-                }
-                .padding(.horizontal, 60)
+            centerContent
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(.top, viewModel.isSearchAvailable && viewModel.isSearching ? 20 : 40)
                 .offset(y: OverlayChromeMetrics.contentVerticalShift)
-            } else if !viewModel.isSearching && viewModel.timelineFrames.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "clock.badge.exclamationmark")
-                        .font(.system(size: 40))
-                        .foregroundStyle(.white.opacity(0.4))
-                    Text("No frames in this rewind window")
-                        .font(.headline)
-                        .foregroundStyle(.white.opacity(0.6))
-                    Text(
-                        viewModel.isSearchAvailable
-                            ? "Search can still look through all indexed history."
-                            : "Increase rewind history in Settings to keep older frames visible here."
-                    )
-                    .font(.subheadline)
-                    .foregroundStyle(.white.opacity(0.45))
-                }
-            } else if viewModel.shouldShowSearchingState {
-                SearchSearchingStateView()
-            } else if viewModel.shouldShowNoSearchResults {
-                VStack(spacing: 12) {
-                    Image(systemName: "magnifyingglass")
-                        .font(.system(size: 40))
-                        .foregroundStyle(.white.opacity(0.4))
-                    Text("No matches found")
-                        .font(.headline)
-                        .foregroundStyle(.white.opacity(0.6))
-                    Text("Try a different word or broaden the time range.")
-                        .font(.subheadline)
-                        .foregroundStyle(.white.opacity(0.45))
-                }
-            }
-
-            Spacer()
 
             TimelineSlider(viewModel: viewModel)
                 .padding(.horizontal, 40)
@@ -205,6 +166,76 @@ struct ContentAreaView: View {
             if frameCount == 0 {
                 textGrabBannerState = .hint
                 viewModel.setPresentedFrame(nil)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var centerContent: some View {
+        if let frame = displayedFrames[safe: viewModel.selectedIndex] {
+            GeometryReader { row in
+                let chevronWidth: CGFloat = 40
+                let interitem: CGFloat = 20
+                let previewWidth = max(0, row.size.width - (chevronWidth * 2) - (interitem * 2))
+                HStack(spacing: interitem) {
+                    OverlayChromeButton(
+                        systemImage: "chevron.left",
+                        accessibilityLabel: "Previous frame",
+                        accessibilityHint: "Shows the next older captured frame.",
+                        toolTip: "Previous frame (Left Arrow)",
+                        isEnabled: viewModel.canMoveLeft,
+                        action: viewModel.moveLeft
+                    )
+
+                    FramePreviewView(
+                        frame: frame,
+                        viewModel: viewModel,
+                        frameBuffer: viewModel.frameBuffer,
+                        textGrabBannerState: $textGrabBannerState
+                    )
+                    .frame(width: previewWidth, height: row.size.height)
+
+                    OverlayChromeButton(
+                        systemImage: "chevron.right",
+                        accessibilityLabel: "Next frame",
+                        accessibilityHint: "Shows the next newer captured frame.",
+                        toolTip: "Next frame (Right Arrow)",
+                        isEnabled: viewModel.canMoveRight,
+                        action: viewModel.moveRight
+                    )
+                }
+                .frame(width: row.size.width, height: row.size.height)
+            }
+            .padding(.horizontal, 60)
+        } else if !viewModel.isSearching && viewModel.timelineFrames.isEmpty {
+            VStack(spacing: 12) {
+                Image(systemName: "clock.badge.exclamationmark")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.white.opacity(0.4))
+                Text("No frames in this rewind window")
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.6))
+                Text(
+                    viewModel.isSearchAvailable
+                        ? "Search can still look through all indexed history."
+                        : "Increase rewind history in Settings to keep older frames visible here."
+                )
+                .font(.subheadline)
+                .foregroundStyle(.white.opacity(0.45))
+            }
+        } else if viewModel.shouldShowSearchingState {
+            SearchSearchingStateView()
+        } else if viewModel.shouldShowNoSearchResults {
+            VStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.white.opacity(0.4))
+                Text("No matches found")
+                    .font(.headline)
+                    .foregroundStyle(.white.opacity(0.6))
+                Text("Try a different word or broaden the time range.")
+                    .font(.subheadline)
+                    .foregroundStyle(.white.opacity(0.45))
             }
         }
     }
@@ -248,8 +279,11 @@ private struct OverlayTopBar: View {
                 )
                 .frame(width: OverlayChromeMetrics.sideSlotWidth, alignment: .leading)
 
-                HStack(spacing: 8) {
+                HStack(spacing: 12) {
                     InstructionsOverlay()
+                    if viewModel.availableDisplays.count > 1 {
+                        DisplayPickerStrip(viewModel: viewModel)
+                    }
                     if shouldShowIsland {
                         MenuBarVisibilityIsland()
                             .overlay(alignment: .leading) {
@@ -288,6 +322,70 @@ private struct OverlayTopBar: View {
                 shouldShowIsland = true
             }
         }
+    }
+}
+
+private struct DisplayPickerStrip: View {
+    var viewModel: OverlayViewModel
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(viewModel.availableDisplays, id: \.id) { display in
+                DisplayChip(
+                    display: display,
+                    isActive: viewModel.activeDisplay?.id == display.id,
+                    action: { viewModel.switchDisplay(to: display) }
+                )
+            }
+
+            Text("Tab")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundStyle(.white.opacity(0.45))
+                .padding(.leading, 2)
+                .padding(.top, 2)
+                .accessibilityHidden(true)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .darkBarBackground(in: Capsule())
+    }
+}
+
+private struct DisplayChip: View {
+    let display: DisplayInfo
+    let isActive: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 4) {
+                if !display.isConnected {
+                    Image(systemName: "clock")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundStyle(foregroundStyle.opacity(0.7))
+                }
+                Text(display.name)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundStyle(foregroundStyle)
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(backgroundFill))
+        }
+        .buttonStyle(.plain)
+        .help(display.isConnected ? "Show \(display.name) (Tab)" : "Show \(display.name) — disconnected, historical only (Tab)")
+        .accessibilityLabel(display.isConnected ? "Switch to \(display.name)" : "Switch to \(display.name) (historical)")
+    }
+
+    private var foregroundStyle: Color {
+        if isActive {
+            return Color.black.opacity(0.9)
+        }
+        return display.isConnected ? Color.white.opacity(0.7) : Color.white.opacity(0.45)
+    }
+
+    private var backgroundFill: Color {
+        isActive ? Color.white.opacity(0.95) : Color.clear
     }
 }
 

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -6,6 +6,7 @@
 import CoreGraphics
 import Foundation
 import Observation
+import SwiftUI
 import os.log
 
 private let overlayViewLogger = Logger(subsystem: "sg.tk.JustNow", category: "OverlayView")
@@ -95,12 +96,15 @@ class OverlayViewModel {
 
     var selectedIndex: Int = 0
     var presentedFrame: StoredFrame?
-    let timelineFrames: [StoredFrame]
+    private(set) var timelineFrames: [StoredFrame]
     let frameBuffer: FrameBuffer
     let recentTimelineWindow: TimeInterval
     let rewindHistoryOption: RewindHistoryOption
     let timelineReferenceDate: Date
     let onDismiss: () -> Void
+    let availableDisplays: [DisplayInfo]
+    private(set) var activeDisplay: DisplayInfo?
+    private let primaryDisplayID: UUID?
 
     var isSearching = false
     var searchQuery = ""
@@ -175,6 +179,9 @@ class OverlayViewModel {
         frameBuffer: FrameBuffer,
         recentTimelineWindow: TimeInterval,
         rewindHistoryOption: RewindHistoryOption,
+        availableDisplays: [DisplayInfo],
+        activeDisplay: DisplayInfo?,
+        primaryDisplayID: UUID?,
         onDismiss: @escaping () -> Void
     ) {
         self.timelineFrames = timelineFrames
@@ -182,6 +189,9 @@ class OverlayViewModel {
         self.recentTimelineWindow = recentTimelineWindow
         self.rewindHistoryOption = rewindHistoryOption
         self.timelineReferenceDate = Date()
+        self.availableDisplays = availableDisplays
+        self.activeDisplay = activeDisplay
+        self.primaryDisplayID = primaryDisplayID
         self.onDismiss = onDismiss
         self.selectedIndex = max(0, timelineFrames.count - 1)
     }
@@ -305,6 +315,35 @@ class OverlayViewModel {
         selectedIndex = max(0, displayedFrameCount - 1)
     }
 
+    func cycleDisplay(forward: Bool) {
+        guard availableDisplays.count > 1 else { return }
+        let activeID = activeDisplay?.id
+        let currentIndex = availableDisplays.firstIndex { $0.id == activeID } ?? 0
+        let step = forward ? 1 : -1
+        let count = availableDisplays.count
+        let nextIndex = ((currentIndex + step) % count + count) % count
+        switchDisplay(to: availableDisplays[nextIndex])
+    }
+
+    func switchDisplay(to display: DisplayInfo) {
+        guard display.id != activeDisplay?.id else { return }
+        let newFrames = frameBuffer.getFilteredFrames(
+            recentWindow: recentTimelineWindow,
+            maximumAge: rewindHistoryOption.duration,
+            displayID: display.id,
+            includeLegacyFrames: display.id == primaryDisplayID
+        )
+        var transaction = Transaction()
+        transaction.disablesAnimations = true
+        withTransaction(transaction) {
+            clearSearch()
+            activeDisplay = display
+            timelineFrames = newFrames
+            selectedIndex = max(0, newFrames.count - 1)
+            presentedFrame = nil
+        }
+    }
+
     func prefetchImagesNearSelection() {
         imagePrefetchTask?.cancel()
         imagePrefetchTask = nil
@@ -361,6 +400,8 @@ class OverlayViewModel {
         let searchCutoff = request.scope.cutoff(using: rewindHistoryOption)
         let buffer = frameBuffer
         let cache = frameBuffer.textCache
+        let activeDisplayID = activeDisplay?.id
+        let includeLegacy = activeDisplay?.id == primaryDisplayID
 
         searchTask = Task {
             let matchedIDs = await cache.searchFrameIDs(matching: request.query, limit: 10_000, since: searchCutoff)
@@ -372,9 +413,15 @@ class OverlayViewModel {
             var results: [StoredFrame] = []
             results.reserveCapacity(matchedIDs.count)
             for matchedID in matchedIDs {
-                if let frame = frameByID[matchedID] {
-                    results.append(frame)
+                guard let frame = frameByID[matchedID] else { continue }
+                if let activeDisplayID {
+                    if let frameDisplayID = frame.displayID {
+                        guard frameDisplayID == activeDisplayID else { continue }
+                    } else if !includeLegacy {
+                        continue
+                    }
                 }
+                results.append(frame)
             }
             results.reverse()
 

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -38,23 +38,46 @@ class OverlayWindowController: NSObject {
 
     func showOverlay(
         recentTimelineWindow: TimeInterval,
-        rewindHistoryOption: RewindHistoryOption
+        rewindHistoryOption: RewindHistoryOption,
+        activeDisplay: DisplayInfo?,
+        availableDisplays: [DisplayInfo]
     ) {
-        guard window == nil, let screen = NSScreen.main else { return }
+        guard window == nil else { return }
+
+        // Open on the screen that owns the active display; fall back to main.
+        let resolvedScreen: NSScreen? = {
+            if let activeDisplay,
+               let displayID = activeDisplay.displayID,
+               let screen = DisplayIdentity.screen(for: displayID) {
+                return screen
+            }
+            return NSScreen.main
+        }()
+        guard let screen = resolvedScreen else { return }
 
         // Pause pruning while overlay is visible
         frameBuffer.isPruningPaused = true
 
-        // Get frames with near-duplicates filtered out for smoother browsing
+        let primaryDisplayID = Self.primaryDisplayID(among: availableDisplays)
+
+        // Get frames with near-duplicates filtered out for smoother browsing.
+        // Legacy (nil displayID) frames predate multi-display support so their
+        // source display is ambiguous — they stay hidden from display-scoped
+        // timelines rather than polluting whichever slot happens to be primary.
         let timelineFrames = frameBuffer.getFilteredFrames(
             recentWindow: recentTimelineWindow,
-            maximumAge: rewindHistoryOption.duration
+            maximumAge: rewindHistoryOption.duration,
+            displayID: activeDisplay?.id,
+            includeLegacyFrames: activeDisplay?.id == primaryDisplayID
         )
         let vm = OverlayViewModel(
             timelineFrames: timelineFrames,
             frameBuffer: frameBuffer,
             recentTimelineWindow: recentTimelineWindow,
             rewindHistoryOption: rewindHistoryOption,
+            availableDisplays: availableDisplays,
+            activeDisplay: activeDisplay,
+            primaryDisplayID: primaryDisplayID,
             onDismiss: { [weak self] in
                 self?.hideOverlay()
             }
@@ -77,9 +100,19 @@ class OverlayWindowController: NSObject {
         window.acceptsMouseMovedEvents = true
 
         let overlayView = OverlayView(viewModel: vm)
+            .frame(width: screen.frame.width, height: screen.frame.height)
+            .clipped()
         let hostingView = NSHostingView(rootView: overlayView)
         hostingView.frame = screen.frame
         hostingView.autoresizingMask = [.width, .height]
+        // On macOS 13+, NSHostingView defaults to growing with its SwiftUI
+        // content's intrinsic size. For a fullscreen overlay we explicitly
+        // want the hosting view pinned to the window; otherwise SwiftUI's
+        // maxWidth/maxHeight .infinity bubbles up and the hosting view
+        // resizes beyond the window on each layout pass.
+        if #available(macOS 13.0, *) {
+            hostingView.sizingOptions = []
+        }
         window.contentView = hostingView
 
         window.setFrame(screen.frame, display: true)
@@ -134,6 +167,10 @@ class OverlayWindowController: NSObject {
                 vm.jumpRight()
             case .goToEnd:
                 vm.goToEnd()
+            case .cycleDisplayForward:
+                vm.cycleDisplay(forward: true)
+            case .cycleDisplayBackward:
+                vm.cycleDisplay(forward: false)
             }
 
             return nil
@@ -177,6 +214,18 @@ class OverlayWindowController: NSObject {
 
     var isVisible: Bool {
         window != nil && window!.isVisible
+    }
+
+    /// Picks the built-in display first, else the first in the list. Legacy
+    /// (pre-multi-display) frames surface under whichever display wins this.
+    private static func primaryDisplayID(among displays: [DisplayInfo]) -> UUID? {
+        if let builtIn = displays.first(where: { info in
+            guard let did = info.displayID else { return false }
+            return CGDisplayIsBuiltin(did) != 0
+        }) {
+            return builtIn.id
+        }
+        return displays.first(where: { $0.isConnected })?.id ?? displays.first?.id
     }
 }
 

--- a/JustNowTests/OCRFrameQueueTests.swift
+++ b/JustNowTests/OCRFrameQueueTests.swift
@@ -97,7 +97,9 @@ final class OCRFrameQueueTests: XCTestCase {
         StoredFrame(
             id: UUID(),
             timestamp: Date().addingTimeInterval(-secondsAgo),
-            hash: 0
+            hash: 0,
+            displayID: nil,
+            displayName: nil
         )
     }
 }

--- a/JustNowTests/OCRIndexingWorkerTests.swift
+++ b/JustNowTests/OCRIndexingWorkerTests.swift
@@ -105,7 +105,9 @@ final class OCRIndexingWorkerTests: XCTestCase {
         StoredFrame(
             id: UUID(),
             timestamp: Date().addingTimeInterval(-secondsAgo),
-            hash: 0
+            hash: 0,
+            displayID: nil,
+            displayName: nil
         )
     }
 }

--- a/JustNowTests/OverlayTimelineTests.swift
+++ b/JustNowTests/OverlayTimelineTests.swift
@@ -51,7 +51,9 @@ final class OverlayTimelineTests: XCTestCase {
             StoredFrame(
                 id: UUID(),
                 timestamp: now.addingTimeInterval(-offset),
-                hash: 0
+                hash: 0,
+                displayID: nil,
+                displayName: nil
             )
         }
     }


### PR DESCRIPTION
This adds support for capturing snapshots from multiple monitors when connected, adding display ID to metadata, and UI for switching between displays when viewing history.

<img width="663" height="104" alt="Screenshot 2026-04-16 at 6 44 58 PM" src="https://github.com/user-attachments/assets/9933afd4-ce23-40f1-8bd2-08cc7b78a466" />

- Store capture history per-display
- Allow switching between displays while viewing history with Tab
- Can rewind all displays in history even after displays change

I am sorry this PR is so large! I begged Claude and Codex to make it as minimal as possible, but I had to touch a relatively large surface area to make the app multi-display-aware.