### PR TITLE
Improve overlay search and capture startup

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -264,85 +264,101 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         setupCaptureTask?.cancel()
         setupCaptureTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            defer { self.setupCaptureTask = nil }
+            await self.runSetupCapture()
+        }
+    }
 
-            // Initialize frame buffer (loads persisted frames from disk)
-            do {
-                let retentionPolicy = self.currentRetentionPolicy()
-                let buffer = try await FrameBuffer(retentionPolicy: retentionPolicy)
-                guard !Task.isCancelled else { return }
+    private func runSetupCapture() async {
+        defer { setupCaptureTask = nil }
 
-                self.frameBuffer = buffer
-                self.lastAppliedRetentionPolicy = retentionPolicy
-                self.settingsContext.frameBuffer = buffer
+        do {
+            try await initializeFrameBufferForStartup()
+        } catch {
+            handleFrameBufferInitializationFailure(error)
+            return
+        }
 
-                let loadedCount = buffer.frameCount
-                if loadedCount > 0 {
-                    captureLogger.info("Loaded \(loadedCount, privacy: .public) frames from disk")
-                }
-            } catch {
-                if error is CancellationError || Task.isCancelled {
-                    return
-                }
-                captureLogger.error("Failed to initialize frame buffer: \(error.localizedDescription, privacy: .public)")
-                // Show error but don't quit
-                self.showErrorAlert(error)
-                return
-            }
+        guard !Task.isCancelled else { return }
 
+        configureCaptureStartupCoordinator()
+
+        guard captureEventController.canStartCapture() else {
+            applyBlockedCaptureStatusIfAvailable()
+            return
+        }
+
+        await startCaptureForLaunchState()
+    }
+
+    private func initializeFrameBufferForStartup() async throws {
+        let retentionPolicy = currentRetentionPolicy()
+        let buffer = try await FrameBuffer(retentionPolicy: retentionPolicy)
+        guard !Task.isCancelled else { return }
+
+        frameBuffer = buffer
+        lastAppliedRetentionPolicy = retentionPolicy
+        settingsContext.frameBuffer = buffer
+        logLoadedFrameCount(buffer.frameCount)
+    }
+
+    private func handleFrameBufferInitializationFailure(_ error: Error) {
+        guard !(error is CancellationError), !Task.isCancelled else { return }
+        captureLogger.error("Failed to initialize frame buffer: \(error.localizedDescription, privacy: .public)")
+        // Show error but don't quit
+        showErrorAlert(error)
+    }
+
+    private func logLoadedFrameCount(_ loadedCount: Int) {
+        guard loadedCount > 0 else { return }
+        captureLogger.info("Loaded \(loadedCount, privacy: .public) frames from disk")
+    }
+
+    private func configureCaptureStartupCoordinator() {
+        captureCoordinator.delegate = self
+        applyCapturePolicy(currentCapturePolicy())
+    }
+
+    private func applyCapturePolicy(_ policy: CapturePolicy) {
+        captureCoordinator.updateCaptureInterval(policy.interval)
+        captureCoordinator.updateCaptureScale(policy.scale)
+        frameBuffer?.updateSaveOptions(
+            policy.saveOptions,
+            duplicatePolicy: policy.duplicatePolicy
+        )
+        frameBuffer?.updateOCRIndexingPolicy(policy.ocrIndexingPolicy)
+    }
+
+    private func startCaptureForLaunchState() async {
+        switch resolveLaunchPermissionState() {
+        case .granted:
+            await startCaptureForGrantedLaunchPermission()
+        case .requestedThisLaunch:
+            // Intro alert first — clicking "Open System Settings" fires the Permiso
+            // coach, so users who dismiss the alert aren't surprised by a floating
+            // panel appearing over System Settings out of nowhere.
+            presentPermissionAlert(status: "Awaiting Permission")
+        case .deniedPreviously:
+            presentPermissionAlert(status: "No Permission")
+        }
+    }
+
+    private func startCaptureForGrantedLaunchPermission() async {
+        do {
+            try await captureCoordinator.startCapture()
             guard !Task.isCancelled else { return }
-
-            self.captureCoordinator.delegate = self
-            let preflightPolicy = self.currentCapturePolicy()
-            self.captureCoordinator.updateCaptureInterval(preflightPolicy.interval)
-            self.captureCoordinator.updateCaptureScale(preflightPolicy.scale)
-            self.frameBuffer?.updateSaveOptions(
-                preflightPolicy.saveOptions,
-                duplicatePolicy: preflightPolicy.duplicatePolicy
-            )
-            self.frameBuffer?.updateOCRIndexingPolicy(preflightPolicy.ocrIndexingPolicy)
-
-            guard self.captureEventController.canStartCapture() else {
-                if let blockedStatus = self.captureEventController.blockedStatus() {
-                    self.updateCaptureStatus(blockedStatus)
-                }
+            guard captureEventController.canStartCapture() else {
+                await captureCoordinator.stopCapture()
+                applyBlockedCaptureStatusIfAvailable()
                 return
             }
-
-            switch self.resolveLaunchPermissionState() {
-            case .granted:
-                do {
-                    try await self.captureCoordinator.startCapture()
-                    guard !Task.isCancelled else { return }
-                    guard self.captureEventController.canStartCapture() else {
-                        await self.captureCoordinator.stopCapture()
-                        if let blockedStatus = self.captureEventController.blockedStatus() {
-                            self.updateCaptureStatus(blockedStatus)
-                        }
-                        return
-                    }
-                    self.updateCaptureStatus("Active")
-                    self.capturePolicyController.resetAppliedPolicy()
-                    self.updateCapturePolicy()
-                } catch is CancellationError {
-                    return
-                } catch CaptureError.permissionDenied {
-                    self.updateCaptureStatus("No Permission")
-                    self.showPermissionAlert()
-                } catch {
-                    self.updateCaptureStatus("Error")
-                    self.showErrorAlert(error)
-                }
-            case .requestedThisLaunch:
-                self.updateCaptureStatus("Awaiting Permission")
-                // Intro alert first — clicking "Open System Settings" fires the Permiso
-                // coach, so users who dismiss the alert aren't surprised by a floating
-                // panel appearing over System Settings out of nowhere.
-                self.showPermissionAlert()
-            case .deniedPreviously:
-                self.updateCaptureStatus("No Permission")
-                self.showPermissionAlert()
-            }
+            handleSuccessfulCaptureStart()
+        } catch is CancellationError {
+            return
+        } catch CaptureError.permissionDenied {
+            presentPermissionAlert(status: "No Permission")
+        } catch {
+            updateCaptureStatus("Error")
+            showErrorAlert(error)
         }
     }
 
@@ -487,16 +503,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 applyBlockedCaptureStatusIfAvailable()
                 return false
             }
-            updateCaptureStatus("Active")
-            capturePolicyController.resetAppliedPolicy()
-            updateCapturePolicy()
-            captureLogger.info("\(successMessage, privacy: .public)")
+            handleSuccessfulCaptureStart(successMessage: successMessage)
             return true
         } catch is CancellationError {
             return false
         } catch CaptureError.permissionDenied {
-            updateCaptureStatus("No Permission")
-            showPermissionAlert()
+            presentPermissionAlert(status: "No Permission")
             return false
         } catch {
             captureLogger.error("\(failurePrefix, privacy: .public): \(error.localizedDescription, privacy: .public)")
@@ -508,6 +520,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     private func applyBlockedCaptureStatusIfAvailable() {
         if let blockedStatus = captureEventController.blockedStatus() {
             updateCaptureStatus(blockedStatus)
+        }
+    }
+
+    private func handleSuccessfulCaptureStart(successMessage: String? = nil) {
+        updateCaptureStatus("Active")
+        capturePolicyController.resetAppliedPolicy()
+        updateCapturePolicy()
+        if let successMessage {
+            captureLogger.info("\(successMessage, privacy: .public)")
         }
     }
 
@@ -813,6 +834,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     private func updatePermissionHelpMenuItem() {
         let needsPermissionHelp = !ScreenCaptureManager.hasScreenRecordingPermission()
         statusItemController?.setPermissionHelpVisible(needsPermissionHelp)
+    }
+
+    private func presentPermissionAlert(status: String, force: Bool = false) {
+        updateCaptureStatus(status)
+        showPermissionAlert(force: force)
     }
 
     private func showPermissionAlert(force: Bool = false) {

--- a/JustNow/Capture/CaptureEventController.swift
+++ b/JustNow/Capture/CaptureEventController.swift
@@ -33,7 +33,7 @@ final class CaptureEventController {
         enableBlackFrameFilter: @escaping (TimeInterval) -> Void,
         endForegroundActivity: @escaping () -> Void,
         updatePauseMenu: @escaping (Bool) -> Void,
-        logger: @escaping (String) -> Void = { captureLogger.info("\($0, privacy: .public)") }
+        logger: ((String) -> Void)? = nil
     ) {
         self.context = context
         self.scheduleStart = scheduleStart
@@ -43,7 +43,9 @@ final class CaptureEventController {
         self.enableBlackFrameFilter = enableBlackFrameFilter
         self.endForegroundActivity = endForegroundActivity
         self.updatePauseMenu = updatePauseMenu
-        self.logger = logger
+        self.logger = logger ?? { message in
+            captureLogger.info("\(message, privacy: .public)")
+        }
     }
 
     var isUserPaused: Bool {

--- a/JustNow/Capture/CaptureStopController.swift
+++ b/JustNow/Capture/CaptureStopController.swift
@@ -24,12 +24,14 @@ final class CaptureStopController {
         updateStatus: @escaping (String) -> Void,
         stopCapture: @escaping () async -> Void,
         endForegroundActivity: @escaping () -> Void,
-        logger: @escaping (String) -> Void = { captureLogger.info("\($0, privacy: .public)") }
+        logger: ((String) -> Void)? = nil
     ) {
         self.updateStatus = updateStatus
         self.stopCapture = stopCapture
         self.endForegroundActivity = endForegroundActivity
-        self.logger = logger
+        self.logger = logger ?? { message in
+            captureLogger.info("\(message, privacy: .public)")
+        }
     }
 
     func scheduleStop(_ request: CaptureStopRequest) {

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -91,6 +91,7 @@ private final class CachedCGImageBox {
 @MainActor
 class FrameBuffer {
     private var frames: [StoredFrame] = []
+    private var frameLookup: [UUID: StoredFrame] = [:]
     private let frameStore: FrameStore
     private let retentionManager: RetentionManager
     private let blackFrameDetector = BlackFrameDetector.screenOff
@@ -211,7 +212,22 @@ class FrameBuffer {
     }
 
     func containsFrame(id: UUID) -> Bool {
-        frames.contains { $0.id == id }
+        frameLookup[id] != nil
+    }
+
+    /// Return frames for the provided IDs in the same order as the IDs.
+    func frames(withIDs ids: [UUID]) -> [StoredFrame] {
+        guard !ids.isEmpty else { return [] }
+
+        var matchedFrames: [StoredFrame] = []
+        matchedFrames.reserveCapacity(ids.count)
+
+        for id in ids {
+            guard let frame = frameLookup[id] else { continue }
+            matchedFrames.append(frame)
+        }
+
+        return matchedFrames
     }
 
     func cacheOCRTextIfCurrent(_ text: String, for frame: StoredFrame) async -> Bool {
@@ -427,6 +443,7 @@ class FrameBuffer {
         cancelBackgroundOCRIndexing(clearQueue: true)
         try await frameStore.clear()
         frames.removeAll()
+        frameLookup.removeAll()
         thumbnailCache.removeAllObjects()
         fullImageCache.removeAllObjects()
         inFlightFullImageLoads.removeAll()
@@ -472,8 +489,7 @@ class FrameBuffer {
 
     private func loadPersistedFrames() async {
         let metadata = await frameStore.getAllMetadata()
-
-        frames = metadata
+        let persistedFrames = metadata
             .sorted { $0.timestamp < $1.timestamp }
             .map {
                 StoredFrame(
@@ -484,6 +500,8 @@ class FrameBuffer {
                     displayName: $0.displayName
                 )
             }
+        frames = persistedFrames
+        frameLookup = Dictionary(uniqueKeysWithValues: persistedFrames.map { ($0.id, $0) })
     }
 
     func enableBlackFrameFilter(for seconds: TimeInterval) {
@@ -699,6 +717,9 @@ class FrameBuffer {
         do {
             try await frameStore.pruneFrames(ids: toPrune)
             frames.removeAll { toPrune.contains($0.id) }
+            for id in toPrune {
+                frameLookup.removeValue(forKey: id)
+            }
             removeQueuedOCRFrames(ids: toPrune)
             let validIDs = Set(frames.map { $0.id })
             await textCache.prune(keepingFrameIDs: validIDs)
@@ -743,6 +764,7 @@ class FrameBuffer {
 
     private func recordStoredFrame(_ frame: StoredFrame) {
         frames.insert(frame, at: frameInsertionIndex(for: frame.timestamp))
+        frameLookup[frame.id] = frame
     }
 
     private func enqueueFrameForBackgroundOCR(_ frame: StoredFrame) {

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -466,7 +466,7 @@ class OverlayViewModel {
                 markQualityInfoPendingIfNeeded()
             } catch {
                 overlayViewLogger.error(
-                    "Failed screenshot save (\(operationName, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+                    "Failed screenshot save (\(operationName, privacy: .public)): \(error.localizedDescription, privacy: .private)"
                 )
                 showSaveToast(makeErrorToast(error))
             }

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -424,24 +424,16 @@ class OverlayViewModel {
     func saveCurrentFrameToScreenshotsLocation() {
         guard let frame = displayedFrames[safe: selectedIndex] else { return }
         let buffer = frameBuffer
-        let destinations = currentSaveDestinations()
-        Task { @MainActor in
-            do {
-                var savedURL: URL? = nil
-                if destinations.toFolder {
-                    savedURL = try await buffer.saveFrameToScreenshotsLocation(frame)
-                }
-                if destinations.toClipboard {
-                    let image = try await buffer.getFullImage(for: frame)
-                    Self.copyImageToClipboard(image)
-                }
-                playSavedSoundIfNeeded()
-                showSaveToast(makeSuccessToast(savedURL: savedURL, destinations: destinations))
-                markQualityInfoPendingIfNeeded()
-            } catch {
-                overlayViewLogger.error("Failed to save frame to screenshots location: \(error.localizedDescription)")
-                showSaveToast(makeErrorToast(error))
+        performScreenshotSave(operationName: "current frame") { destinations in
+            var savedURL: URL? = nil
+            if destinations.toFolder {
+                savedURL = try await buffer.saveFrameToScreenshotsLocation(frame)
             }
+            if destinations.toClipboard {
+                let image = try await buffer.getFullImage(for: frame)
+                Self.copyImageToClipboard(image)
+            }
+            return savedURL
         }
     }
 
@@ -449,21 +441,33 @@ class OverlayViewModel {
     /// drag-to-region path when ⌘ is held during the drag.
     func saveCroppedScreenshot(image: CGImage) {
         let buffer = frameBuffer
+        performScreenshotSave(operationName: "cropped region") { destinations in
+            var savedURL: URL? = nil
+            if destinations.toFolder {
+                savedURL = try await buffer.saveCroppedImageToScreenshotsLocation(image)
+            }
+            if destinations.toClipboard {
+                Self.copyImageToClipboard(image)
+            }
+            return savedURL
+        }
+    }
+
+    private func performScreenshotSave(
+        operationName: String,
+        operation: @escaping (_ destinations: SaveDestinations) async throws -> URL?
+    ) {
         let destinations = currentSaveDestinations()
         Task { @MainActor in
             do {
-                var savedURL: URL? = nil
-                if destinations.toFolder {
-                    savedURL = try await buffer.saveCroppedImageToScreenshotsLocation(image)
-                }
-                if destinations.toClipboard {
-                    Self.copyImageToClipboard(image)
-                }
+                let savedURL = try await operation(destinations)
                 playSavedSoundIfNeeded()
                 showSaveToast(makeSuccessToast(savedURL: savedURL, destinations: destinations))
                 markQualityInfoPendingIfNeeded()
             } catch {
-                overlayViewLogger.error("Failed to save cropped screenshot: \(error.localizedDescription)")
+                overlayViewLogger.error(
+                    "Failed screenshot save (\(operationName, privacy: .public)): \(error.localizedDescription, privacy: .public)"
+                )
                 showSaveToast(makeErrorToast(error))
             }
         }
@@ -688,12 +692,10 @@ class OverlayViewModel {
 
             guard !Task.isCancelled else { return }
 
-            let allFrames = buffer.getFrames()
-            let frameByID = Dictionary(uniqueKeysWithValues: allFrames.map { ($0.id, $0) })
+            let matchedFrames = buffer.frames(withIDs: matchedIDs)
             var results: [StoredFrame] = []
-            results.reserveCapacity(matchedIDs.count)
-            for matchedID in matchedIDs {
-                guard let frame = frameByID[matchedID] else { continue }
+            results.reserveCapacity(matchedFrames.count)
+            for frame in matchedFrames {
                 if let activeDisplayID {
                     if let frameDisplayID = frame.displayID {
                         guard frameDisplayID == activeDisplayID else { continue }

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -1,46 +1,46 @@
 import Foundation
 
 enum AppStorageKey {
-    static let captureInterval = "captureInterval"
-    static let rewindHistorySeconds = "rewindHistorySeconds"
-    static let recentTimelineWindowSeconds = "recentTimelineWindowSeconds"
-    static let reduceCaptureOnBattery = "reduceCaptureOnBattery"
-    static let shortcutKeyCode = "shortcutKeyCode"
-    static let shortcutModifiers = "shortcutModifiers"
-    static let capturePauseShortcutKeyCode = "capturePauseShortcutKeyCode"
-    static let capturePauseShortcutModifiers = "capturePauseShortcutModifiers"
-    static let overlayDismissKeyCode = "overlayDismissKeyCode"
-    static let overlayDismissModifiers = "overlayDismissModifiers"
-    static let textGrabSoundEnabled = "textGrabSoundEnabled"
-    static let saveScreenshotSoundEnabled = "saveScreenshotSoundEnabled"
-    static let textGrabDebugPreviewEnabled = "textGrabDebugPreviewEnabled"
-    static let showMenuBarIcon = "showMenuBarIcon"
-    static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
-    static let screenshotSaveLocationOverride = "screenshotSaveLocationOverride"
-    static let screenshotSaveToFolder = "screenshotSaveToFolder"
-    static let screenshotSaveToClipboard = "screenshotSaveToClipboard"
-    static let hasSeenSaveQualityInfo = "hasSeenSaveQualityInfo"
-    static let regionScreenshotShortcutHintCount = "regionScreenshotShortcutHintCount"
+    nonisolated static let captureInterval = "captureInterval"
+    nonisolated static let rewindHistorySeconds = "rewindHistorySeconds"
+    nonisolated static let recentTimelineWindowSeconds = "recentTimelineWindowSeconds"
+    nonisolated static let reduceCaptureOnBattery = "reduceCaptureOnBattery"
+    nonisolated static let shortcutKeyCode = "shortcutKeyCode"
+    nonisolated static let shortcutModifiers = "shortcutModifiers"
+    nonisolated static let capturePauseShortcutKeyCode = "capturePauseShortcutKeyCode"
+    nonisolated static let capturePauseShortcutModifiers = "capturePauseShortcutModifiers"
+    nonisolated static let overlayDismissKeyCode = "overlayDismissKeyCode"
+    nonisolated static let overlayDismissModifiers = "overlayDismissModifiers"
+    nonisolated static let textGrabSoundEnabled = "textGrabSoundEnabled"
+    nonisolated static let saveScreenshotSoundEnabled = "saveScreenshotSoundEnabled"
+    nonisolated static let textGrabDebugPreviewEnabled = "textGrabDebugPreviewEnabled"
+    nonisolated static let showMenuBarIcon = "showMenuBarIcon"
+    nonisolated static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
+    nonisolated static let screenshotSaveLocationOverride = "screenshotSaveLocationOverride"
+    nonisolated static let screenshotSaveToFolder = "screenshotSaveToFolder"
+    nonisolated static let screenshotSaveToClipboard = "screenshotSaveToClipboard"
+    nonisolated static let hasSeenSaveQualityInfo = "hasSeenSaveQualityInfo"
+    nonisolated static let regionScreenshotShortcutHintCount = "regionScreenshotShortcutHintCount"
 }
 
 enum AppStorageDefault {
-    static let captureInterval = 0.5
-    static let rewindHistorySeconds = RewindHistoryOption.defaultValue.rawValue
-    static let recentTimelineWindowSeconds = RecentTimelineWindow.defaultValue.rawValue
-    static let reduceCaptureOnBattery = true
-    static let shortcutKeyCode = 38  // J key
-    static let shortcutModifiers = 1_572_864  // ⌘⌥
-    static let capturePauseShortcutKeyCode = 38  // J key
-    static let capturePauseShortcutModifiers = 1_703_936  // ⌘⌥⇧
-    static let overlayDismissKeyCode = 53
-    static let overlayDismissModifiers = 0
-    static let textGrabSoundEnabled = true
-    static let saveScreenshotSoundEnabled = true
-    static let textGrabDebugPreviewEnabled = false
-    static let showMenuBarIcon = true
-    static let hasSeenMenuBarHideInfo = false
-    static let screenshotSaveLocationOverride = ""
-    static let screenshotSaveToFolder = true
-    static let screenshotSaveToClipboard = false
-    static let hasSeenSaveQualityInfo = false
+    nonisolated static let captureInterval = 0.5
+    nonisolated static let rewindHistorySeconds = RewindHistoryOption.defaultValue.rawValue
+    nonisolated static let recentTimelineWindowSeconds = RecentTimelineWindow.defaultValue.rawValue
+    nonisolated static let reduceCaptureOnBattery = true
+    nonisolated static let shortcutKeyCode = 38  // J key
+    nonisolated static let shortcutModifiers = 1_572_864  // ⌘⌥
+    nonisolated static let capturePauseShortcutKeyCode = 38  // J key
+    nonisolated static let capturePauseShortcutModifiers = 1_703_936  // ⌘⌥⇧
+    nonisolated static let overlayDismissKeyCode = 53
+    nonisolated static let overlayDismissModifiers = 0
+    nonisolated static let textGrabSoundEnabled = true
+    nonisolated static let saveScreenshotSoundEnabled = true
+    nonisolated static let textGrabDebugPreviewEnabled = false
+    nonisolated static let showMenuBarIcon = true
+    nonisolated static let hasSeenMenuBarHideInfo = false
+    nonisolated static let screenshotSaveLocationOverride = ""
+    nonisolated static let screenshotSaveToFolder = true
+    nonisolated static let screenshotSaveToClipboard = false
+    nonisolated static let hasSeenSaveQualityInfo = false
 }

--- a/JustNow/Utilities/Permiso/PermisoAssistant.swift
+++ b/JustNow/Utilities/Permiso/PermisoAssistant.swift
@@ -22,7 +22,18 @@ final class PermisoAssistant {
 
     func present(
         panel: PermisoPanel,
-        hostApp: PermisoHostApp = .current(),
+        sourceFrameInScreen: CGRect? = nil
+    ) {
+        present(
+            panel: panel,
+            hostApp: .current(),
+            sourceFrameInScreen: sourceFrameInScreen
+        )
+    }
+
+    func present(
+        panel: PermisoPanel,
+        hostApp: PermisoHostApp,
         sourceFrameInScreen: CGRect? = nil
     ) {
         dismiss()
@@ -62,8 +73,9 @@ final class PermisoAssistant {
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshPosition()
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.refreshPosition()
             }
         }
         refreshPosition()
@@ -107,8 +119,9 @@ final class PermisoAssistant {
     private func ensurePolling() {
         guard trackingTimer == nil else { return }
         trackingTimer = Timer.scheduledTimer(withTimeInterval: 0.15, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.refreshPosition()
+            guard let self else { return }
+            MainActor.assumeIsolated {
+                self.refreshPosition()
             }
         }
     }

--- a/JustNow/Utilities/ScreenshotSaveLocation.swift
+++ b/JustNow/Utilities/ScreenshotSaveLocation.swift
@@ -38,7 +38,7 @@ enum ScreenshotSaveLocation {
     /// supplied URL points to an existing directory we can plausibly write
     /// into. Tests can supply an in-memory predicate; production passes a
     /// closure that defers to `FileManager`.
-    static func resolve(
+    nonisolated static func resolve(
         inputs: ScreenshotSaveLocationInputs,
         directoryExists: (URL) -> Bool
     ) -> URL {
@@ -58,7 +58,7 @@ enum ScreenshotSaveLocation {
     /// Live convenience that wires the pure resolver up to the real
     /// `FileManager`, the running app's `UserDefaults`, and the system
     /// `com.apple.screencapture` domain.
-    static func resolveLive(
+    nonisolated static func resolveLive(
         defaults: UserDefaults = .standard,
         fileManager: FileManager = .default
     ) -> URL {
@@ -87,18 +87,18 @@ enum ScreenshotSaveLocation {
 
     // MARK: - Helpers
 
-    private static func candidateFromOverride(_ path: String) -> URL? {
+    nonisolated private static func candidateFromOverride(_ path: String) -> URL? {
         let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
         return URL(fileURLWithPath: expandTilde(trimmed), isDirectory: true)
     }
 
-    private static func candidateFromSystemLocation(_ raw: String?) -> URL? {
+    nonisolated private static func candidateFromSystemLocation(_ raw: String?) -> URL? {
         guard let raw, !raw.isEmpty else { return nil }
         return URL(fileURLWithPath: expandTilde(raw), isDirectory: true)
     }
 
-    private static func expandTilde(_ raw: String) -> String {
+    nonisolated private static func expandTilde(_ raw: String) -> String {
         (raw as NSString).expandingTildeInPath
     }
 }


### PR DESCRIPTION
## Summary
- speed up overlay search lookups by reusing indexed frame access from `FrameBuffer`
- remove the remaining Swift concurrency warnings in the capture, screenshot-save, and Permiso paths
- split `AppDelegate` capture startup into smaller helpers so launch-time setup is easier to follow

## Testing
- `xcodebuild test -scheme JustNow -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY='' -derivedDataPath build-appdelegate-refactor`
- `./Scripts/local-install-app.sh`
