### PR TITLE
fix: remove empty CFBundleDisplayName

### DIFF
--- a/JustNow.xcodeproj/project.pbxproj
+++ b/JustNow.xcodeproj/project.pbxproj
@@ -348,7 +348,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -384,7 +383,6 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "";
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";


### PR DESCRIPTION
## Summary

Both Debug and Release configs set `INFOPLIST_KEY_CFBundleDisplayName = ""`, which propagates into the built bundle's `Info.plist` as `CFBundleDisplayName=""`. macOS prefers `CFBundleDisplayName` over `CFBundleName` whenever the key is present, so the empty string wins — Activity Monitor (and a few other places that consult the display name) end up rendering the JustNow process row with no name at all.

Dropping the key entirely lets the system fall through to `CFBundleName` (already `"JustNow"`), which is what's wanted in every case.

## Test plan

- [ ] Build a fresh Release: `plutil -p JustNow.app/Contents/Info.plist | grep CFBundleDisplayName` no longer prints the key.
- [ ] Launch the app; Activity Monitor's process list shows "JustNow" instead of a blank row.
- [ ] Finder Get Info on the bundle still shows the name correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)