### PR TITLE
fix: handle secondary display overlay sizing

### DIFF
--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -39,6 +39,7 @@ class ScreenCaptureManager: NSObject {
     private var filter: SCContentFilter?
     private var config: SCStreamConfiguration?
     private var displayDimensions: (width: Int, height: Int)?
+    private var displayBackingScale: CGFloat = 1
     private var captureScale: Int = 2
 
     weak var delegate: ScreenCaptureDelegate?
@@ -92,6 +93,7 @@ class ScreenCaptureManager: NSObject {
         }
 
         let dimensions = (width: display.width, height: display.height)
+        displayBackingScale = Self.backingScale(for: targetDisplayID)
         let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
 
         let cfg = SCStreamConfiguration()
@@ -349,7 +351,33 @@ class ScreenCaptureManager: NSObject {
     }
 
     private func applyCaptureScale(to config: SCStreamConfiguration, dimensions: (width: Int, height: Int)) {
-        config.width = dimensions.width * captureScale
-        config.height = dimensions.height * captureScale
+        let output = ScreenCaptureSizing.outputDimensions(
+            displayDimensions: dimensions,
+            desiredScale: captureScale,
+            displayBackingScale: displayBackingScale
+        )
+        config.width = output.width
+        config.height = output.height
+    }
+
+    private static func backingScale(for displayID: CGDirectDisplayID) -> CGFloat {
+        if let screen = DisplayIdentity.screen(for: displayID) {
+            return max(1, screen.backingScaleFactor)
+        }
+        return 1
+    }
+}
+
+enum ScreenCaptureSizing {
+    static func outputDimensions(
+        displayDimensions: (width: Int, height: Int),
+        desiredScale: Int,
+        displayBackingScale: CGFloat
+    ) -> (width: Int, height: Int) {
+        let scale = min(CGFloat(max(1, desiredScale)), max(1, displayBackingScale))
+        return (
+            width: max(1, Int((CGFloat(displayDimensions.width) * scale).rounded())),
+            height: max(1, Int((CGFloat(displayDimensions.height) * scale).rounded()))
+        )
     }
 }

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -104,11 +104,12 @@ class OverlayWindowController: NSObject {
         window.ignoresMouseEvents = false
         window.acceptsMouseMovedEvents = true
 
+        let contentFrame = OverlayWindowLayout.contentFrame(forScreenFrame: screen.frame)
         let overlayView = OverlayView(viewModel: vm)
-            .frame(width: screen.frame.width, height: screen.frame.height)
+            .frame(width: contentFrame.width, height: contentFrame.height)
             .clipped()
         let hostingView = NSHostingView(rootView: overlayView)
-        hostingView.frame = screen.frame
+        hostingView.frame = contentFrame
         hostingView.autoresizingMask = [.width, .height]
         // On macOS 13+, NSHostingView defaults to growing with its SwiftUI
         // content's intrinsic size. For a fullscreen overlay we explicitly
@@ -286,4 +287,10 @@ class OverlayWindowController: NSObject {
 class OverlayWindow: NSWindow {
     override var canBecomeKey: Bool { true }
     override var canBecomeMain: Bool { true }
+}
+
+enum OverlayWindowLayout {
+    static func contentFrame(forScreenFrame screenFrame: CGRect) -> CGRect {
+        CGRect(origin: .zero, size: screenFrame.size)
+    }
 }

--- a/JustNowTests/OverlayWindowLayoutTests.swift
+++ b/JustNowTests/OverlayWindowLayoutTests.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+import XCTest
+@testable import JustNow
+
+final class OverlayWindowLayoutTests: XCTestCase {
+    func testContentFrameUsesWindowLocalOriginForSecondaryDisplayToTheRight() {
+        let screenFrame = CGRect(x: 1728, y: 0, width: 2560, height: 1440)
+
+        let contentFrame = OverlayWindowLayout.contentFrame(forScreenFrame: screenFrame)
+
+        XCTAssertEqual(contentFrame.origin, .zero)
+        XCTAssertEqual(contentFrame.size, screenFrame.size)
+    }
+
+    func testContentFrameUsesWindowLocalOriginForSecondaryDisplayAbove() {
+        let screenFrame = CGRect(x: -160, y: 1117, width: 3008, height: 1692)
+
+        let contentFrame = OverlayWindowLayout.contentFrame(forScreenFrame: screenFrame)
+
+        XCTAssertEqual(contentFrame.origin, .zero)
+        XCTAssertEqual(contentFrame.size, screenFrame.size)
+    }
+}

--- a/JustNowTests/ScreenCaptureSizingTests.swift
+++ b/JustNowTests/ScreenCaptureSizingTests.swift
@@ -1,0 +1,37 @@
+import XCTest
+@testable import JustNow
+
+final class ScreenCaptureSizingTests: XCTestCase {
+    func testOutputDimensionsClampDesiredScaleToOneForNonRetinaDisplay() {
+        let output = ScreenCaptureSizing.outputDimensions(
+            displayDimensions: (width: 2560, height: 1440),
+            desiredScale: 2,
+            displayBackingScale: 1
+        )
+
+        XCTAssertEqual(output.width, 2560)
+        XCTAssertEqual(output.height, 1440)
+    }
+
+    func testOutputDimensionsUseDesiredScaleForRetinaDisplay() {
+        let output = ScreenCaptureSizing.outputDimensions(
+            displayDimensions: (width: 1728, height: 1117),
+            desiredScale: 2,
+            displayBackingScale: 2
+        )
+
+        XCTAssertEqual(output.width, 3456)
+        XCTAssertEqual(output.height, 2234)
+    }
+
+    func testOutputDimensionsRespectLowPowerScaleOnRetinaDisplay() {
+        let output = ScreenCaptureSizing.outputDimensions(
+            displayDimensions: (width: 1728, height: 1117),
+            desiredScale: 1,
+            displayBackingScale: 2
+        )
+
+        XCTAssertEqual(output.width, 1728)
+        XCTAssertEqual(output.height, 1117)
+    }
+}


### PR DESCRIPTION
## Summary
- clamp ScreenCaptureKit output dimensions to the target display backing scale so 1x external displays do not render captures into the top-left quarter of an oversized surface
- keep overlay hosting content in window-local coordinates while the borderless window remains positioned on the selected screen
- add regression tests for secondary-display overlay layout and capture output sizing

## Validation
- `xcodebuild test -scheme JustNow -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO DEVELOPMENT_TEAM=`
- `./Scripts/local-install-app.sh`