### PR TITLE
feat: customisable save location for overlay screenshots

### DIFF
--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -367,9 +367,9 @@ class FrameBuffer {
     }
 
     /// Copy the frame's stored JPEG (full original pixel dimensions) to the
-    /// user's Desktop. Returns the destination URL.
-    func saveFrameToDesktop(_ frame: StoredFrame) async throws -> URL {
-        try await frameStore.copyFrameToDesktop(id: frame.id, timestamp: frame.timestamp)
+    /// user's chosen screenshots location. Returns the destination URL.
+    func saveFrameToScreenshotsLocation(_ frame: StoredFrame) async throws -> URL {
+        try await frameStore.copyFrameToScreenshotsLocation(id: frame.id, timestamp: frame.timestamp)
     }
 
     /// Get thumbnail, with caching

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -160,12 +160,7 @@ actor FrameStore {
             throw FrameStoreError.fileNotFound(id)
         }
 
-        let desktopURL = try fileManager.url(
-            for: .desktopDirectory,
-            in: .userDomainMask,
-            appropriateFor: nil,
-            create: false
-        )
+        let destinationDirectory = ScreenshotSaveLocation.resolveLive(fileManager: fileManager)
 
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -174,10 +169,10 @@ actor FrameStore {
         let baseName = "JustNow \(stamp)"
         let ext = (metadata.filename as NSString).pathExtension
 
-        var destination = desktopURL.appendingPathComponent("\(baseName).\(ext)")
+        var destination = destinationDirectory.appendingPathComponent("\(baseName).\(ext)")
         var suffix = 2
         while fileManager.fileExists(atPath: destination.path) {
-            destination = desktopURL.appendingPathComponent("\(baseName) (\(suffix)).\(ext)")
+            destination = destinationDirectory.appendingPathComponent("\(baseName) (\(suffix)).\(ext)")
             suffix += 1
         }
 

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -146,10 +146,11 @@ actor FrameStore {
         return image
     }
 
-    /// Copy the frame's stored JPEG to the user's Desktop, preserving original
-    /// pixel dimensions and the encoder quality used when capturing. Returns
-    /// the destination URL, with a `(n)` suffix if the target name is taken.
-    func copyFrameToDesktop(id: UUID, timestamp: Date) throws -> URL {
+    /// Copy the frame's stored JPEG to the user's chosen screenshots location,
+    /// preserving original pixel dimensions and the encoder quality used when
+    /// capturing. Returns the destination URL, with a `(n)` suffix if the
+    /// target name is taken.
+    func copyFrameToScreenshotsLocation(id: UUID, timestamp: Date) throws -> URL {
         guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
             throw FrameStoreError.fileNotFound(id)
         }

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -53,7 +53,7 @@ struct OverlayMoreMenuIsland: View {
             Button {
                 viewModel.saveCurrentFrameToScreenshotsLocation()
             } label: {
-                Label("Save Screenshot to Desktop", systemImage: "square.and.arrow.down")
+                Label("Save Screenshot…", systemImage: "square.and.arrow.down")
             }
             .keyboardShortcut("s", modifiers: .command)
             .disabled(!viewModel.canSaveCurrentFrame)

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -53,7 +53,7 @@ struct OverlayMoreMenuIsland: View {
             Button {
                 viewModel.saveCurrentFrameToScreenshotsLocation()
             } label: {
-                Label("Save Screenshot…", systemImage: "square.and.arrow.down")
+                Label("Save Screenshot", systemImage: "square.and.arrow.down")
             }
             .keyboardShortcut("s", modifiers: .command)
             .disabled(!viewModel.canSaveCurrentFrame)

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -51,7 +51,7 @@ struct OverlayMoreMenuIsland: View {
     var body: some View {
         Menu {
             Button {
-                viewModel.saveCurrentFrameToDesktop()
+                viewModel.saveCurrentFrameToScreenshotsLocation()
             } label: {
                 Label("Save Screenshot to Desktop", systemImage: "square.and.arrow.down")
             }

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -395,12 +395,12 @@ class OverlayViewModel {
         onOpenSettings()
     }
 
-    func saveCurrentFrameToDesktop() {
+    func saveCurrentFrameToScreenshotsLocation() {
         guard let frame = displayedFrames[safe: selectedIndex] else { return }
         let buffer = frameBuffer
         Task { @MainActor in
             do {
-                let url = try await buffer.saveFrameToDesktop(frame)
+                let url = try await buffer.saveFrameToScreenshotsLocation(frame)
                 showSaveToast(OverlayToast(
                     icon: "checkmark.circle.fill",
                     title: "Saved to Desktop",
@@ -409,7 +409,7 @@ class OverlayViewModel {
                     revealURL: url
                 ))
             } catch {
-                overlayViewLogger.error("Failed to save frame to Desktop: \(error.localizedDescription)")
+                overlayViewLogger.error("Failed to save frame to screenshots location: \(error.localizedDescription)")
                 showSaveToast(OverlayToast(
                     icon: "exclamationmark.triangle.fill",
                     title: "Couldn't save screenshot",

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -403,7 +403,7 @@ class OverlayViewModel {
                 let url = try await buffer.saveFrameToScreenshotsLocation(frame)
                 showSaveToast(OverlayToast(
                     icon: "checkmark.circle.fill",
-                    title: "Saved to Desktop",
+                    title: savedToastTitle(for: url),
                     detail: url.lastPathComponent,
                     isError: false,
                     revealURL: url
@@ -419,6 +419,19 @@ class OverlayViewModel {
                 ))
             }
         }
+    }
+
+    /// Toast title for a successful save. Prefers "Saved to <FolderName>"
+    /// when the folder name is short and looks like a normal directory name;
+    /// falls back to plain "Saved" so we never overflow the toast width.
+    private func savedToastTitle(for url: URL) -> String {
+        let folderName = url.deletingLastPathComponent().lastPathComponent
+        let allowed = CharacterSet.alphanumerics.union(.whitespaces).union(CharacterSet(charactersIn: "-_."))
+        let isFriendly =
+            !folderName.isEmpty
+            && folderName.count <= 14
+            && folderName.unicodeScalars.allSatisfy { allowed.contains($0) }
+        return isFriendly ? "Saved to \(folderName)" : "Saved"
     }
 
     private func showSaveToast(_ toast: OverlayToast) {

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -176,7 +176,7 @@ class OverlayWindowController: NSObject {
             case .cycleDisplayBackward:
                 vm.cycleDisplay(forward: false)
             case .saveScreenshot:
-                vm.saveCurrentFrameToDesktop()
+                vm.saveCurrentFrameToScreenshotsLocation()
             case .openSettings:
                 vm.openSettings()
             }

--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -1,0 +1,116 @@
+//
+//  ScreenshotSaveLocationSettingsSection.swift
+//  JustNow
+//
+
+import AppKit
+import SwiftUI
+
+/// Settings section that lets the user pick a custom destination for
+/// screenshots saved from the rewind overlay (⌘S / "Save Screenshot…").
+///
+/// The control follows the resolution chain implemented in
+/// `ScreenshotSaveLocation.resolveLive`: an explicit override here wins over
+/// the macOS system screenshot location, which in turn wins over `~/Desktop`.
+struct ScreenshotSaveLocationSettingsSection: View {
+    @Binding var overridePath: String
+
+    /// Bumped on appear, when the override changes, and after picking a
+    /// folder, so the resolved path display refreshes against the live system
+    /// screenshot location.
+    @State private var refreshTick: Int = 0
+
+    private var resolvedURL: URL {
+        _ = refreshTick
+        return ScreenshotSaveLocation.resolveLive()
+    }
+
+    private var trimmedOverride: String {
+        overridePath.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            LabeledContent {
+                Text(displayPath(for: resolvedURL))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            } label: {
+                Text("Saving to")
+            }
+
+            if !trimmedOverride.isEmpty {
+                LabeledContent {
+                    Text(displayPath(for: URL(fileURLWithPath: (trimmedOverride as NSString).expandingTildeInPath, isDirectory: true)))
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                } label: {
+                    Text("Override")
+                }
+            }
+
+            HStack(spacing: 8) {
+                Button("Choose folder…") {
+                    chooseFolder()
+                }
+
+                Button("Use system default") {
+                    overridePath = ""
+                    refreshTick &+= 1
+                }
+                .disabled(trimmedOverride.isEmpty)
+
+                Spacer()
+            }
+
+            Text("Screenshots saved with ⌘S in rewind go to your override if it's set, otherwise to the macOS system screenshot folder, otherwise to your Desktop.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .onAppear { refreshTick &+= 1 }
+        .onChange(of: overridePath) { _, _ in refreshTick &+= 1 }
+    }
+
+    // MARK: - Actions
+
+    private func chooseFolder() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.canCreateDirectories = true
+        panel.prompt = "Choose"
+        panel.title = "Choose screenshot save location"
+
+        let trimmed = trimmedOverride
+        if !trimmed.isEmpty {
+            panel.directoryURL = URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath, isDirectory: true)
+        }
+
+        if panel.runModal() == .OK, let url = panel.url {
+            overridePath = url.path
+            refreshTick &+= 1
+        }
+    }
+
+    // MARK: - Display helpers
+
+    /// Render a URL as a path with `~` for the home directory, matching how
+    /// Finder and most macOS preferences surfaces show user paths.
+    private func displayPath(for url: URL) -> String {
+        let path = url.path
+        let home = NSHomeDirectory()
+        if path == home {
+            return "~"
+        }
+        if path.hasPrefix(home + "/") {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+}

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -24,6 +24,8 @@ struct SettingsView: View {
     @AppStorage(AppStorageKey.textGrabDebugPreviewEnabled) private var textGrabDebugPreviewEnabled: Bool = AppStorageDefault.textGrabDebugPreviewEnabled
     @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
     @AppStorage(AppStorageKey.hasSeenMenuBarHideInfo) private var hasSeenMenuBarHideInfo: Bool = AppStorageDefault.hasSeenMenuBarHideInfo
+    @AppStorage(AppStorageKey.screenshotSaveLocationOverride)
+    private var screenshotSaveLocationOverride: String = AppStorageDefault.screenshotSaveLocationOverride
     @State private var showHideIconInfoAlert: Bool = false
 
     var context: SettingsContext = SettingsContext()
@@ -128,6 +130,14 @@ struct SettingsView: View {
                     .fixedSize(horizontal: false, vertical: true)
             } header: {
                 Text("Rewind")
+            }
+
+            Section {
+                ScreenshotSaveLocationSettingsSection(
+                    overridePath: $screenshotSaveLocationOverride
+                )
+            } header: {
+                Text("Screenshot save location")
             }
 
             Section {

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -15,6 +15,7 @@ enum AppStorageKey {
     static let textGrabDebugPreviewEnabled = "textGrabDebugPreviewEnabled"
     static let showMenuBarIcon = "showMenuBarIcon"
     static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
+    static let screenshotSaveLocationOverride = "screenshotSaveLocationOverride"
 }
 
 enum AppStorageDefault {
@@ -32,4 +33,5 @@ enum AppStorageDefault {
     static let textGrabDebugPreviewEnabled = false
     static let showMenuBarIcon = true
     static let hasSeenMenuBarHideInfo = false
+    static let screenshotSaveLocationOverride = ""
 }

--- a/JustNow/Utilities/ScreenshotSaveLocation.swift
+++ b/JustNow/Utilities/ScreenshotSaveLocation.swift
@@ -1,0 +1,99 @@
+//
+//  ScreenshotSaveLocation.swift
+//  JustNow
+//
+
+import Foundation
+
+/// Pure inputs to the screenshot save-location resolver.
+///
+/// All fields are simple values rather than live `UserDefaults` snapshots so
+/// the resolver itself stays trivial to test (functional core).
+struct ScreenshotSaveLocationInputs: Equatable {
+    /// JustNow's own override path. Empty string = unset.
+    var overridePath: String
+
+    /// macOS' system screenshots `location` from `com.apple.screencapture`.
+    /// May be `nil`, tilde-prefixed, or absolute.
+    var systemLocationRaw: String?
+
+    /// Resolved Desktop URL (the ultimate fallback). Injected so tests can
+    /// avoid touching the real filesystem if they wish.
+    var desktopURL: URL
+}
+
+enum ScreenshotSaveLocation {
+    /// Resolve the directory that screenshots should be written to, in this
+    /// order, falling through on validation failure:
+    ///
+    /// 1. `overridePath` (JustNow setting) — empty string skips this.
+    /// 2. `systemLocationRaw` (macOS' screenshot `location` default).
+    /// 3. `desktopURL` (`~/Desktop`).
+    ///
+    /// `directoryExists` is the validation hook: it returns `true` when the
+    /// supplied URL points to an existing directory we can plausibly write
+    /// into. Tests can supply an in-memory predicate; production passes a
+    /// closure that defers to `FileManager`.
+    static func resolve(
+        inputs: ScreenshotSaveLocationInputs,
+        directoryExists: (URL) -> Bool
+    ) -> URL {
+        if let candidate = candidateFromOverride(inputs.overridePath),
+           directoryExists(candidate) {
+            return candidate
+        }
+
+        if let candidate = candidateFromSystemLocation(inputs.systemLocationRaw),
+           directoryExists(candidate) {
+            return candidate
+        }
+
+        return inputs.desktopURL
+    }
+
+    /// Live convenience that wires the pure resolver up to the real
+    /// `FileManager`, the running app's `UserDefaults`, and the system
+    /// `com.apple.screencapture` domain.
+    static func resolveLive(
+        defaults: UserDefaults = .standard,
+        fileManager: FileManager = .default
+    ) -> URL {
+        let override = defaults.string(forKey: AppStorageKey.screenshotSaveLocationOverride) ?? ""
+        let systemRaw = UserDefaults(suiteName: "com.apple.screencapture")?.string(forKey: "location")
+        let desktop = (try? fileManager.url(
+            for: .desktopDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: false
+        )) ?? URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Desktop", isDirectory: true)
+
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: override,
+            systemLocationRaw: systemRaw,
+            desktopURL: desktop
+        )
+
+        return resolve(inputs: inputs, directoryExists: { url in
+            var isDirectory: ObjCBool = false
+            let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            return exists && isDirectory.boolValue
+        })
+    }
+
+    // MARK: - Helpers
+
+    private static func candidateFromOverride(_ path: String) -> URL? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        return URL(fileURLWithPath: expandTilde(trimmed), isDirectory: true)
+    }
+
+    private static func candidateFromSystemLocation(_ raw: String?) -> URL? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return URL(fileURLWithPath: expandTilde(raw), isDirectory: true)
+    }
+
+    private static func expandTilde(_ raw: String) -> String {
+        (raw as NSString).expandingTildeInPath
+    }
+}

--- a/JustNow/Utilities/ScreenshotSaveLocation.swift
+++ b/JustNow/Utilities/ScreenshotSaveLocation.swift
@@ -28,7 +28,11 @@ enum ScreenshotSaveLocation {
     ///
     /// 1. `overridePath` (JustNow setting) — empty string skips this.
     /// 2. `systemLocationRaw` (macOS' screenshot `location` default).
-    /// 3. `desktopURL` (`~/Desktop`).
+    /// 3. `desktopURL` (`~/Desktop`) — the terminal fallback, returned even
+    ///    when validation rejects it. The downstream copy will surface a
+    ///    real filesystem error (and a "Couldn't save screenshot" toast) if
+    ///    the Desktop is somehow unwritable, which is preferable to looping
+    ///    or silently inventing another path.
     ///
     /// `directoryExists` is the validation hook: it returns `true` when the
     /// supplied URL points to an existing directory we can plausibly write
@@ -76,7 +80,8 @@ enum ScreenshotSaveLocation {
         return resolve(inputs: inputs, directoryExists: { url in
             var isDirectory: ObjCBool = false
             let exists = fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
-            return exists && isDirectory.boolValue
+            guard exists, isDirectory.boolValue else { return false }
+            return fileManager.isWritableFile(atPath: url.path)
         })
     }
 

--- a/JustNowTests/ScreenshotSaveLocationTests.swift
+++ b/JustNowTests/ScreenshotSaveLocationTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import JustNow
+
+final class ScreenshotSaveLocationTests: XCTestCase {
+    private let desktop = URL(fileURLWithPath: "/Users/test/Desktop", isDirectory: true)
+
+    /// Predicate that says only the supplied set of paths exist on disk.
+    private func onlyExisting(_ paths: [String]) -> (URL) -> Bool {
+        let set = Set(paths)
+        return { set.contains($0.path) }
+    }
+
+    func testFallsThroughToDesktopWhenAllSourcesEmpty() {
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: "",
+            systemLocationRaw: nil,
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting([desktop.path])
+        )
+
+        XCTAssertEqual(resolved, desktop)
+    }
+
+    func testFallsThroughToSystemLocationWhenOverrideMissing() {
+        let systemPath = "/Volumes/External/Screens"
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: "/Users/test/Nope",
+            systemLocationRaw: systemPath,
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting([systemPath, desktop.path])
+        )
+
+        XCTAssertEqual(resolved.path, systemPath)
+    }
+
+    func testExpandsTildeInSystemLocation() {
+        let homeRelative = "~/Pictures/Shots"
+        let expanded = (homeRelative as NSString).expandingTildeInPath
+
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: "",
+            systemLocationRaw: homeRelative,
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting([expanded, desktop.path])
+        )
+
+        XCTAssertEqual(resolved.path, expanded)
+    }
+
+    func testSystemAbsolutePathThatDoesNotExistFallsThroughToDesktop() {
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: "",
+            systemLocationRaw: "/no/such/folder",
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting([desktop.path])
+        )
+
+        XCTAssertEqual(resolved, desktop)
+    }
+
+    func testValidOverrideWinsOverEverything() {
+        let override = "/Users/test/CustomShots"
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: override,
+            systemLocationRaw: "/Users/test/Pictures",
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting([override, "/Users/test/Pictures", desktop.path])
+        )
+
+        XCTAssertEqual(resolved.path, override)
+    }
+
+    func testWhitespaceOnlyOverrideIsTreatedAsUnset() {
+        let inputs = ScreenshotSaveLocationInputs(
+            overridePath: "   ",
+            systemLocationRaw: "/Users/test/Pictures",
+            desktopURL: desktop
+        )
+
+        let resolved = ScreenshotSaveLocation.resolve(
+            inputs: inputs,
+            directoryExists: onlyExisting(["/Users/test/Pictures", desktop.path])
+        )
+
+        XCTAssertEqual(resolved.path, "/Users/test/Pictures")
+    }
+}


### PR DESCRIPTION
Closes #26.

## Summary

Lets users customise where ⌘S in the rewind overlay saves screenshots.

The destination is resolved by a small pure helper, in this order:

1. **JustNow override** — an absolute path stored under the new `screenshotSaveLocationOverride` AppStorage key (empty = unset).
2. **macOS system screenshot location** — `com.apple.screencapture`'s `location` default (tilde-expanded).
3. **`~/Desktop`** — the existing default.

Each candidate is validated as an existing directory before use; the resolver falls through on validation failure. The pure core takes a `ScreenshotSaveLocationInputs` snapshot in and returns a `URL`, with a thin `resolveLive(...)` wrapper that wires it to `UserDefaults` / `FileManager` so the helper itself stays hermetic and testable.

### Renames (no behaviour change)

* `FrameStore.copyFrameToDesktop(id:timestamp:)` → `copyFrameToScreenshotsLocation(id:timestamp:)`
* `FrameBuffer.saveFrameToDesktop(_:)` → `saveFrameToScreenshotsLocation(_:)`
* `OverlayViewModel.saveCurrentFrameToDesktop()` → `saveCurrentFrameToScreenshotsLocation()`

### Settings UI

A new **Screenshot save location** section in the Settings window:

* a read-only "Saving to" row showing the currently resolved path (with `~` for the home folder),
* an "Override" row listing the explicit path when one is set,
* **Choose folder…** (`NSOpenPanel`, `canChooseDirectories = true`, `canChooseFiles = false`),
* **Use system default** to clear the override,
* helper text explaining the override → system → Desktop chain.

### Copy changes

* The overlay "More actions" menu item is now **Save Screenshot…** (the destination is no longer in the label since it can vary).
* The success toast is destination-aware: **Saved to <FolderName>** when the folder name is short and conventional (e.g. *Saved to Pictures*, *Saved to Desktop*); falls back to plain **Saved** otherwise to keep the toast width bounded. The filename still appears in the toast detail.

## Test plan

- [x] `xcodebuild ... build` succeeds.
- [x] `xcodebuild ... build-for-testing` succeeds (test execution skipped due to known local Team ID mismatch on the test bundle — tests compile).
- [x] Resolution chain unit tests cover: all sources empty → Desktop; override set to missing path → falls to system; tilde-prefixed system path expands; system absolute path that doesn't exist → Desktop; valid override wins; whitespace-only override treated as unset.
- [ ] Manual: set a custom folder via Settings → Choose folder…, save with ⌘S, verify the file lands there and toast reads *Saved to <FolderName>*.
- [ ] Manual: clear the override, set the macOS Screenshot menu's "Save to" to a non-Desktop folder (e.g. Pictures), save with ⌘S, verify the file lands in that folder.
- [ ] Manual: clear both, save with ⌘S, verify the file lands on the Desktop.