### PR TITLE
[codex] Align macOS settings row layout

### DIFF
--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -31,6 +31,16 @@ struct ScreenshotSaveLocationSettingsSection: View {
         overridePath.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    private var overrideURL: URL? {
+        guard !trimmedOverride.isEmpty else { return nil }
+        return URL(fileURLWithPath: (trimmedOverride as NSString).expandingTildeInPath, isDirectory: true)
+    }
+
+    private var isUsingOverride: Bool {
+        guard let overrideURL else { return false }
+        return resolvedURL.standardizedFileURL == overrideURL.standardizedFileURL
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             Toggle("Save to folder", isOn: $saveToFolder)
@@ -49,26 +59,22 @@ struct ScreenshotSaveLocationSettingsSection: View {
                 }
 
             if saveToFolder {
-                LabeledContent {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Saving to")
+
                     Text(displayPath(for: resolvedURL))
                         .lineLimit(1)
                         .truncationMode(.middle)
                         .foregroundStyle(.secondary)
                         .textSelection(.enabled)
-                } label: {
-                    Text("Saving to")
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
 
-                if !trimmedOverride.isEmpty {
-                    LabeledContent {
-                        Text(displayPath(for: URL(fileURLWithPath: (trimmedOverride as NSString).expandingTildeInPath, isDirectory: true)))
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-                            .foregroundStyle(.secondary)
-                            .textSelection(.enabled)
-                    } label: {
-                        Text("Override")
-                    }
+                if overrideURL != nil && !isUsingOverride {
+                    Text("The selected custom folder is unavailable, so JustNow is using the system screenshot location.")
+                        .font(.caption)
+                        .foregroundStyle(.orange)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
 
                 HStack(spacing: 8) {

--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -42,7 +42,7 @@ struct ScreenshotSaveLocationSettingsSection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        Group {
             Toggle("Save to folder", isOn: $saveToFolder)
                 .onChange(of: saveToFolder) { _, newValue in
                     if !newValue && !saveToClipboard {

--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -16,6 +16,7 @@ struct ScreenshotSaveLocationSettingsSection: View {
     @Binding var overridePath: String
     @Binding var saveToFolder: Bool
     @Binding var saveToClipboard: Bool
+    @Binding var saveScreenshotSoundEnabled: Bool
 
     /// Bumped on appear, when the override changes, and after picking a
     /// folder, so the resolved path display refreshes against the live system
@@ -57,38 +58,41 @@ struct ScreenshotSaveLocationSettingsSection: View {
                         saveToFolder = true
                     }
                 }
+            Toggle("Play sound when saving screenshot", isOn: $saveScreenshotSoundEnabled)
 
             if saveToFolder {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Saving to")
+                VStack(alignment: .leading, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Saving to")
 
-                    Text(displayPath(for: resolvedURL))
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
+                        Text(displayPath(for: resolvedURL))
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                if overrideURL != nil && !isUsingOverride {
-                    Text("The selected custom folder is unavailable, so JustNow is using the system screenshot location.")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                HStack(spacing: 8) {
-                    Button("Choose folder…") {
-                        chooseFolder()
+                    if overrideURL != nil && !isUsingOverride {
+                        Text("The selected custom folder is unavailable, so JustNow is using the system screenshot location.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
 
-                    Button("Use system default") {
-                        overridePath = ""
-                        refreshTick &+= 1
-                    }
-                    .disabled(trimmedOverride.isEmpty)
+                    HStack(spacing: 8) {
+                        Button("Choose folder…") {
+                            chooseFolder()
+                        }
 
-                    Spacer()
+                        Button("Use system default") {
+                            overridePath = ""
+                            refreshTick &+= 1
+                        }
+                        .disabled(trimmedOverride.isEmpty)
+
+                        Spacer()
+                    }
                 }
             }
 

--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -37,14 +37,18 @@ struct ScreenshotSaveLocationSettingsSection: View {
         return URL(fileURLWithPath: (trimmedOverride as NSString).expandingTildeInPath, isDirectory: true)
     }
 
-    private var isUsingOverride: Bool {
+    private func isUsingOverride(resolvedURL: URL) -> Bool {
         guard let overrideURL else { return false }
         return resolvedURL.standardizedFileURL == overrideURL.standardizedFileURL
     }
 
     var body: some View {
+        let resolvedURL = resolvedURL
+
         Group {
             Toggle("Save to folder", isOn: $saveToFolder)
+                .onAppear { refreshTick &+= 1 }
+                .onChange(of: overridePath) { _, _ in refreshTick &+= 1 }
                 .onChange(of: saveToFolder) { _, newValue in
                     if !newValue && !saveToClipboard {
                         // Don't allow both off — turn clipboard on so a
@@ -73,8 +77,8 @@ struct ScreenshotSaveLocationSettingsSection: View {
                     }
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                    if overrideURL != nil && !isUsingOverride {
-                        Text("The selected custom folder is unavailable, so JustNow is using the system screenshot location.")
+                    if overrideURL != nil && !isUsingOverride(resolvedURL: resolvedURL) {
+                        Text("The selected custom folder is unavailable, so JustNow is using the folder shown above.")
                             .font(.caption)
                             .foregroundStyle(.orange)
                             .fixedSize(horizontal: false, vertical: true)
@@ -101,8 +105,6 @@ struct ScreenshotSaveLocationSettingsSection: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
         }
-        .onAppear { refreshTick &+= 1 }
-        .onChange(of: overridePath) { _, _ in refreshTick &+= 1 }
     }
 
     private var captionText: String {

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -481,11 +481,11 @@ struct SettingsView: View {
 
     @ViewBuilder
     private func shortcutRow<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
-        HStack(alignment: .center, spacing: 16) {
-            Text(title)
-            Spacer(minLength: 16)
+        LabeledContent {
             content()
                 .frame(width: 240, alignment: .trailing)
+        } label: {
+            Text(title)
         }
     }
 

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -139,10 +139,9 @@ struct SettingsView: View {
                 ScreenshotSaveLocationSettingsSection(
                     overridePath: $screenshotSaveLocationOverride,
                     saveToFolder: $screenshotSaveToFolder,
-                    saveToClipboard: $screenshotSaveToClipboard
+                    saveToClipboard: $screenshotSaveToClipboard,
+                    saveScreenshotSoundEnabled: $saveScreenshotSoundEnabled
                 )
-
-                Toggle("Play sound when saving screenshot", isOn: $saveScreenshotSoundEnabled)
             } header: {
                 Text("Screenshot save location")
             }

--- a/JustNow/UI/StatusItemController.swift
+++ b/JustNow/UI/StatusItemController.swift
@@ -276,7 +276,7 @@ final class StatusItemController: NSObject, NSMenuDelegate {
 
         menu.addItem(.separator())
 
-        let settingsItem = NSMenuItem(title: "Settings...", action: #selector(handleShowSettings), keyEquivalent: ",")
+        let settingsItem = NSMenuItem(title: "Settings…", action: #selector(handleShowSettings), keyEquivalent: ",")
         settingsItem.target = self
         menu.addItem(settingsItem)
 


### PR DESCRIPTION
## Summary

- align the Settings menu item and shortcut rows with native macOS Settings conventions
- simplify the screenshot save location section so it shows one effective destination instead of duplicate effective/override rows
- reorder screenshot save controls so the sound toggle sits with the other toggles and the destination plus folder buttons stay visually grouped

## Root Cause

The screenshot save location controls were wrapped in an internal `VStack`, so SwiftUI treated the block as compact custom content instead of separate native Form rows. The destination and buttons also became separate rows once the section was unwrapped, which introduced an unwanted divider between related controls.

## Validation

- Ran `./Scripts/local-install-app.sh`
- Confirmed the app installed to `/Applications/JustNow.app` and relaunched successfully
