### PR TITLE
feat: reveal saved screenshot in Finder on toast click

### DIFF
--- a/JustNow/UI/OverlayView.swift
+++ b/JustNow/UI/OverlayView.swift
@@ -3,6 +3,7 @@
 //  JustNow
 //
 
+import AppKit
 import CoreGraphics
 import SwiftUI
 
@@ -49,7 +50,10 @@ struct OverlayView: View {
         }
         .overlay(alignment: .top) {
             if let toast = viewModel.saveToast {
-                OverlayToastView(toast: toast)
+                OverlayToastView(toast: toast) { url in
+                    NSWorkspace.shared.activateFileViewerSelecting([url])
+                    viewModel.dismissSaveToast()
+                }
                     .padding(.top, 90)
                     .transition(.asymmetric(
                         insertion: .move(edge: .top).combined(with: .opacity),
@@ -64,8 +68,35 @@ struct OverlayView: View {
 
 private struct OverlayToastView: View {
     let toast: OverlayToast
+    let onReveal: (URL) -> Void
+
+    @State private var isHovering = false
 
     var body: some View {
+        if let url = toast.revealURL {
+            Button {
+                onReveal(url)
+            } label: {
+                toastContent
+            }
+            .buttonStyle(.plain)
+            .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .onHover { hovering in
+                isHovering = hovering
+                if hovering {
+                    NSCursor.pointingHand.push()
+                } else {
+                    NSCursor.pop()
+                }
+            }
+            .accessibilityLabel(Text(toast.title))
+            .accessibilityHint(Text("Click to reveal in Finder."))
+        } else {
+            toastContent
+        }
+    }
+
+    private var toastContent: some View {
         HStack(spacing: 10) {
             Image(systemName: toast.icon)
                 .font(.system(size: 14, weight: .semibold))
@@ -86,7 +117,14 @@ private struct OverlayToastView: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
         .darkBarBackground(in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay {
+            if isHovering {
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+            }
+        }
         .shadow(color: .black.opacity(0.35), radius: 10, y: 4)
+        .animation(.easeOut(duration: 0.12), value: isHovering)
     }
 }
 

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -17,6 +17,7 @@ struct OverlayToast: Equatable, Identifiable {
     let title: String
     let detail: String?
     let isError: Bool
+    let revealURL: URL?
 }
 
 enum SearchTimeScope: String, CaseIterable {
@@ -404,7 +405,8 @@ class OverlayViewModel {
                     icon: "checkmark.circle.fill",
                     title: "Saved to Desktop",
                     detail: url.lastPathComponent,
-                    isError: false
+                    isError: false,
+                    revealURL: url
                 ))
             } catch {
                 overlayViewLogger.error("Failed to save frame to Desktop: \(error.localizedDescription)")
@@ -412,7 +414,8 @@ class OverlayViewModel {
                     icon: "exclamationmark.triangle.fill",
                     title: "Couldn't save screenshot",
                     detail: error.localizedDescription,
-                    isError: true
+                    isError: true,
+                    revealURL: nil
                 ))
             }
         }
@@ -426,6 +429,12 @@ class OverlayViewModel {
             guard !Task.isCancelled else { return }
             saveToast = nil
         }
+    }
+
+    func dismissSaveToast() {
+        saveToastTask?.cancel()
+        saveToastTask = nil
+        saveToast = nil
     }
 
     func setPresentedFrame(_ frame: StoredFrame?) {


### PR DESCRIPTION
## Summary

- Adds `revealURL: URL?` to `OverlayToast` and populates it on a successful save (errors stay nil).
- When `revealURL` is non-nil, the toast renders inside a `Button` that calls `NSWorkspace.activateFileViewerSelecting([url])` and dismisses the toast immediately. The overlay itself stays open.
- Adds a subtle hover tint, the pointing-hand cursor, and a "Click to reveal in Finder" accessibility hint. Error toasts keep their existing passive style.

Closes #27

## Test plan

- [ ] Press ⌘S in the rewind overlay; toast appears with the saved filename.
- [ ] Click the toast: the file is revealed in Finder, the toast disappears, and the overlay remains open.
- [ ] Hover the toast: cursor switches to a pointing hand and a faint tint appears.
- [ ] Force a save failure (e.g. read-only Desktop): error toast appears and is **not** clickable, no cursor change.
- [ ] VoiceOver announces the title plus "Click to reveal in Finder" hint on the success toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)