### PR TITLE
fix: harmonise overlay more-menu glyph with neighbouring islands

### DIFF
--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -68,7 +68,7 @@ struct OverlayMoreMenuIsland: View {
             .keyboardShortcut(",", modifiers: .command)
         } label: {
             Image(systemName: "ellipsis")
-                .font(.system(size: 14, weight: .bold))
+                .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(.white.opacity(0.75))
                 .frame(width: 32, height: 32)
                 .contentShape(Circle())


### PR DESCRIPTION
## Summary

Spotted while smoke-testing #23 locally: the new `…` actions menu read as visually heavier than the rest of the overlay top bar. The frame size was correct (32×32, same height as the other pills), but the glyph itself was at `size: 14, weight: .bold` — noticeably bigger and heavier than the surrounding islands' `size: 10-11` icons and `size: 11, weight: .medium` text.

This drops the ellipsis to `size: 11, weight: .medium` so it sits at the same typographic weight as everything else in the row. Frame, shape, hit target, opacity, and accessibility metadata are all unchanged.

## Before / after

(Manual visual comparison only — the change is one line.)

## Test plan

- [ ] Open overlay; the `…` no longer reads as the heaviest element in the top bar.
- [ ] Click `…` → menu still opens with Save Screenshot and Open Settings…
- [ ] Hit target unchanged (32×32 circle).