### PR TITLE
Harden capture optimisation cleanup

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -10,6 +10,7 @@ import Sparkle
 import os.log
 
 private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
+private let inputActivityForwardingInterval: TimeInterval = 1.0
 
 enum FeatureFlags {
     /// Temporary kill switch while in-app search is hidden from release builds.
@@ -402,9 +403,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     private func setupInputMonitor() {
+        var lastMouseMoveForwardedAt = -Double.greatestFiniteMagnitude
+
+        // Keep mouse movement as an activity signal so the adaptive capture
+        // policy exits idle without waiting for a click or the periodic policy
+        // timer. Gate it before hopping to the main actor to avoid 60Hz Tasks.
         inputEventMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.keyDown, .leftMouseDown, .rightMouseDown, .otherMouseDown, .scrollWheel, .mouseMoved]
-        ) { [weak self] _ in
+        ) { [weak self] event in
+            if event.type == .mouseMoved {
+                guard event.timestamp - lastMouseMoveForwardedAt >= inputActivityForwardingInterval else {
+                    return
+                }
+                lastMouseMoveForwardedAt = event.timestamp
+            }
+
             guard let self else { return }
             Task { @MainActor [self] in
                 self.handleUserActivity()
@@ -730,7 +743,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     private func secondsSinceLastUserEvent() -> TimeInterval {
-        let anyEventType = CGEventType(rawValue: UInt32.max)!
+        // `~0` is the sentinel "any event type" — wrapped in `?? .null` to
+        // avoid a future-Swift force-unwrap crash if the bridging tightens.
+        let anyEventType = CGEventType(rawValue: ~0) ?? .null
         return CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: anyEventType)
     }
 

--- a/JustNow/Capture/BlackFrameDetector.swift
+++ b/JustNow/Capture/BlackFrameDetector.swift
@@ -30,6 +30,14 @@ struct BlackFrameDetector {
         let bytesPerRow = image.bytesPerRow
 
         guard bytesPerPixel >= 3 else { return false }
+
+        // SCK delivers BGRA8888, so the first byte is blue and the third is
+        // red. Treating them as R/G/B silently miscomputes luma for non-zero
+        // uniform dark colours.
+        let bitmapInfo = image.bitmapInfo
+        let byteOrder = bitmapInfo.intersection(.byteOrderMask)
+        let isBGRA = bytesPerPixel == 4 && byteOrder == .byteOrder32Little
+
         var maximumLuma: UInt8 = 0
         var minimumLuma: UInt8 = 255
         var darkCount = 0
@@ -40,10 +48,12 @@ struct BlackFrameDetector {
             for gridX in 0..<gridSize {
                 let x = (width * (2 * gridX + 1)) / (2 * gridSize)
                 let offset = y * bytesPerRow + x * bytesPerPixel
+                let red = isBGRA ? bytes[offset + 2] : bytes[offset]
+                let blue = isBGRA ? bytes[offset] : bytes[offset + 2]
                 let luma = lumaForRGBSample(
-                    red: bytes[offset],
+                    red: red,
                     green: bytes[offset + 1],
-                    blue: bytes[offset + 2]
+                    blue: blue
                 )
 
                 maximumLuma = max(maximumLuma, luma)

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -129,14 +129,28 @@ class FrameBuffer {
     private let fullImageCache = NSCache<NSUUID, CachedCGImageBox>()
     private var inFlightFullImageLoads: [UUID: Task<CachedCGImageBox, Error>] = [:]
 
+    private static let fullImageCacheByteBudget: Int = 256 * 1024 * 1024
+    private static let thumbnailCacheByteBudget: Int = 16 * 1024 * 1024
+
+    private static func byteCost(of image: CGImage) -> Int {
+        // Decoded bitmap size — `bytesPerRow * height` is a tight approximation
+        // even when the underlying surface uses extra padding.
+        max(image.bytesPerRow * image.height, image.width * image.height * 4)
+    }
+
     // OCR text cache for faster subsequent searches
     let textCache = TextCache()
 
     init(retentionPolicy: RetentionPolicy) async throws {
         self.frameStore = try FrameStore()
         self.retentionManager = RetentionManager(policy: retentionPolicy)
-        thumbnailCache.countLimit = 100
-        fullImageCache.countLimit = 24
+        // A single 5K BGRA frame is ~58 MB decoded. `countLimit` lets 24 of
+        // those pin ~1.4 GB; switch to byte budgets so the cache evicts under
+        // real memory pressure.
+        thumbnailCache.countLimit = 200
+        thumbnailCache.totalCostLimit = Self.thumbnailCacheByteBudget
+        fullImageCache.countLimit = 12
+        fullImageCache.totalCostLimit = Self.fullImageCacheByteBudget
 
         // Load persisted frames
         await loadPersistedFrames()
@@ -410,7 +424,7 @@ class FrameBuffer {
             return nil
         }
 
-        thumbnailCache.setObject(CachedCGImageBox(cgImage), forKey: key)
+        thumbnailCache.setObject(CachedCGImageBox(cgImage), forKey: key, cost: Self.byteCost(of: cgImage))
         return cgImage
     }
 
@@ -555,7 +569,7 @@ class FrameBuffer {
 
         do {
             let cachedImage = try await loadTask.value
-            fullImageCache.setObject(cachedImage, forKey: key)
+            fullImageCache.setObject(cachedImage, forKey: key, cost: Self.byteCost(of: cachedImage.image))
             inFlightFullImageLoads.removeValue(forKey: frame.id)
             return cachedImage
         } catch {

--- a/JustNow/Capture/PerceptualHash.swift
+++ b/JustNow/Capture/PerceptualHash.swift
@@ -7,6 +7,10 @@ import CoreGraphics
 import CoreImage
 
 nonisolated struct PerceptualHash {
+    // Cache the colourspace across calls; per-call construction is wasteful on
+    // a per-frame hot path.
+    private static let grayColorSpace = CGColorSpaceCreateDeviceGray()
+
     /// Compute a 64-bit perceptual hash from a CGImage
     /// Uses average hash algorithm: resize to 8x8, convert to grayscale, threshold by mean
     /// Runs on background thread to keep main actor responsive
@@ -26,7 +30,7 @@ nonisolated struct PerceptualHash {
             height: height,
             bitsPerComponent: 8,
             bytesPerRow: width,
-            space: CGColorSpaceCreateDeviceGray(),
+            space: grayColorSpace,
             bitmapInfo: CGImageAlphaInfo.none.rawValue
         ) else {
             return 0

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -5,6 +5,7 @@
 
 import ScreenCaptureKit
 import AppKit
+import CoreVideo
 import os.log
 
 private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
@@ -97,6 +98,11 @@ class ScreenCaptureManager: NSObject {
         applyCaptureScale(to: cfg, dimensions: dimensions)
         cfg.showsCursor = true
         cfg.capturesAudio = false
+        // Pin the surface format so SCK doesn't pick a wider, more expensive
+        // default. BGRA + sRGB matches the JPEG encode path and avoids hidden
+        // colour-space conversion on every capture.
+        cfg.pixelFormat = kCVPixelFormatType_32BGRA
+        cfg.colorSpaceName = CGColorSpace.sRGB
         try Task.checkCancellation()
 
         self.filter = filter

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -39,9 +39,15 @@ actor FrameStore {
     private let manifestURL: URL
 
     private var manifest: FrameManifest
+    private var manifestIndex: [UUID: Int] = [:]
     private var manifestDirty = false
     private var pendingManifestChanges = 0
     private var manifestSaveTask: Task<Void, Never>?
+    private let manifestEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }()
 
     private static let manifestSaveDelay: Duration = .seconds(5)
     private static let manifestSaveImmediateThreshold = 25
@@ -68,6 +74,25 @@ actor FrameStore {
         } else {
             manifest = FrameManifest()
         }
+        manifestIndex = Self.makeManifestIndex(from: manifest.frames)
+    }
+
+    private static func makeManifestIndex(from frames: [FrameMetadata]) -> [UUID: Int] {
+        var index: [UUID: Int] = [:]
+        index.reserveCapacity(frames.count)
+        for (offset, frame) in frames.enumerated() {
+            index[frame.id] = offset
+        }
+        return index
+    }
+
+    private func rebuildManifestIndex() {
+        manifestIndex = Self.makeManifestIndex(from: manifest.frames)
+    }
+
+    private func metadata(forID id: UUID) -> FrameMetadata? {
+        guard let index = manifestIndex[id], index < manifest.frames.count else { return nil }
+        return manifest.frames[index]
     }
 
     // MARK: - Public API
@@ -113,6 +138,7 @@ actor FrameStore {
             displayName: displayName
         )
 
+        manifestIndex[metadata.id] = manifest.frames.count
         manifest.frames.append(metadata)
         manifest.lastModified = Date()
         scheduleManifestSave()
@@ -121,7 +147,7 @@ actor FrameStore {
     }
 
     func loadFullImage(id: UUID) throws -> CGImage {
-        guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
+        guard let metadata = metadata(forID: id) else {
             throw FrameStoreError.fileNotFound(id)
         }
 
@@ -134,7 +160,7 @@ actor FrameStore {
     }
 
     func loadSearchIndexImage(id: UUID, maxPixelSize: Int) throws -> CGImage {
-        guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
+        guard let metadata = metadata(forID: id) else {
             throw FrameStoreError.fileNotFound(id)
         }
 
@@ -151,7 +177,7 @@ actor FrameStore {
     /// capturing. Returns the destination URL, with a `(n)` suffix if the
     /// target name is taken.
     func copyFrameToScreenshotsLocation(id: UUID, timestamp: Date) throws -> URL {
-        guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
+        guard let metadata = metadata(forID: id) else {
             throw FrameStoreError.fileNotFound(id)
         }
 
@@ -209,7 +235,7 @@ actor FrameStore {
     }
 
     func loadThumbnail(id: UUID) -> CGImage? {
-        guard let metadata = manifest.frames.first(where: { $0.id == id }) else {
+        guard let metadata = metadata(forID: id) else {
             return nil
         }
 
@@ -237,7 +263,7 @@ actor FrameStore {
         guard !ids.isEmpty else { return }
 
         for id in ids {
-            guard let metadata = manifest.frames.first(where: { $0.id == id }) else { continue }
+            guard let metadata = metadata(forID: id) else { continue }
 
             let fullPath = framesURL.appendingPathComponent(metadata.filename)
             let thumbPath = framesURL.appendingPathComponent(metadata.thumbnailFilename)
@@ -246,6 +272,7 @@ actor FrameStore {
         }
 
         manifest.frames.removeAll { ids.contains($0.id) }
+        rebuildManifestIndex()
         manifest.lastModified = Date()
         scheduleManifestSave()
     }
@@ -260,6 +287,7 @@ actor FrameStore {
         }
 
         manifest.frames.removeAll()
+        manifestIndex.removeAll(keepingCapacity: true)
         manifest.lastModified = Date()
         performManifestSave()
     }
@@ -267,6 +295,13 @@ actor FrameStore {
     func cleanupOrphans() throws {
         // Get all files in frames directory
         guard let files = try? fileManager.contentsOfDirectory(at: framesURL, includingPropertiesForKeys: nil) else {
+            return
+        }
+
+        // Refuse to wipe on-disk frames when the manifest looks suspiciously
+        // empty — protects against a corrupted or missing manifest forcing
+        // every captured JPEG to be deleted as an "orphan".
+        if manifest.frames.isEmpty && !files.isEmpty {
             return
         }
 
@@ -280,9 +315,13 @@ actor FrameStore {
         }
 
         // Remove manifest entries for missing files
+        let beforeCount = manifest.frames.count
         manifest.frames = manifest.frames.filter { frame in
             let fullPath = framesURL.appendingPathComponent(frame.filename)
             return fileManager.fileExists(atPath: fullPath.path)
+        }
+        if manifest.frames.count != beforeCount {
+            rebuildManifestIndex()
         }
 
         performManifestSave()
@@ -330,10 +369,9 @@ actor FrameStore {
     }
 
     private func saveManifest() throws {
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
-        let data = try encoder.encode(manifest)
-        try data.write(to: manifestURL)
+        let data = try manifestEncoder.encode(manifest)
+        // Atomic write so a crash mid-flush leaves the previous manifest
+        // intact rather than truncating it to zero bytes.
+        try data.write(to: manifestURL, options: .atomic)
     }
 }

--- a/JustNow/Storage/TextCache.swift
+++ b/JustNow/Storage/TextCache.swift
@@ -426,8 +426,18 @@ actor TextCache {
             "SELECT frame_id FROM frame_text_fts EXCEPT SELECT frame_id FROM frame_text LIMIT 1;",
             on: db
         )) ?? true
+        let staleTextInFTS = (try? hasRows(
+            """
+            SELECT frame_text.frame_id
+            FROM frame_text
+            JOIN frame_text_fts ON frame_text.frame_id = frame_text_fts.frame_id
+            WHERE frame_text.text <> frame_text_fts.text
+            LIMIT 1;
+            """,
+            on: db
+        )) ?? true
 
-        guard primaryCount != ftsCount || missingFromFTS || staleInFTS else { return }
+        guard primaryCount != ftsCount || missingFromFTS || staleInFTS || staleTextInFTS else { return }
 
         Self.logger.info("Repairing FTS index (primary=\(primaryCount), fts=\(ftsCount))")
         try execute("DELETE FROM frame_text_fts;", on: db)

--- a/JustNow/Storage/TextCache.swift
+++ b/JustNow/Storage/TextCache.swift
@@ -22,7 +22,8 @@ actor TextCache {
     private static let sqliteTransient = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 
     init() {
-        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory() + "/Library/Application Support")
         let appDir = appSupport.appendingPathComponent("JustNow", isDirectory: true)
         self.databaseURL = appDir.appendingPathComponent("text_cache.sqlite")
         self.legacyCacheURL = appDir.appendingPathComponent("text_cache.json")
@@ -32,7 +33,7 @@ actor TextCache {
             let connection = try Self.openDatabase(at: databaseURL)
             db = connection
             try Self.createSchema(on: connection)
-            try Self.repairIndex(on: connection)
+            try Self.repairIndexIfNeeded(on: connection)
             Self.logger.info("Text cache ready with \(Self.countRows(in: connection)) entries")
 
             Task { [weak self] in
@@ -404,9 +405,39 @@ actor TextCache {
         try execute("CREATE INDEX IF NOT EXISTS idx_frame_text_timestamp ON frame_text(timestamp DESC);", on: db)
     }
 
-    private static func repairIndex(on db: OpaquePointer) throws {
+    /// FTS5 maintains its own durable inverted index; routine rebuilds are
+    /// unnecessary and quadratic with history size. Rebuild only when the FTS
+    /// table drifts from the primary table, including same-count missing or
+    /// duplicate rows.
+    private static func repairIndexIfNeeded(on db: OpaquePointer) throws {
+        let primaryCount = (try? withPreparedStatement("SELECT COUNT(*) FROM frame_text;", on: db) { statement in
+            sqlite3_step(statement) == SQLITE_ROW ? Int(sqlite3_column_int64(statement, 0)) : 0
+        }) ?? 0
+
+        let ftsCount = (try? withPreparedStatement("SELECT COUNT(*) FROM frame_text_fts;", on: db) { statement in
+            sqlite3_step(statement) == SQLITE_ROW ? Int(sqlite3_column_int64(statement, 0)) : 0
+        }) ?? 0
+
+        let missingFromFTS = (try? hasRows(
+            "SELECT frame_id FROM frame_text EXCEPT SELECT frame_id FROM frame_text_fts LIMIT 1;",
+            on: db
+        )) ?? true
+        let staleInFTS = (try? hasRows(
+            "SELECT frame_id FROM frame_text_fts EXCEPT SELECT frame_id FROM frame_text LIMIT 1;",
+            on: db
+        )) ?? true
+
+        guard primaryCount != ftsCount || missingFromFTS || staleInFTS else { return }
+
+        Self.logger.info("Repairing FTS index (primary=\(primaryCount), fts=\(ftsCount))")
         try execute("DELETE FROM frame_text_fts;", on: db)
         try execute("INSERT INTO frame_text_fts(frame_id, text) SELECT frame_id, text FROM frame_text;", on: db)
+    }
+
+    private static func hasRows(_ sql: String, on db: OpaquePointer) throws -> Bool {
+        try withPreparedStatement(sql, on: db) { statement in
+            sqlite3_step(statement) == SQLITE_ROW
+        }
     }
 
     private static func countRows(in db: OpaquePointer) -> Int {

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -536,7 +536,7 @@ class OverlayViewModel {
     private func makeErrorToast(_ error: Error) -> OverlayToast {
         OverlayToast(
             icon: "exclamationmark.triangle.fill",
-            title: "Couldn't save screenshot",
+            title: "Couldn\u{2019}t save screenshot",
             detail: error.localizedDescription,
             style: .error,
             revealURL: nil

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -130,8 +130,6 @@ class OverlayWindowController: NSObject {
         keyEventMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
             guard let self = self, let vm = self.viewModel else { return event }
 
-            print("[JustNow] Key pressed: keyCode=\(event.keyCode), chars='\(event.characters ?? "")'")
-
             let action = resolveOverlayKeyboardAction(
                 keyCode: event.keyCode,
                 modifiers: event.modifierFlags,
@@ -188,7 +186,12 @@ class OverlayWindowController: NSObject {
         // Track ⌘ state so the instructions pill and drag handler can switch
         // to "screenshot region" mode without each owning its own monitor.
         flagsChangedMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
-            self?.viewModel?.isCommandHeld = event.modifierFlags.contains(.command)
+            // Only publish when the bit actually flips — Observation invalidates
+            // subscribers on every assignment, equal-value writes included.
+            let isHeld = event.modifierFlags.contains(.command)
+            if self?.viewModel?.isCommandHeld != isHeld {
+                self?.viewModel?.isCommandHeld = isHeld
+            }
             return event
         }
 
@@ -263,7 +266,7 @@ class OverlayWindowController: NSObject {
     }
 
     var isVisible: Bool {
-        window != nil && window!.isVisible
+        window?.isVisible == true
     }
 
     /// Picks the built-in display first, else the first in the list. Legacy

--- a/JustNow/Utilities/SearchTextLayout.swift
+++ b/JustNow/Utilities/SearchTextLayout.swift
@@ -23,32 +23,36 @@ nonisolated struct SearchTextLayout: Codable, Sendable {
     }
 
     func highlightRects(matching query: String) -> [CGRect] {
-        let tokens = SearchQueryTokeniser.tokens(from: query)
-        guard !tokens.isEmpty else { return [] }
+        let queryTokens = SearchQueryTokeniser.tokens(from: query)
+        let lowercasedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !queryTokens.isEmpty else {
+            guard !lowercasedQuery.isEmpty else { return [] }
+            return lines.compactMap { line in
+                line.text.lowercased().contains(lowercasedQuery) ? line.rect : nil
+            }
+        }
 
         var rects: [CGRect] = []
         rects.reserveCapacity(lines.count)
 
+        // Single pass: collect word-level rects when we can, fall back to the
+        // line rect when the query matches the line as a whole. Each word and
+        // line is tokenised at most once per call.
         for line in lines {
-            let matchingWordRects = line.words.compactMap { word -> CGRect? in
+            var lineHasWordHit = false
+            for word in line.words {
                 let wordTokens = SearchQueryTokeniser.tokens(from: word.text)
-                guard wordTokens.contains(where: { token in
-                    tokens.contains(where: { token.hasPrefix($0) })
-                }) else {
-                    return nil
-                }
-                return word.rect
+                guard tokensMatch(wordTokens, anyOf: queryTokens) else { continue }
+                rects.append(word.rect)
+                lineHasWordHit = true
             }
 
-            if !matchingWordRects.isEmpty {
-                rects.append(contentsOf: matchingWordRects)
+            if lineHasWordHit {
                 continue
             }
 
             let lineTokens = SearchQueryTokeniser.tokens(from: line.text)
-            if lineTokens.contains(where: { token in
-                tokens.contains(where: { token.hasPrefix($0) })
-            }) {
+            if tokensMatch(lineTokens, anyOf: queryTokens) {
                 rects.append(line.rect)
             }
         }
@@ -57,12 +61,22 @@ nonisolated struct SearchTextLayout: Codable, Sendable {
             return rects
         }
 
-        let lowercasedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        // Last-resort substring match (catches queries that tokenise empty,
+        // e.g. punctuation-only or whitespace-only highlights from FTS).
         guard !lowercasedQuery.isEmpty else { return [] }
 
         return lines.compactMap { line in
             line.text.lowercased().contains(lowercasedQuery) ? line.rect : nil
         }
+    }
+
+    private func tokensMatch(_ candidateTokens: [String], anyOf queryTokens: [String]) -> Bool {
+        for candidate in candidateTokens {
+            for query in queryTokens where candidate.hasPrefix(query) {
+                return true
+            }
+        }
+        return false
     }
 }
 

--- a/JustNow/Utilities/TextRecognitionManager.swift
+++ b/JustNow/Utilities/TextRecognitionManager.swift
@@ -238,7 +238,16 @@ nonisolated enum TextRecognitionManager {
         request.recognitionLevel = recognitionLevel
         request.usesLanguageCorrection = usesLanguageCorrection
         request.automaticallyDetectsLanguage = automaticallyDetectsLanguage
-        request.recognitionLanguages = Locale.preferredLanguages
+        // When auto-detect is off, every entry in `recognitionLanguages` loads
+        // an additional language model and broadens the glyph set — material
+        // per-frame cost for background indexing. Pin to the user's primary
+        // language. When auto-detect is on, supplying the full list is just an
+        // ordering hint to the detector and stays cheap.
+        if automaticallyDetectsLanguage {
+            request.recognitionLanguages = Locale.preferredLanguages
+        } else if let primary = Locale.preferredLanguages.first {
+            request.recognitionLanguages = [primary]
+        }
         return request
     }
 

--- a/JustNowTests/BlackFrameDetectorTests.swift
+++ b/JustNowTests/BlackFrameDetectorTests.swift
@@ -21,6 +21,15 @@ final class BlackFrameDetectorTests: XCTestCase {
         XCTAssertFalse(detector.isBlackFrame(image))
     }
 
+    func testRejectsUniformDarkRedBGRAFrame() throws {
+        let detector = BlackFrameDetector.screenOff
+        let image = try makeBGRAImage(width: 16, height: 16) { _, _ in
+            (40, 0, 0, 255)
+        }
+
+        XCTAssertFalse(detector.isBlackFrame(image))
+    }
+
     func testRejectsStructuredDarkFrame() throws {
         let detector = BlackFrameDetector.screenOff
         let image = try makeImage(width: 16, height: 16) { x, y in
@@ -54,6 +63,47 @@ final class BlackFrameDetectorTests: XCTestCase {
         let provider = try XCTUnwrap(CGDataProvider(data: Data(bytes) as CFData))
         let colorSpace = CGColorSpaceCreateDeviceRGB()
         let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.noneSkipLast.rawValue)
+
+        return try XCTUnwrap(
+            CGImage(
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bitsPerPixel: 32,
+                bytesPerRow: width * 4,
+                space: colorSpace,
+                bitmapInfo: bitmapInfo,
+                provider: provider,
+                decode: nil,
+                shouldInterpolate: false,
+                intent: .defaultIntent
+            )
+        )
+    }
+
+    private func makeBGRAImage(
+        width: Int,
+        height: Int,
+        pixel: (Int, Int) -> (UInt8, UInt8, UInt8, UInt8)
+    ) throws -> CGImage {
+        var bytes = [UInt8](repeating: 0, count: width * height * 4)
+
+        for y in 0..<height {
+            for x in 0..<width {
+                let offset = (y * width + x) * 4
+                let (red, green, blue, alpha) = pixel(x, y)
+                bytes[offset] = blue
+                bytes[offset + 1] = green
+                bytes[offset + 2] = red
+                bytes[offset + 3] = alpha
+            }
+        }
+
+        let provider = try XCTUnwrap(CGDataProvider(data: Data(bytes) as CFData))
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitmapInfo = CGBitmapInfo.byteOrder32Little.union(
+            CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
+        )
 
         return try XCTUnwrap(
             CGImage(

--- a/JustNowTests/TextRecognitionManagerTests.swift
+++ b/JustNowTests/TextRecognitionManagerTests.swift
@@ -135,6 +135,21 @@ final class TextRecognitionManagerTests: XCTestCase {
         XCTAssertEqual(layout.highlightRects(matching: "capture"), [lineRect])
     }
 
+    func testHighlightRectsFallBackToLineRectForPunctuationQueries() {
+        let lineRect = CGRect(x: 0.14, y: 0.3, width: 0.42, height: 0.1)
+        let layout = SearchTextLayout(
+            lines: [
+                SearchTextLine(
+                    text: "Loading...",
+                    rect: lineRect,
+                    words: []
+                )
+            ]
+        )
+
+        XCTAssertEqual(layout.highlightRects(matching: "..."), [lineRect])
+    }
+
     func testDisplayedRectFlipsNormalisedVisionCoordinatesIntoOverlaySpace() {
         let displayedRect = TextGrabGeometry.displayedRect(
             forNormalisedImageRect: CGRect(x: 0.25, y: 0.5, width: 0.25, height: 0.25),

--- a/site/index.html
+++ b/site/index.html
@@ -8,11 +8,26 @@
       name="description"
       content="A free macOS menu bar app that lets you rewind your screen and copy text from whatever you just closed. No AI circus."
     >
+    <link rel="canonical" href="https://justnow.tk.sg/">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://justnow.tk.sg/">
+    <meta property="og:title" content="JustNow — rewind your screen">
+    <meta property="og:description" content="A free macOS menu bar app that lets you rewind your screen and copy text from whatever you just closed. No AI circus.">
+    <meta property="og:image" content="https://justnow.tk.sg/assets/justnow-overlay-hero.jpg">
+    <meta property="og:image:alt" content="JustNow's rewind overlay showing a recent browser frame and drag-to-grab text selection">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="JustNow — rewind your screen">
+    <meta name="twitter:description" content="Rewind your Mac screen and copy the bit you needed. Local, free, no AI circus.">
+    <meta name="twitter:image" content="https://justnow.tk.sg/assets/justnow-overlay-hero.jpg">
+    <meta name="theme-color" content="#f6f4ef" media="(prefers-color-scheme: light)">
+    <meta name="theme-color" content="#1e1f22" media="(prefers-color-scheme: dark)">
     <link rel="stylesheet" href="/styles.css">
     <link rel="icon" href="/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="/favicon-32.png" sizes="32x32" type="image/png">
+    <link rel="apple-touch-icon" href="/favicon-32.png">
   </head>
   <body>
+    <a href="#main" class="skip-link">Skip to content</a>
     <div class="page">
 
       <header class="header">
@@ -26,6 +41,7 @@
         </nav>
       </header>
 
+      <main id="main">
       <section class="hero">
         <h1>You just closed that window.<br>Now get it back.</h1>
         <p class="hero-sub">
@@ -56,6 +72,8 @@
           alt="JustNow's rewind overlay showing a recent browser frame and drag-to-grab text selection"
           width="1800"
           height="1169"
+          fetchpriority="high"
+          decoding="async"
         >
         <figcaption>
           Activate, scrub back, find what you forgot. Drag to get the text in
@@ -161,6 +179,7 @@
           </div>
         </dl>
       </section>
+      </main>
 
       <footer class="footer">
         <div class="footer-links">
@@ -169,8 +188,8 @@
           <a href="/releases/">Release notes</a>
         </div>
         <p class="footer-colophon">
-          Built by <a href=”https://github.com/yjsoon”>@yjsoon</a> from
-          <a href=”https://tinkercademy.com”>Tinkercademy</a> because
+          Built by <a href="https://github.com/yjsoon">@yjsoon</a> from
+          <a href="https://tinkercademy.com">Tinkercademy</a> because
           <i>&ldquo;oh noooo I was filling a form and closed the window
           accidentally againnnnn&rdquo;</i>.
         </p>

--- a/site/styles.css
+++ b/site/styles.css
@@ -110,6 +110,25 @@ img {
   display: block;
 }
 
+/* ---- Skip link (a11y) ---- */
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  background: var(--accent);
+  color: var(--accent-fg);
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+  z-index: 1000;
+  font-size: var(--text-sm);
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
 /* ---- Page shell ---- */
 
 .page {


### PR DESCRIPTION
## Summary
- harden the optimisation pass across capture, image caching, manifest lookup, OCR text caching, and overlay search highlights
- preserve mouse movement as an idle-exit signal while throttling the global monitor before main-actor work
- add public-site metadata and skip-link polish

## Validation
- `xcodebuild test -scheme JustNow -project JustNow.xcodeproj -configuration Debug -derivedDataPath /tmp/justnow-build-review -destination 'platform=macOS,arch=arm64' CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES DEVELOPMENT_TEAM=PQ6U5ESLN2`
- `./Scripts/local-install-app.sh`
- launched `/Applications/JustNow.app` and verified the `JustNow` process is running
