### PR TITLE
feat: add rewind drag action setting

### DIFF
--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -406,7 +406,7 @@ class FrameBuffer {
     }
 
     /// Encode an in-memory cropped CGImage as JPEG and save it to the user's
-    /// chosen screenshots location. Used for ⌘-drag region screenshots from
+    /// chosen screenshots location. Used for screenshot-region drags from
     /// the rewind overlay.
     func saveCroppedImageToScreenshotsLocation(_ image: CGImage, timestamp: Date = Date()) async throws -> URL {
         try await frameStore.saveCroppedImageToScreenshotsLocation(image: image, timestamp: timestamp)

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -209,7 +209,7 @@ actor FrameStore {
     /// Encode the in-memory cropped image as JPEG and write it to the user's
     /// chosen screenshots location, using the same filename pattern as
     /// `copyFrameToScreenshotsLocation` and the same `(n)`-suffix collision
-    /// handling. Used by ⌘-drag screenshots from the rewind overlay.
+    /// handling. Used by screenshot drags from the rewind overlay.
     func saveCroppedImageToScreenshotsLocation(image: CGImage, timestamp: Date) throws -> URL {
         guard let jpegData = ImageEncoder.jpegData(from: image, quality: ImageEncoder.fullImageQuality) else {
             throw FrameStoreError.imageEncodingFailed

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -2,13 +2,16 @@ import SwiftUI
 
 struct InstructionsOverlay: View {
     var viewModel: OverlayViewModel
+    @AppStorage(AppStorageKey.rewindDragAction) private var rewindDragActionRaw: String = AppStorageDefault.rewindDragAction
 
     var body: some View {
-        // The "drag" affordance flips to "drag for screenshot" whenever
-        // we're in region-screenshot mode — either ⌘ is held, or the user
-        // armed it via the "Save Region…" menu item.
-        let dragLabel = viewModel.isInRegionScreenshotMode ? "Drag for screenshot" : "Drag to grab text"
-        let dragIcon = viewModel.isInRegionScreenshotMode ? "camera.viewfinder" : "text.viewfinder"
+        // The "drag" affordance follows the user's default drag action and flips while Command is held.
+        let isScreenshotMode = RewindDragAction.storedValue(rewindDragActionRaw).performsScreenshot(
+            commandHeld: viewModel.isCommandHeld,
+            isArmed: viewModel.isRegionScreenshotArmed
+        )
+        let dragLabel = isScreenshotMode ? "Drag for screenshot" : "Drag to grab text"
+        let dragIcon = isScreenshotMode ? "camera.viewfinder" : "text.viewfinder"
 
         ViewThatFits(in: .horizontal) {
             instructionPill(dragLabel: dragLabel, dragIcon: dragIcon, showsSearchShortcut: FeatureFlags.isSearchEnabled)

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -144,20 +144,14 @@ class OverlayViewModel {
 
     /// Tracks whether ⌘ is currently held inside the overlay window. The
     /// modifier-flag monitor in OverlayWindowController writes here so the
-    /// instructions pill and selection drag handler can switch to
-    /// "screenshot region" mode without each component owning a monitor.
+    /// instructions pill and selection drag handler can switch between the
+    /// user's default drag action and the alternate action.
     var isCommandHeld: Bool = false
 
     /// Set true by the "Save Region…" menu item so the very next drag
-    /// performs a region screenshot without requiring ⌘. The drag handler
-    /// clears it after consuming, so this is one-shot.
+    /// performs a region screenshot regardless of the user's default drag
+    /// action. The drag handler clears it after consuming, so this is one-shot.
     var isRegionScreenshotArmed: Bool = false
-
-    /// Either path that should make the next drag perform a region
-    /// screenshot — live ⌘ hold or armed via the menu.
-    var isInRegionScreenshotMode: Bool {
-        isCommandHeld || isRegionScreenshotArmed
-    }
 
     var isSearchAvailable: Bool {
         FeatureFlags.isSearchEnabled
@@ -562,16 +556,15 @@ class OverlayViewModel {
         }
     }
 
-    /// Triggered by the "Save Region…" menu item: behave as if ⌘ is held
-    /// for the next drag, and briefly teach the ⌘-drag shortcut the first
-    /// couple of times the menu path is used.
+    /// Triggered by the "Save Region…" menu item: the next drag captures a region
+    /// screenshot regardless of the user's default drag action.
     func armRegionScreenshot() {
         isRegionScreenshotArmed = true
         let defaults = UserDefaults.standard
         let hintCount = defaults.integer(forKey: AppStorageKey.regionScreenshotShortcutHintCount)
         let title: String
         if hintCount < 2 {
-            title = "Drag to capture. You can also hold \u{2318} and drag."
+            title = "Drag to capture a screenshot region."
             defaults.set(hintCount + 1, forKey: AppStorageKey.regionScreenshotShortcutHintCount)
         } else {
             title = "Drag to capture."

--- a/JustNow/UI/OverlayWindowController.swift
+++ b/JustNow/UI/OverlayWindowController.swift
@@ -88,6 +88,7 @@ class OverlayWindowController: NSObject {
             onOpenSettings: onOpenSettings
         )
         self.viewModel = vm
+        vm.isCommandHeld = NSEvent.modifierFlags.contains(.command)
 
         let window = OverlayWindow(
             contentRect: screen.frame,
@@ -185,7 +186,7 @@ class OverlayWindowController: NSObject {
         }
 
         // Track ⌘ state so the instructions pill and drag handler can switch
-        // to "screenshot region" mode without each owning its own monitor.
+        // between the user's default drag action and the alternate action.
         flagsChangedMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
             // Only publish when the bit actually flips — Observation invalidates
             // subscribers on every assignment, equal-value writes included.

--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -7,7 +7,8 @@ import AppKit
 import SwiftUI
 
 /// Settings section that lets the user pick a custom destination for
-/// screenshots saved from the rewind overlay (⌘S / "Save Screenshot…").
+/// screenshots saved from the rewind overlay (⌘S, "Save Screenshot…", and
+/// screenshot drags).
 ///
 /// The control follows the resolution chain implemented in
 /// `ScreenshotSaveLocation.resolveLive`: an explicit override here wins over
@@ -89,6 +90,10 @@ struct ScreenshotSaveLocationSettingsSection: View {
                             chooseFolder()
                         }
 
+                        Button("Open folder") {
+                            NSWorkspace.shared.open(resolvedURL)
+                        }
+
                         Button("Use system default") {
                             overridePath = ""
                             refreshTick &+= 1
@@ -110,11 +115,11 @@ struct ScreenshotSaveLocationSettingsSection: View {
     private var captionText: String {
         switch (saveToFolder, saveToClipboard) {
         case (true, true):
-            return "⌘S and ⌘-drag in rewind both save the screenshot to the folder above and copy it to your clipboard."
+            return "Full-frame screenshots and screenshot drags in rewind both save the screenshot to the folder above and copy it to your clipboard."
         case (true, false):
-            return "⌘S and ⌘-drag in rewind save the screenshot to your override if it's set, otherwise to the macOS system screenshot folder, otherwise to your Desktop."
+            return "Full-frame screenshots and screenshot drags in rewind save the screenshot to your override if it's set, otherwise to the macOS system screenshot folder, otherwise to your Desktop."
         case (false, true):
-            return "⌘S and ⌘-drag in rewind copy the screenshot to your clipboard. No file is written to disk."
+            return "Full-frame screenshots and screenshot drags in rewind copy the screenshot to your clipboard. No file is written to disk."
         case (false, false):
             return ""
         }

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 import Sparkle
 import Foundation
+import AppKit
 
 struct SettingsView: View {
     @AppStorage(AppStorageKey.captureInterval) private var captureInterval: Double = AppStorageDefault.captureInterval
@@ -23,6 +24,7 @@ struct SettingsView: View {
     @AppStorage(AppStorageKey.textGrabSoundEnabled) private var textGrabSoundEnabled: Bool = AppStorageDefault.textGrabSoundEnabled
     @AppStorage(AppStorageKey.saveScreenshotSoundEnabled) private var saveScreenshotSoundEnabled: Bool = AppStorageDefault.saveScreenshotSoundEnabled
     @AppStorage(AppStorageKey.textGrabDebugPreviewEnabled) private var textGrabDebugPreviewEnabled: Bool = AppStorageDefault.textGrabDebugPreviewEnabled
+    @AppStorage(AppStorageKey.rewindDragAction) private var rewindDragAction: String = AppStorageDefault.rewindDragAction
     @AppStorage(AppStorageKey.showMenuBarIcon) private var showMenuBarIcon: Bool = AppStorageDefault.showMenuBarIcon
     @AppStorage(AppStorageKey.hasSeenMenuBarHideInfo) private var hasSeenMenuBarHideInfo: Bool = AppStorageDefault.hasSeenMenuBarHideInfo
     @AppStorage(AppStorageKey.screenshotSaveLocationOverride)
@@ -51,26 +53,30 @@ struct SettingsView: View {
     var body: some View {
         Form {
             Section {
-                Toggle("Launch on startup", isOn: launchAtLoginBinding)
-                    .disabled(!context.canConfigureLaunchAtLogin)
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Launch on startup", isOn: launchAtLoginBinding)
+                        .disabled(!context.canConfigureLaunchAtLogin)
 
-                Text("If macOS asks for approval, enable JustNow in System Settings > General > Login Items.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text("If macOS asks for approval, enable JustNow in System Settings > General > Login Items.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-                Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
-                    .onChange(of: showMenuBarIcon) { _, newValue in
-                        if !newValue && !hasSeenMenuBarHideInfo {
-                            showHideIconInfoAlert = true
-                            hasSeenMenuBarHideInfo = true
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Show menu bar icon", isOn: $showMenuBarIcon)
+                        .onChange(of: showMenuBarIcon) { _, newValue in
+                            if !newValue && !hasSeenMenuBarHideInfo {
+                                showHideIconInfoAlert = true
+                                hasSeenMenuBarHideInfo = true
+                            }
                         }
-                    }
 
-                Text("Hides the icon in the macOS menu bar. If you lose access, relaunch JustNow from Finder or Spotlight to reopen Settings, or toggle it back from the rewind overlay.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text("Hides the icon in the macOS menu bar. If you lose access, relaunch JustNow from Finder or Spotlight to reopen Settings, or toggle it back from the rewind overlay.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } header: {
                 Text("General")
             }
@@ -124,13 +130,35 @@ struct SettingsView: View {
             }
 
             Section {
-                Toggle("Play copied-text sound", isOn: $textGrabSoundEnabled)
-                Toggle("Show text-grab debug preview", isOn: $textGrabDebugPreviewEnabled)
+                VStack(alignment: .leading, spacing: 8) {
+                    LabeledContent {
+                        Picker("", selection: $rewindDragAction) {
+                            ForEach(RewindDragAction.allCases) { action in
+                                Text(action.settingsLabel).tag(action.rawValue)
+                            }
+                        }
+                        .labelsHidden()
+                        .pickerStyle(.menu)
+                    } label: {
+                        Text("Default drag action")
+                    }
 
-                Text("In rewind, drag over the frame to copy on-screen text from just that area. JustNow cleans up the OCR before it lands on the clipboard, and debug preview shows the exact crop sent into OCR.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
+                    Text("Choose what happens when you drag over a rewind frame. Hold Command while dragging for the other action. Screenshots follow your screenshot save location settings.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Toggle("Play copied-text sound", isOn: $textGrabSoundEnabled)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Toggle("Show text-grab debug preview", isOn: $textGrabDebugPreviewEnabled)
+
+                    Text("Copied text is cleaned up before it lands on the clipboard. Debug preview shows the exact crop sent into OCR.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             } header: {
                 Text("Rewind")
             }
@@ -220,8 +248,16 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                Button("Clear All History", role: .destructive) {
-                    showClearConfirmation = true
+                HStack(spacing: 8) {
+                    Button("Open Storage Folder") {
+                        openStorageFolder()
+                    }
+
+                    Spacer()
+
+                    Button("Clear All History", role: .destructive) {
+                        showClearConfirmation = true
+                    }
                 }
             } header: {
                 Text("Storage")
@@ -371,6 +407,16 @@ struct SettingsView: View {
             storageSize = 0
             frameCount = 0
         }
+    }
+
+    private func openStorageFolder() {
+        let applicationSupportURL =
+            FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        let storageURL = applicationSupportURL.appendingPathComponent("JustNow", isDirectory: true)
+        try? FileManager.default.createDirectory(at: storageURL, withIntermediateDirectories: true)
+        NSWorkspace.shared.open(storageURL)
     }
 
     private var frameBufferIdentity: ObjectIdentifier? {

--- a/JustNow/UI/TextGrabSelectionOverlay.swift
+++ b/JustNow/UI/TextGrabSelectionOverlay.swift
@@ -154,6 +154,7 @@ struct TextGrabSelectionOverlay: View {
     let debugCaptureEnabled: Bool
     @Binding var bannerState: TextGrabBannerState
     @Binding var debugSnapshot: TextGrabDebugSnapshot?
+    @AppStorage(AppStorageKey.rewindDragAction) private var rewindDragActionRaw: String = AppStorageDefault.rewindDragAction
 
     @State private var selectionRect: CGRect?
     @State private var isProcessing = false
@@ -163,6 +164,10 @@ struct TextGrabSelectionOverlay: View {
     @State private var pointerLocation: CGPoint?
     @State private var displayedImageRectSnapshot: CGRect = .zero
     @State private var isCurrentDragCancelled = false
+
+    private var rewindDragAction: RewindDragAction {
+        RewindDragAction.storedValue(rewindDragActionRaw)
+    }
 
     var body: some View {
         GeometryReader { proxy in
@@ -205,8 +210,17 @@ struct TextGrabSelectionOverlay: View {
                 displayedImageRectSnapshot = newDisplayedImageRect
                 reevaluateCursor(displayedImageRect: newDisplayedImageRect)
             }
+            .onChange(of: viewModel.isCommandHeld) { _, _ in
+                reevaluateCursor(displayedImageRect: displayedImageRect)
+            }
+            .onChange(of: viewModel.isRegionScreenshotArmed) { _, _ in
+                reevaluateCursor(displayedImageRect: displayedImageRect)
+            }
+            .onChange(of: rewindDragActionRaw) { _, _ in
+                reevaluateCursor(displayedImageRect: displayedImageRect)
+            }
         }
-            .onDisappear {
+        .onDisappear {
             selectionTask?.cancel()
             bannerResetTask?.cancel()
             viewModel.isTextGrabActive = false
@@ -243,8 +257,8 @@ struct TextGrabSelectionOverlay: View {
             .onEnded { value in
                 // Capture the armed flag and disarm now so every exit path
                 // (including the early returns below) leaves the menu-armed
-                // state cleared. Subsequent drags then revert to OCR unless
-                // ⌘ is held.
+                // state cleared. Subsequent drags then revert to the user's
+                // saved drag preference.
                 let wasArmed = viewModel.isRegionScreenshotArmed
                 viewModel.disarmRegionScreenshot()
 
@@ -274,7 +288,10 @@ struct TextGrabSelectionOverlay: View {
                 }
 
                 selectionRect = finalRect
-                let isRegionMode = NSEvent.modifierFlags.contains(.command) || wasArmed
+                let isRegionMode = rewindDragAction.performsScreenshot(
+                    commandHeld: NSEvent.modifierFlags.contains(.command),
+                    isArmed: wasArmed
+                )
                 if isRegionMode {
                     beginRegionScreenshot(for: finalRect, displayedImageRect: displayedImageRect)
                 } else {
@@ -283,7 +300,7 @@ struct TextGrabSelectionOverlay: View {
             }
     }
 
-    /// ⌘-drag (or menu-armed) variant: crop the displayed image to the
+    /// Screenshot-drag variant: crop the displayed image to the
     /// selection and hand it to the view model's screenshot save flow. We
     /// don't run OCR or touch the banner state so the toast (with
     /// reveal-in-Finder) is the only feedback, mirroring ⌘S on the full
@@ -407,7 +424,7 @@ struct TextGrabSelectionOverlay: View {
             pointerLocation = location
             updateScreenshotCursor(
                 isInsideImage: displayedImageRect.contains(location),
-                isEnabled: !isProcessing
+                isEnabled: !isProcessing && isScreenshotDragMode
             )
         case .ended:
             pointerLocation = nil
@@ -423,7 +440,14 @@ struct TextGrabSelectionOverlay: View {
 
         updateScreenshotCursor(
             isInsideImage: displayedImageRect.contains(pointerLocation),
-            isEnabled: !isProcessing
+            isEnabled: !isProcessing && isScreenshotDragMode
+        )
+    }
+
+    private var isScreenshotDragMode: Bool {
+        rewindDragAction.performsScreenshot(
+            commandHeld: viewModel.isCommandHeld,
+            isArmed: viewModel.isRegionScreenshotArmed
         )
     }
 

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -14,6 +14,7 @@ enum AppStorageKey {
     nonisolated static let textGrabSoundEnabled = "textGrabSoundEnabled"
     nonisolated static let saveScreenshotSoundEnabled = "saveScreenshotSoundEnabled"
     nonisolated static let textGrabDebugPreviewEnabled = "textGrabDebugPreviewEnabled"
+    nonisolated static let rewindDragAction = "rewindDragAction"
     nonisolated static let showMenuBarIcon = "showMenuBarIcon"
     nonisolated static let hasSeenMenuBarHideInfo = "hasSeenMenuBarHideInfo"
     nonisolated static let screenshotSaveLocationOverride = "screenshotSaveLocationOverride"
@@ -21,6 +22,39 @@ enum AppStorageKey {
     nonisolated static let screenshotSaveToClipboard = "screenshotSaveToClipboard"
     nonisolated static let hasSeenSaveQualityInfo = "hasSeenSaveQualityInfo"
     nonisolated static let regionScreenshotShortcutHintCount = "regionScreenshotShortcutHintCount"
+}
+
+enum RewindDragAction: String, CaseIterable, Identifiable {
+    case saveText
+    case saveScreenshot
+
+    nonisolated var id: String { rawValue }
+
+    nonisolated var settingsLabel: String {
+        switch self {
+        case .saveText:
+            "Grab Text"
+        case .saveScreenshot:
+            "Capture Screenshot"
+        }
+    }
+
+    nonisolated func performsScreenshot(commandHeld: Bool, isArmed: Bool = false) -> Bool {
+        if isArmed {
+            return true
+        }
+
+        switch self {
+        case .saveText:
+            return commandHeld
+        case .saveScreenshot:
+            return !commandHeld
+        }
+    }
+
+    nonisolated static func storedValue(_ rawValue: String) -> RewindDragAction {
+        RewindDragAction(rawValue: rawValue) ?? .saveText
+    }
 }
 
 enum AppStorageDefault {
@@ -37,6 +71,7 @@ enum AppStorageDefault {
     nonisolated static let textGrabSoundEnabled = true
     nonisolated static let saveScreenshotSoundEnabled = true
     nonisolated static let textGrabDebugPreviewEnabled = false
+    nonisolated static let rewindDragAction = RewindDragAction.saveText.rawValue
     nonisolated static let showMenuBarIcon = true
     nonisolated static let hasSeenMenuBarHideInfo = false
     nonisolated static let screenshotSaveLocationOverride = ""

--- a/JustNowTests/RewindDragActionTests.swift
+++ b/JustNowTests/RewindDragActionTests.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import JustNow
+
+final class RewindDragActionTests: XCTestCase {
+    func testSaveTextDefaultUsesCommandForScreenshot() {
+        XCTAssertFalse(RewindDragAction.saveText.performsScreenshot(commandHeld: false))
+        XCTAssertTrue(RewindDragAction.saveText.performsScreenshot(commandHeld: true))
+    }
+
+    func testSaveScreenshotDefaultInvertsCommandGesture() {
+        XCTAssertTrue(RewindDragAction.saveScreenshot.performsScreenshot(commandHeld: false))
+        XCTAssertFalse(RewindDragAction.saveScreenshot.performsScreenshot(commandHeld: true))
+    }
+
+    func testArmedRegionScreenshotAlwaysCapturesScreenshot() {
+        XCTAssertTrue(RewindDragAction.saveText.performsScreenshot(commandHeld: false, isArmed: true))
+        XCTAssertTrue(RewindDragAction.saveScreenshot.performsScreenshot(commandHeld: true, isArmed: true))
+    }
+
+    func testStoredValueFallsBackToSaveText() {
+        XCTAssertEqual(RewindDragAction.storedValue("missing"), .saveText)
+    }
+}


### PR DESCRIPTION
## Summary

- Add a Rewind setting for choosing the default drag action: Grab Text or Capture Screenshot
- Invert the Command-drag behaviour based on that preference while preserving menu-armed screenshot capture
- Polish related Settings copy/layout and screenshot destination wording
- Add tests for the drag-action inversion and fallback behaviour

## Validation

- `git diff --check`
- `xcodebuild test -quiet -scheme JustNow -configuration Debug -derivedDataPath build CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES DEVELOPMENT_TEAM=PQ6U5ESLN2`
- `./Scripts/local-install-app.sh`

Built and launched `/Applications/JustNow.app` from latest `origin/main` before opening this PR.