### PR TITLE
feat: option to hide menu bar icon (closes #17)

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -99,6 +99,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
     @AppStorage(AppStorageKey.capturePauseShortcutModifiers) private var capturePauseShortcutModifiers: Int = AppStorageDefault.capturePauseShortcutModifiers
     @AppStorage(AppStorageKey.overlayDismissKeyCode) private var overlayDismissKeyCode: Int = AppStorageDefault.overlayDismissKeyCode
     @AppStorage(AppStorageKey.overlayDismissModifiers) private var overlayDismissModifiers: Int = AppStorageDefault.overlayDismissModifiers
+    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
     private var capturePolicyTimer: Timer?
     private var userDefaultsObserver: NSObjectProtocol?
     private var thermalObserver: NSObjectProtocol?
@@ -212,6 +213,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
         handlePendingPermissionPromptResolutionIfNeeded()
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        showSettings()
+        return false
+    }
+
     // MARK: - Setup
 
     private func setupStatusItem() {
@@ -226,6 +232,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
                 menuWillOpen: { [weak self] in self?.handleStatusMenuWillOpen() }
             )
         )
+        statusItemController.setVisible(showMenuBarIcon)
     }
 
     private func setupHotKey() {
@@ -355,6 +362,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, ScreenCaptureDelegate {
             Task { @MainActor [self] in
                 self.updateCapturePolicy()
                 await self.updateRetentionPolicyIfNeeded()
+                self.statusItemController?.setVisible(self.showMenuBarIcon)
             }
         }
 

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -44,3 +44,29 @@ struct CompactInstructionLabelStyle: LabelStyle {
         }
     }
 }
+
+struct MenuBarVisibilityIsland: View {
+    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "inset.filled.tophalf.bottomhalf.rectangle")
+                .font(.system(size: 11))
+                .foregroundStyle(.white.opacity(0.6))
+            Toggle("", isOn: $showMenuBarIcon)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .controlSize(.mini)
+                .scaleEffect(0.6)
+                .frame(width: 22, height: 13)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .darkBarBackground(in: Capsule())
+        .help(showMenuBarIcon ? "Hide menu bar icon" : "Show menu bar icon")
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Show menu bar icon")
+        .accessibilityValue(showMenuBarIcon ? "On" : "Off")
+        .accessibilityHint("Toggles whether JustNow's icon appears in the macOS menu bar.")
+    }
+}

--- a/JustNow/UI/OverlayTimeline.swift
+++ b/JustNow/UI/OverlayTimeline.swift
@@ -34,7 +34,6 @@ extension View {
 
 struct TimelineSlider: View {
     var viewModel: OverlayViewModel
-    let textGrabBannerState: TextGrabBannerState
 
     private var displayedFrames: [StoredFrame] { viewModel.displayedFrames }
     private var frameCount: Int { displayedFrames.count }

--- a/JustNow/UI/OverlayTimeline.swift
+++ b/JustNow/UI/OverlayTimeline.swift
@@ -72,6 +72,7 @@ struct TimelineSlider: View {
     var body: some View {
         VStack(spacing: 12) {
             TimeLabels(frames: displayedFrames)
+                .offset(y: 19)
 
             SliderTrack(
                 frameCount: frameCount,
@@ -82,19 +83,31 @@ struct TimelineSlider: View {
             )
             .frame(height: timelineMarkers.isEmpty ? 32 : 54)
             .padding(.horizontal, 8)
-
-            ZStack {
-                footerMetadata
-                    .opacity(textGrabBannerState == .hint ? 1 : 0)
-
-                if textGrabBannerState != .hint {
-                    TextGrabToast(state: textGrabBannerState)
-                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                }
-            }
-            .frame(minHeight: 44)
-            .animation(.spring(response: 0.28, dampingFraction: 0.86), value: textGrabBannerState)
+            .offset(y: 12)
         }
+    }
+}
+
+struct TimelineFooter: View {
+    var viewModel: OverlayViewModel
+    let textGrabBannerState: TextGrabBannerState
+
+    private var displayedFrames: [StoredFrame] { viewModel.displayedFrames }
+    private var frameCount: Int { displayedFrames.count }
+    private var currentFrame: StoredFrame? { displayedFrames[safe: viewModel.selectedIndex] }
+
+    var body: some View {
+        ZStack {
+            footerMetadata
+                .opacity(textGrabBannerState == .hint ? 1 : 0)
+
+            if textGrabBannerState != .hint {
+                TextGrabToast(state: textGrabBannerState)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .frame(minHeight: 44)
+        .animation(.spring(response: 0.28, dampingFraction: 0.86), value: textGrabBannerState)
     }
 
     @ViewBuilder
@@ -268,6 +281,7 @@ private struct SliderTrack: View {
                         }
                     }
                     .frame(height: 12)
+                    .offset(y: -4)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -8,11 +8,15 @@ import SwiftUI
 
 private enum OverlayChromeMetrics {
     static let controlSize: CGFloat = 40
-    static let topPadding: CGFloat = 24
+    static let topPadding: CGFloat = 29
     static let horizontalPadding: CGFloat = 28
     static let contentSpacing: CGFloat = 12
     static let sideSlotWidth: CGFloat = controlSize
     static let searchBarTopPadding: CGFloat = topPadding + controlSize + contentSpacing
+    static let contentVerticalShift: CGFloat = 28
+    static let timelineBottomPadding: CGFloat = 50
+    static let sliderTrackVerticalShift: CGFloat = 7
+    static let timelineFooterBottomPadding: CGFloat = 7
 }
 
 struct OverlayView: View {
@@ -148,6 +152,7 @@ struct ContentAreaView: View {
                 }
                 .padding(.horizontal, 60)
                 .padding(.top, viewModel.isSearchAvailable && viewModel.isSearching ? 20 : 40)
+                .offset(y: OverlayChromeMetrics.contentVerticalShift)
             } else if !viewModel.isSearching && viewModel.timelineFrames.isEmpty {
                 VStack(spacing: 12) {
                     Image(systemName: "clock.badge.exclamationmark")
@@ -183,9 +188,12 @@ struct ContentAreaView: View {
             Spacer()
 
             TimelineSlider(viewModel: viewModel, textGrabBannerState: textGrabBannerState)
-                .frame(height: 100)
                 .padding(.horizontal, 40)
-                .padding(.bottom, 50)
+                .padding(.bottom, OverlayChromeMetrics.timelineBottomPadding)
+        }
+        .overlay(alignment: .bottom) {
+            TimelineFooter(viewModel: viewModel, textGrabBannerState: textGrabBannerState)
+                .padding(.bottom, OverlayChromeMetrics.timelineFooterBottomPadding)
         }
         .animation(.easeInOut(duration: 0.2), value: viewModel.isSearchAvailable && viewModel.isSearching)
         .task(id: viewModel.selectedFramePrefetchKey) {
@@ -205,6 +213,8 @@ struct ContentAreaView: View {
 
 private struct OverlayTopBar: View {
     var viewModel: OverlayViewModel
+    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
+    @State private var shouldShowIsland: Bool = false
 
     @ViewBuilder
     private var searchControl: some View {
@@ -239,9 +249,27 @@ private struct OverlayTopBar: View {
                 )
                 .frame(width: OverlayChromeMetrics.sideSlotWidth, alignment: .leading)
 
-                InstructionsOverlay()
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .layoutPriority(1)
+                HStack(spacing: 8) {
+                    InstructionsOverlay()
+                    if shouldShowIsland {
+                        MenuBarVisibilityIsland()
+                            .overlay(alignment: .leading) {
+                                GeometryReader { proxy in
+                                    Text("menu restored; re-hide in settings")
+                                        .font(.system(size: 11, weight: .medium))
+                                        .foregroundStyle(.white.opacity(0.55))
+                                        .fixedSize()
+                                        .frame(height: proxy.size.height, alignment: .center)
+                                        .offset(x: proxy.size.width + 10)
+                                        .opacity(showMenuBarIcon ? 1 : 0)
+                                        .animation(.easeInOut(duration: 0.25), value: showMenuBarIcon)
+                                }
+                                .allowsHitTesting(false)
+                            }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .center)
+                .layoutPriority(1)
 
                 searchControl
                     .frame(width: OverlayChromeMetrics.sideSlotWidth, alignment: .trailing)
@@ -250,6 +278,16 @@ private struct OverlayTopBar: View {
             .padding(.top, OverlayChromeMetrics.topPadding)
 
             Spacer()
+        }
+        .onAppear {
+            if !showMenuBarIcon {
+                shouldShowIsland = true
+            }
+        }
+        .onChange(of: showMenuBarIcon) { _, newValue in
+            if !newValue {
+                shouldShowIsland = true
+            }
         }
     }
 }

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -15,7 +15,6 @@ private enum OverlayChromeMetrics {
     static let searchBarTopPadding: CGFloat = topPadding + controlSize + contentSpacing
     static let contentVerticalShift: CGFloat = 28
     static let timelineBottomPadding: CGFloat = 50
-    static let sliderTrackVerticalShift: CGFloat = 7
     static let timelineFooterBottomPadding: CGFloat = 7
 }
 
@@ -187,7 +186,7 @@ struct ContentAreaView: View {
 
             Spacer()
 
-            TimelineSlider(viewModel: viewModel, textGrabBannerState: textGrabBannerState)
+            TimelineSlider(viewModel: viewModel)
                 .padding(.horizontal, 40)
                 .padding(.bottom, OverlayChromeMetrics.timelineBottomPadding)
         }

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -22,6 +22,9 @@ struct SettingsView: View {
     @AppStorage(AppStorageKey.overlayDismissModifiers) private var overlayDismissModifiers: Int = AppStorageDefault.overlayDismissModifiers
     @AppStorage(AppStorageKey.textGrabSoundEnabled) private var textGrabSoundEnabled: Bool = AppStorageDefault.textGrabSoundEnabled
     @AppStorage(AppStorageKey.textGrabDebugPreviewEnabled) private var textGrabDebugPreviewEnabled: Bool = AppStorageDefault.textGrabDebugPreviewEnabled
+    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
+    @AppStorage(AppStorageKey.hasSeenMenuBarHideInfo) private var hasSeenMenuBarHideInfo: Bool = AppStorageDefault.hasSeenMenuBarHideInfo
+    @State private var showHideIconInfoAlert: Bool = false
 
     var context: SettingsContext = SettingsContext()
 
@@ -47,6 +50,19 @@ struct SettingsView: View {
                     .disabled(!context.canConfigureLaunchAtLogin)
 
                 Text("If macOS asks for approval, enable JustNow in System Settings > General > Login Items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                    .onChange(of: showMenuBarIcon) { _, newValue in
+                        if !newValue && !hasSeenMenuBarHideInfo {
+                            showHideIconInfoAlert = true
+                            hasSeenMenuBarHideInfo = true
+                        }
+                    }
+
+                Text("Hides the icon in the macOS menu bar. If you lose access, relaunch JustNow from Finder or Spotlight to reopen Settings, or toggle it back from the rewind overlay.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)
@@ -320,6 +336,11 @@ struct SettingsView: View {
             }
         } message: {
             Text(launchAtLoginAlertMessage ?? "")
+        }
+        .alert("Menu bar icon hidden", isPresented: $showHideIconInfoAlert) {
+            Button("Got it", role: .cancel) { }
+        } message: {
+            Text("To bring it back, relaunch JustNow from Finder or Spotlight to reopen Settings, or switch it back on from the rewind overlay.")
         }
     }
 

--- a/JustNow/UI/StatusItemController.swift
+++ b/JustNow/UI/StatusItemController.swift
@@ -206,6 +206,10 @@ final class StatusItemController: NSObject, NSMenuDelegate {
         frameCountItem.title = "Frames: \(count)"
     }
 
+    func setVisible(_ isVisible: Bool) {
+        statusItem.isVisible = isVisible
+    }
+
     func setCaptureStatus(_ status: String) {
         captureStatusItem.title = "Capture: \(status)"
     }

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -13,6 +13,8 @@ enum AppStorageKey {
     static let overlayDismissModifiers = "overlayDismissModifiers"
     static let textGrabSoundEnabled = "textGrabSoundEnabled"
     static let textGrabDebugPreviewEnabled = "textGrabDebugPreviewEnabled"
+    static let showMenuBarIcon = "showMenuBarIcon"
+    static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
 }
 
 enum AppStorageDefault {
@@ -28,4 +30,6 @@ enum AppStorageDefault {
     static let overlayDismissModifiers = 0
     static let textGrabSoundEnabled = true
     static let textGrabDebugPreviewEnabled = false
+    static let showMenuBarIcon = true
+    static let hasSeenMenuBarHideInfo = false
 }


### PR DESCRIPTION
## Summary

Implements [issue #17](https://github.com/yjsoon/justnow/issues/17) — an option to hide JustNow's menu bar icon, with recovery paths so users can't get stranded.

- Settings → General gains a **Show menu bar icon** toggle, default on.
- Hiding it flips `NSStatusItem.isVisible` (we keep `StatusItemController` alive — no teardown/rebuild churn).
- Two recovery paths, independent of the global hotkey:
  - `applicationShouldHandleReopen(_:hasVisibleWindows:)` opens Settings on any relaunch (Finder double-click, Spotlight, `open -a`). LSUIElement apps still receive these `kAEReopenApplication` AppleEvents — this is the same pattern Moom and similar menu-bar-only apps use.
  - The rewind overlay grows a restore pill whenever the icon is hidden. The pill contains a scaled-down native `.switch` Toggle (`.controlSize(.mini)` + `scaleEffect 0.6`) and latches on for the current overlay session, so toggling back on doesn't yank it out from under the cursor. A faded **menu restored; re-hide in settings** hint fades in to the right of the pill using a GeometryReader-positioned overlay (no layout shift).
- A first-time info alert on hiding explains both recovery paths so the user knows what to do before needing to do it.

## Overlay layout tuning

The new pill needed breathing room in the top bar and elsewhere. Notable changes in `OverlayView.swift` and `OverlayTimeline.swift`:

- `TimelineFooter` (frame counter + time-ago) split out of `TimelineSlider` and pinned to the bottom edge as an `overlay(alignment: .bottom)` — this keeps the counter visible even when the scrubber itself is repositioned.
- Preview frame, scrubber, time labels, and hour-marker labels all nudged via `.offset` (visual-only — `.padding` caused Spacer redistribution to double-shift the preview).
- `OverlayChromeMetrics` gains `contentVerticalShift`, `timelineBottomPadding`, `timelineFooterBottomPadding` constants so these are easy to re-tune.

## Test plan

- [ ] Toggle **Show menu bar icon** off in Settings → icon disappears, one-time info alert fires.
- [ ] Relaunch JustNow from Spotlight / Finder → Settings window opens (no duplicate instance).
- [ ] Open rewind overlay while icon is hidden → restore pill appears to the right of the instructions pill.
- [ ] Click the toggle on the pill → icon reappears in menu bar, "menu restored; re-hide in settings" fades in beside the pill, pill stays in place.
- [ ] Click the toggle again → hint fades out, pill still visible until overlay dismissed.
- [ ] Close and reopen the overlay with the icon visible → pill no longer present.
- [ ] With icon hidden + Settings already open, toggling it back on doesn't fire the alert again (`hasSeenMenuBarHideInfo`).
- [ ] Scrubber, hour markers, time labels, and frame counter all render at sensible positions on a 13" MacBook display and an external 27" display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)