### PR TITLE
chore: clean up empty INFOPLIST_KEY_* build settings

### DIFF
--- a/JustNow.xcodeproj/project.pbxproj
+++ b/JustNow.xcodeproj/project.pbxproj
@@ -348,9 +348,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Tinkertanker";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -383,9 +382,8 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
-				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Tinkertanker";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",

--- a/JustNow.xcodeproj/project.pbxproj
+++ b/JustNow.xcodeproj/project.pbxproj
@@ -349,7 +349,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Tinkertanker";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 YJ Soon";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
@@ -383,7 +383,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = JustNow/Info.plist;
 				INFOPLIST_KEY_LSUIElement = YES;
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Tinkertanker";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 YJ Soon";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",


### PR DESCRIPTION
## Summary

Same anti-pattern as #24 — with `GENERATE_INFOPLIST_FILE = YES`, empty-string `INFOPLIST_KEY_*` settings materialise into the merged `Info.plist` as set-but-empty keys, which some tooling reads as "present" rather than absent.

Cleans up the two remaining offenders in both Debug and Release:

- **`INFOPLIST_KEY_LSApplicationCategoryType`** — dropped entirely. Until JustNow has a reason to claim a Launchpad/Finder category, the system can treat the app as uncategorised. Easy to add back when needed (e.g. `public.app-category.utilities`).
- **`INFOPLIST_KEY_NSHumanReadableCopyright`** — set to `Copyright © 2026 Tinkertanker`. Finder's Get Info and `mdls` will now show a real value instead of blank.

## Verification

```
$ plutil -p .../JustNow.app/Contents/Info.plist | grep -E "LSApplicationCategoryType |NSHumanReadableCopyright"
  "NSHumanReadableCopyright" => "Copyright © 2026 Tinkertanker"
```

`LSApplicationCategoryType` is absent from the merged plist, `NSHumanReadableCopyright` carries a real value. Acceptance criteria from #25 met.

## Test plan

- [ ] CI/local build passes with the modified pbxproj.
- [ ] After install, `mdls -name kMDItemCopyright /Applications/JustNow.app` shows the new copyright string.
- [ ] Finder → Get Info on the installed `.app` shows the copyright line.

Closes #25