### PR TITLE
feat: save current screenshot from overlay

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -580,7 +580,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                     onVisibilityChanged: { [weak self] isVisible in
                         guard let self else { return }
                         self.captureEventController.handleOverlayVisibilityChanged(isVisible: isVisible)
-                    }
+                    },
+                    onOpenSettings: { [weak self] in self?.showSettings() }
                 )
             } else {
                 self.overlayController?.updateDismissShortcut(

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -366,6 +366,12 @@ class FrameBuffer {
         }
     }
 
+    /// Copy the frame's stored JPEG (full original pixel dimensions) to the
+    /// user's Desktop. Returns the destination URL.
+    func saveFrameToDesktop(_ frame: StoredFrame) async throws -> URL {
+        try await frameStore.copyFrameToDesktop(id: frame.id, timestamp: frame.timestamp)
+    }
+
     /// Get thumbnail, with caching
     func getThumbnail(for frame: StoredFrame) async -> CGImage? {
         let key = frame.id as NSUUID

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -146,6 +146,44 @@ actor FrameStore {
         return image
     }
 
+    /// Copy the frame's stored JPEG to the user's Desktop, preserving original
+    /// pixel dimensions and the encoder quality used when capturing. Returns
+    /// the destination URL, with a `(n)` suffix if the target name is taken.
+    func copyFrameToDesktop(id: UUID, timestamp: Date) throws -> URL {
+        guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
+            throw FrameStoreError.fileNotFound(id)
+        }
+
+        let sourcePath = framesURL.appendingPathComponent(metadata.filename)
+        guard fileManager.fileExists(atPath: sourcePath.path) else {
+            throw FrameStoreError.fileNotFound(id)
+        }
+
+        let desktopURL = try fileManager.url(
+            for: .desktopDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd 'at' HH.mm.ss"
+        let stamp = formatter.string(from: timestamp)
+        let baseName = "JustNow \(stamp)"
+        let ext = (metadata.filename as NSString).pathExtension
+
+        var destination = desktopURL.appendingPathComponent("\(baseName).\(ext)")
+        var suffix = 2
+        while fileManager.fileExists(atPath: destination.path) {
+            destination = desktopURL.appendingPathComponent("\(baseName) (\(suffix)).\(ext)")
+            suffix += 1
+        }
+
+        try fileManager.copyItem(at: sourcePath, to: destination)
+        return destination
+    }
+
     func loadThumbnail(id: UUID) -> CGImage? {
         guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
             return nil

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -45,28 +45,40 @@ struct CompactInstructionLabelStyle: LabelStyle {
     }
 }
 
-struct MenuBarVisibilityIsland: View {
-    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
+struct OverlayMoreMenuIsland: View {
+    var viewModel: OverlayViewModel
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "inset.filled.tophalf.bottomhalf.rectangle")
-                .font(.system(size: 11))
-                .foregroundStyle(.white.opacity(0.6))
-            Toggle("", isOn: $showMenuBarIcon)
-                .toggleStyle(.switch)
-                .labelsHidden()
-                .controlSize(.mini)
-                .scaleEffect(0.6)
-                .frame(width: 22, height: 13)
+        Menu {
+            Button {
+                viewModel.saveCurrentFrameToDesktop()
+            } label: {
+                Label("Save Screenshot to Desktop", systemImage: "square.and.arrow.down")
+            }
+            .keyboardShortcut("s", modifiers: .command)
+            .disabled(!viewModel.canSaveCurrentFrame)
+
+            Divider()
+
+            Button {
+                viewModel.openSettings()
+            } label: {
+                Label("Open Settings…", systemImage: "gearshape")
+            }
+            .keyboardShortcut(",", modifiers: .command)
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 14, weight: .bold))
+                .foregroundStyle(.white.opacity(0.75))
+                .frame(width: 32, height: 32)
+                .contentShape(Circle())
         }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 10)
-        .darkBarBackground(in: Capsule())
-        .help(showMenuBarIcon ? "Hide menu bar icon" : "Show menu bar icon")
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Show menu bar icon")
-        .accessibilityValue(showMenuBarIcon ? "On" : "Off")
-        .accessibilityHint("Toggles whether JustNow's icon appears in the macOS menu bar.")
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .darkBarBackground(in: Circle())
+        .help("More actions")
+        .accessibilityLabel("More actions")
+        .accessibilityHint("Save the current screenshot or open Settings.")
     }
 }

--- a/JustNow/UI/OverlayKeyboardAction.swift
+++ b/JustNow/UI/OverlayKeyboardAction.swift
@@ -29,6 +29,8 @@ enum OverlayKeyboardAction: Equatable {
     case goToEnd
     case cycleDisplayForward
     case cycleDisplayBackward
+    case saveScreenshot
+    case openSettings
 }
 
 func resolveOverlayKeyboardAction(
@@ -90,6 +92,18 @@ func resolveOverlayKeyboardAction(
             return .passthrough
         }
         return pressedModifiers.contains(.shift) ? .cycleDisplayBackward : .cycleDisplayForward
+
+    case UInt16(kVK_ANSI_S):
+        if pressedModifiers == .command {
+            return .saveScreenshot
+        }
+        return .passthrough
+
+    case UInt16(kVK_ANSI_Comma):
+        if pressedModifiers == .command {
+            return .openSettings
+        }
+        return .passthrough
 
     default:
         return matchesDismissShortcut ? .dismissOverlay : .passthrough

--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -47,6 +47,46 @@ struct OverlayView: View {
 
             OverlayTopBar(viewModel: viewModel)
         }
+        .overlay(alignment: .top) {
+            if let toast = viewModel.saveToast {
+                OverlayToastView(toast: toast)
+                    .padding(.top, 90)
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .opacity
+                    ))
+                    .id(toast.id)
+            }
+        }
+        .animation(.easeOut(duration: 0.22), value: viewModel.saveToast?.id)
+    }
+}
+
+private struct OverlayToastView: View {
+    let toast: OverlayToast
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: toast.icon)
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(toast.isError ? Color.red.opacity(0.9) : Color.green.opacity(0.9))
+            VStack(alignment: .leading, spacing: 1) {
+                Text(toast.title)
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(.white.opacity(0.95))
+                if let detail = toast.detail {
+                    Text(detail)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.6))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .darkBarBackground(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
     }
 }
 
@@ -243,8 +283,6 @@ struct ContentAreaView: View {
 
 private struct OverlayTopBar: View {
     var viewModel: OverlayViewModel
-    @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
-    @State private var shouldShowIsland: Bool = false
 
     @ViewBuilder
     private var searchControl: some View {
@@ -284,22 +322,7 @@ private struct OverlayTopBar: View {
                     if viewModel.availableDisplays.count > 1 {
                         DisplayPickerStrip(viewModel: viewModel)
                     }
-                    if shouldShowIsland {
-                        MenuBarVisibilityIsland()
-                            .overlay(alignment: .leading) {
-                                GeometryReader { proxy in
-                                    Text("Menu restored; re-hide in settings")
-                                        .font(.system(size: 11, weight: .medium))
-                                        .foregroundStyle(.white.opacity(0.55))
-                                        .fixedSize()
-                                        .frame(height: proxy.size.height, alignment: .center)
-                                        .offset(x: proxy.size.width + 10)
-                                        .opacity(showMenuBarIcon ? 1 : 0)
-                                        .animation(.easeInOut(duration: 0.25), value: showMenuBarIcon)
-                                }
-                                .allowsHitTesting(false)
-                            }
-                    }
+                    OverlayMoreMenuIsland(viewModel: viewModel)
                 }
                 .frame(maxWidth: .infinity, alignment: .center)
                 .layoutPriority(1)
@@ -311,16 +334,6 @@ private struct OverlayTopBar: View {
             .padding(.top, OverlayChromeMetrics.topPadding)
 
             Spacer()
-        }
-        .onAppear {
-            if !showMenuBarIcon {
-                shouldShowIsland = true
-            }
-        }
-        .onChange(of: showMenuBarIcon) { _, newValue in
-            if !newValue {
-                shouldShowIsland = true
-            }
         }
     }
 }

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -391,8 +391,8 @@ class OverlayViewModel {
     }
 
     func openSettings() {
-        onOpenSettings()
         onDismiss()
+        onOpenSettings()
     }
 
     func saveCurrentFrameToDesktop() {

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -3,6 +3,7 @@
 //  JustNow
 //
 
+import AppKit
 import CoreGraphics
 import Foundation
 import Observation
@@ -10,6 +11,14 @@ import SwiftUI
 import os.log
 
 private let overlayViewLogger = Logger(subsystem: "sg.tk.JustNow", category: "OverlayView")
+
+struct OverlayToast: Equatable, Identifiable {
+    let id = UUID()
+    let icon: String
+    let title: String
+    let detail: String?
+    let isError: Bool
+}
 
 enum SearchTimeScope: String, CaseIterable {
     case fiveMinutes
@@ -102,6 +111,7 @@ class OverlayViewModel {
     let rewindHistoryOption: RewindHistoryOption
     let timelineReferenceDate: Date
     let onDismiss: () -> Void
+    let onOpenSettings: () -> Void
     let availableDisplays: [DisplayInfo]
     private(set) var activeDisplay: DisplayInfo?
     private let primaryDisplayID: UUID?
@@ -119,6 +129,9 @@ class OverlayViewModel {
     private var resolvedSearchRequest: SearchRequest?
     var isTextGrabActive = false
     private var cancelTextGrabHandler: (() -> Void)?
+
+    var saveToast: OverlayToast?
+    private var saveToastTask: Task<Void, Never>?
 
     var isSearchAvailable: Bool {
         FeatureFlags.isSearchEnabled
@@ -182,7 +195,8 @@ class OverlayViewModel {
         availableDisplays: [DisplayInfo],
         activeDisplay: DisplayInfo?,
         primaryDisplayID: UUID?,
-        onDismiss: @escaping () -> Void
+        onDismiss: @escaping () -> Void,
+        onOpenSettings: @escaping () -> Void
     ) {
         self.timelineFrames = timelineFrames
         self.frameBuffer = frameBuffer
@@ -193,6 +207,7 @@ class OverlayViewModel {
         self.activeDisplay = activeDisplay
         self.primaryDisplayID = primaryDisplayID
         self.onDismiss = onDismiss
+        self.onOpenSettings = onOpenSettings
         self.selectedIndex = max(0, timelineFrames.count - 1)
     }
 
@@ -369,6 +384,49 @@ class OverlayViewModel {
         let step = delta > 0 ? -1 : 1
         let newIndex = selectedIndex + step
         selectedIndex = max(0, min(displayedFrameCount - 1, newIndex))
+    }
+
+    var canSaveCurrentFrame: Bool {
+        displayedFrames[safe: selectedIndex] != nil
+    }
+
+    func openSettings() {
+        onOpenSettings()
+        onDismiss()
+    }
+
+    func saveCurrentFrameToDesktop() {
+        guard let frame = displayedFrames[safe: selectedIndex] else { return }
+        let buffer = frameBuffer
+        Task { @MainActor in
+            do {
+                let url = try await buffer.saveFrameToDesktop(frame)
+                showSaveToast(OverlayToast(
+                    icon: "checkmark.circle.fill",
+                    title: "Saved to Desktop",
+                    detail: url.lastPathComponent,
+                    isError: false
+                ))
+            } catch {
+                overlayViewLogger.error("Failed to save frame to Desktop: \(error.localizedDescription)")
+                showSaveToast(OverlayToast(
+                    icon: "exclamationmark.triangle.fill",
+                    title: "Couldn't save screenshot",
+                    detail: error.localizedDescription,
+                    isError: true
+                ))
+            }
+        }
+    }
+
+    private func showSaveToast(_ toast: OverlayToast) {
+        saveToastTask?.cancel()
+        saveToast = toast
+        saveToastTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(toast.isError ? 4 : 2.5))
+            guard !Task.isCancelled else { return }
+            saveToast = nil
+        }
     }
 
     func setPresentedFrame(_ frame: StoredFrame?) {

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -3,7 +3,6 @@
 //  JustNow
 //
 
-import AppKit
 import CoreGraphics
 import Foundation
 import Observation

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -12,6 +12,7 @@ class OverlayWindowController: NSObject {
     private var window: OverlayWindow?
     private let frameBuffer: FrameBuffer
     private let onVisibilityChanged: ((Bool) -> Void)?
+    private let onOpenSettings: () -> Void
     private var dismissShortcutKeyCode: Int
     private var dismissShortcutModifiers: Int
     private var keyEventMonitor: Any?
@@ -22,12 +23,14 @@ class OverlayWindowController: NSObject {
         frameBuffer: FrameBuffer,
         dismissShortcutKeyCode: Int,
         dismissShortcutModifiers: Int,
-        onVisibilityChanged: ((Bool) -> Void)? = nil
+        onVisibilityChanged: ((Bool) -> Void)? = nil,
+        onOpenSettings: @escaping () -> Void
     ) {
         self.frameBuffer = frameBuffer
         self.dismissShortcutKeyCode = dismissShortcutKeyCode
         self.dismissShortcutModifiers = dismissShortcutModifiers
         self.onVisibilityChanged = onVisibilityChanged
+        self.onOpenSettings = onOpenSettings
         super.init()
     }
 
@@ -80,7 +83,8 @@ class OverlayWindowController: NSObject {
             primaryDisplayID: primaryDisplayID,
             onDismiss: { [weak self] in
                 self?.hideOverlay()
-            }
+            },
+            onOpenSettings: onOpenSettings
         )
         self.viewModel = vm
 
@@ -171,6 +175,10 @@ class OverlayWindowController: NSObject {
                 vm.cycleDisplay(forward: true)
             case .cycleDisplayBackward:
                 vm.cycleDisplay(forward: false)
+            case .saveScreenshot:
+                vm.saveCurrentFrameToDesktop()
+            case .openSettings:
+                vm.openSettings()
             }
 
             return nil

--- a/JustNowTests/OverlayKeyboardActionTests.swift
+++ b/JustNowTests/OverlayKeyboardActionTests.swift
@@ -52,6 +52,54 @@ final class OverlayKeyboardActionTests: XCTestCase {
         XCTAssertEqual(action, .passthrough)
     }
 
+    func testCommandSResolvesToSaveScreenshot() {
+        let action = resolveOverlayKeyboardAction(
+            keyCode: UInt16(kVK_ANSI_S),
+            modifiers: [.command],
+            dismissShortcutKeyCode: Int(kVK_Escape),
+            dismissShortcutModifiers: 0,
+            state: .init(isSearchAvailable: true, isSearching: false, hasSearchQuery: false, isTextGrabActive: false)
+        )
+
+        XCTAssertEqual(action, .saveScreenshot)
+    }
+
+    func testPlainSPassesThroughWithoutCommand() {
+        let action = resolveOverlayKeyboardAction(
+            keyCode: UInt16(kVK_ANSI_S),
+            modifiers: [],
+            dismissShortcutKeyCode: Int(kVK_Escape),
+            dismissShortcutModifiers: 0,
+            state: .init(isSearchAvailable: true, isSearching: false, hasSearchQuery: false, isTextGrabActive: false)
+        )
+
+        XCTAssertEqual(action, .passthrough)
+    }
+
+    func testCommandCommaResolvesToOpenSettings() {
+        let action = resolveOverlayKeyboardAction(
+            keyCode: UInt16(kVK_ANSI_Comma),
+            modifiers: [.command],
+            dismissShortcutKeyCode: Int(kVK_Escape),
+            dismissShortcutModifiers: 0,
+            state: .init(isSearchAvailable: true, isSearching: false, hasSearchQuery: false, isTextGrabActive: false)
+        )
+
+        XCTAssertEqual(action, .openSettings)
+    }
+
+    func testPlainCommaPassesThroughWithoutCommand() {
+        let action = resolveOverlayKeyboardAction(
+            keyCode: UInt16(kVK_ANSI_Comma),
+            modifiers: [],
+            dismissShortcutKeyCode: Int(kVK_Escape),
+            dismissShortcutModifiers: 0,
+            state: .init(isSearchAvailable: true, isSearching: false, hasSearchQuery: false, isTextGrabActive: false)
+        )
+
+        XCTAssertEqual(action, .passthrough)
+    }
+
     func testArrowModifiersMapToJumpAndBoundaryActions() {
         let dismissModifiers = Int(NSEvent.ModifierFlags.command.rawValue)
 


### PR DESCRIPTION
I thought I'd try replacing the dedicated "show in menu bar" pill with a new "..." sort of menu that would allow the user to pop up the Settings dialog without the menu bar icon visible:

<img width="422" height="160" alt="Screenshot 2026-04-28 at 11 04 35 AM" src="https://github.com/user-attachments/assets/8d7c76d3-2c0b-4480-ad7f-f39d8edb4aa9" />

You can also save the current screenshot from there (or trigger with Cmd+S) and you get a little toast:

<img width="380" height="138" alt="Screenshot 2026-04-28 at 11 06 11 AM" src="https://github.com/user-attachments/assets/f88e79c2-f68e-4060-88f8-a6cec1a57c9f" />

## Summary

- Adds **Save Screenshot to Desktop** (⌘S) — copies the stored JPEG for the currently displayed frame straight to `~/Desktop` with a `JustNow YYYY-MM-DD at HH.mm.ss.jpg` filename, preserving original capture pixel dimensions and the encoder quality the frame was saved at (no extra recompression).
- Replaces the standalone "show menu-bar icon" island with an "…" actions menu (32×32 circular pill matching the existing chrome) that hosts the new save command plus an **Open Settings…** action wired to ⌘,.
- ⌘, is intercepted in the overlay's local key monitor so the shortcut dismisses the rewind UI before opening Settings (otherwise the SwiftUI `Settings { … }` scene auto-shortcut opens its window behind the fullscreen overlay).
- Save success/failure shows a top-center toast banner with the destination filename (or the failure reason) for 2.5s.

## Test plan

- [ ] Open the overlay, navigate to a frame, press ⌘S — file appears on Desktop, toast confirms the filename.
- [ ] Saved file opens at the original capture resolution.
- [ ] Press ⌘S twice quickly — second save lands as `… (2).jpg` (no overwrite).
- [ ] Click the "…" pill — menu shows Save Screenshot (with ⌘S) and Open Settings… (with ⌘,).
- [ ] Press ⌘, with the overlay open — overlay dismisses and Settings opens in front.
- [ ] Open a fresh install with no captures — the "…" pill is still present and Save is disabled.

Closes #22 

🤖 Generated with [Claude Code](https://claude.com/claude-code)