### PR TITLE
refactor: remove over-engineering found by ponytail-audit

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -12,11 +12,6 @@ import os.log
 private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
 private let inputActivityForwardingInterval: TimeInterval = 1.0
 
-enum FeatureFlags {
-    /// Temporary kill switch while in-app search is hidden from release builds.
-    static let isSearchEnabled = true
-}
-
 enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
     case oneMinute = 60
     case twoMinutes = 120
@@ -26,8 +21,6 @@ enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
     static let defaultValue: Self = .fiveMinutes
 
     var id: Double { rawValue }
-
-    var timeInterval: TimeInterval { rawValue }
 
     var label: String {
         switch self {
@@ -159,7 +152,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
 
         setupStatusItem()
         updaterController.startUpdater()
-        setupHotKey()
+        registerHotKeys()
         setupCapture()
         setupTimers()
         setupObservers()
@@ -237,10 +230,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             )
         )
         statusItemController.setVisible(showMenuBarIcon)
-    }
-
-    private func setupHotKey() {
-        registerHotKeys()
     }
 
     private func keyboardShortcutsDidChange() {
@@ -644,7 +633,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             let rewindHistoryOption = RewindHistoryOption.resolved(from: self.rewindHistorySeconds)
             let availableDisplays = self.mergedDisplays(frameBuffer: frameBuffer)
             self.overlayController?.showOverlay(
-                recentTimelineWindow: recentTimelineWindow.timeInterval,
+                recentTimelineWindow: recentTimelineWindow.rawValue,
                 rewindHistoryOption: rewindHistoryOption,
                 activeDisplay: targetDisplay,
                 availableDisplays: availableDisplays
@@ -736,7 +725,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     private func currentCapturePolicy() -> CapturePolicy {
-        capturePolicyController.currentPolicy(
+        capturePolicyController.resolvePolicy(
             settings: currentCapturePolicySettings(),
             environment: currentCapturePolicyEnvironment()
         )
@@ -851,9 +840,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         statusItemController?.setPermissionHelpVisible(needsPermissionHelp)
     }
 
-    private func presentPermissionAlert(status: String, force: Bool = false) {
+    private func presentPermissionAlert(status: String) {
         updateCaptureStatus(status)
-        showPermissionAlert(force: force)
+        showPermissionAlert()
     }
 
     private func showPermissionAlert(force: Bool = false) {

--- a/JustNow/Capture/BlackFrameDetector.swift
+++ b/JustNow/Capture/BlackFrameDetector.swift
@@ -1,19 +1,13 @@
 import CoreGraphics
 
 struct BlackFrameDetector {
-    let gridSize: Int
-    let darkLumaThreshold: UInt8
-    let veryDarkLumaThreshold: UInt8
-    let maximumLumaRange: UInt8
-    let minimumDarkRatio: Double
+    static let screenOff = BlackFrameDetector()
 
-    static let screenOff = BlackFrameDetector(
-        gridSize: 8,
-        darkLumaThreshold: 5,
-        veryDarkLumaThreshold: 6,
-        maximumLumaRange: 3,
-        minimumDarkRatio: 0.95
-    )
+    private let gridSize = 8
+    private let darkLumaThreshold: UInt8 = 5
+    private let veryDarkLumaThreshold: UInt8 = 6
+    private let maximumLumaRange: UInt8 = 3
+    private let minimumDarkRatio = 0.95
 
     func isBlackFrame(_ image: CGImage) -> Bool {
         let width = image.width

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -54,10 +54,6 @@ struct SearchIndexStatus: Sendable, Equatable {
     let indexedFrames: Int
     let queuedFrames: Int
 
-    var pendingFrames: Int {
-        max(totalFrames - indexedFrames, 0)
-    }
-
     static let empty = SearchIndexStatus(totalFrames: 0, indexedFrames: 0, queuedFrames: 0)
 }
 
@@ -78,14 +74,6 @@ private struct PendingIngest {
     let displayID: UUID?
     let displayName: String?
     let syncContinuation: CheckedContinuation<SyncIngestResult, Never>?
-}
-
-private final class CachedCGImageBox {
-    let image: CGImage
-
-    init(_ image: CGImage) {
-        self.image = image
-    }
 }
 
 @MainActor
@@ -125,9 +113,9 @@ class FrameBuffer {
     var isPruningPaused: Bool = false
 
     // Thumbnail cache for quick access
-    private let thumbnailCache = NSCache<NSUUID, CachedCGImageBox>()
-    private let fullImageCache = NSCache<NSUUID, CachedCGImageBox>()
-    private var inFlightFullImageLoads: [UUID: Task<CachedCGImageBox, Error>] = [:]
+    private let thumbnailCache = NSCache<NSUUID, CGImage>()
+    private let fullImageCache = NSCache<NSUUID, CGImage>()
+    private var inFlightFullImageLoads: [UUID: Task<CGImage, Error>] = [:]
 
     private static let fullImageCacheByteBudget: Int = 256 * 1024 * 1024
     private static let thumbnailCacheByteBudget: Int = 16 * 1024 * 1024
@@ -321,11 +309,6 @@ class FrameBuffer {
         return filtered
     }
 
-    func getRecentFrames(within seconds: TimeInterval) -> [StoredFrame] {
-        let cutoff = Date().addingTimeInterval(-seconds)
-        return frames.filter { $0.timestamp >= cutoff }
-    }
-
     /// Displays that have at least one frame in the buffer. Ordered by most
     /// recent capture first so the overlay can surface active displays before
     /// ones that have gone quiet.
@@ -360,13 +343,13 @@ class FrameBuffer {
 
     /// Load full-resolution image from disk
     func getFullImage(for frame: StoredFrame) async throws -> CGImage {
-        try await loadFullImageBox(for: frame).image
+        try await loadFullImage(for: frame)
     }
 
     func prefetchFullImages(for frames: [StoredFrame]) async {
         for frame in frames {
             guard !Task.isCancelled else { return }
-            _ = try? await loadFullImageBox(for: frame)
+            _ = try? await loadFullImage(for: frame)
         }
     }
 
@@ -417,14 +400,14 @@ class FrameBuffer {
         let key = frame.id as NSUUID
 
         if let cached = thumbnailCache.object(forKey: key) {
-            return cached.image
+            return cached
         }
 
         guard let cgImage = await frameStore.loadThumbnail(id: frame.id) else {
             return nil
         }
 
-        thumbnailCache.setObject(CachedCGImageBox(cgImage), forKey: key, cost: Self.byteCost(of: cgImage))
+        thumbnailCache.setObject(cgImage, forKey: key, cost: Self.byteCost(of: cgImage))
         return cgImage
     }
 
@@ -496,7 +479,6 @@ class FrameBuffer {
             await ingestProcessorTask.value
         }
         await frameStore.flushManifest()
-        await textCache.save()
     }
 
     // MARK: - Private
@@ -550,7 +532,7 @@ class FrameBuffer {
         continuation.resume(returning: .cancelled)
     }
 
-    private func loadFullImageBox(for frame: StoredFrame) async throws -> CachedCGImageBox {
+    private func loadFullImage(for frame: StoredFrame) async throws -> CGImage {
         let key = frame.id as NSUUID
         if let cached = fullImageCache.object(forKey: key) {
             return cached
@@ -562,16 +544,15 @@ class FrameBuffer {
 
         let store = frameStore
         let loadTask = Task(priority: .userInitiated) {
-            let image = try await store.loadFullImage(id: frame.id)
-            return CachedCGImageBox(image)
+            try await store.loadFullImage(id: frame.id)
         }
         inFlightFullImageLoads[frame.id] = loadTask
 
         do {
-            let cachedImage = try await loadTask.value
-            fullImageCache.setObject(cachedImage, forKey: key, cost: Self.byteCost(of: cachedImage.image))
+            let image = try await loadTask.value
+            fullImageCache.setObject(image, forKey: key, cost: Self.byteCost(of: image))
             inFlightFullImageLoads.removeValue(forKey: frame.id)
-            return cachedImage
+            return image
         } catch {
             inFlightFullImageLoads.removeValue(forKey: frame.id)
             throw error
@@ -791,7 +772,7 @@ class FrameBuffer {
         guard ocrFrameQueue.enqueue(frame) else { return }
 
         applyOCRQueuePolicy(policy)
-        updateOCRIndexQueueState()
+        recordQueueDepthTelemetry()
         startBackgroundOCRIndexingIfNeeded()
     }
 
@@ -807,11 +788,6 @@ class FrameBuffer {
 
         ocrFrameQueue.enqueue(contentsOf: eligibleFrames)
         applyOCRQueuePolicy(policy)
-        updateOCRIndexQueueState()
-    }
-
-    /// Keep telemetry current without dropping retained frames from the indexing backlog.
-    private func updateOCRIndexQueueState() {
         recordQueueDepthTelemetry()
     }
 

--- a/JustNow/Capture/OCRIndexingWorker.swift
+++ b/JustNow/Capture/OCRIndexingWorker.swift
@@ -31,7 +31,7 @@ struct OCRIndexingWorkerDependencies: Sendable {
                         image = try await frameStore.loadFullImage(id: frame.id)
                     }
 
-                    let text = await TextRecognitionManager.extractText(from: image)
+                    let text = await TextRecognitionManager.extractText(from: image, mode: .searchIndex)
                     guard !Task.isCancelled else { return nil }
 
                     return OCRIndexedFrame(

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -26,10 +26,6 @@ protocol ScreenCaptureDelegate: AnyObject {
     func captureManagerDidStop(_ manager: ScreenCaptureManager)
 }
 
-extension ScreenCaptureDelegate {
-    func captureManagerDidStop(_ manager: ScreenCaptureManager) {}
-}
-
 /// Uses SCScreenshotManager for one-shot captures instead of SCStream.
 /// This avoids the persistent purple "sharing" indicator in the menu bar.
 @MainActor

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -17,19 +17,9 @@ enum FrameStoreError: Error {
 
 nonisolated struct FrameSaveOptions: Sendable, Equatable {
     let quality: CGFloat
-    let thumbnailQuality: CGFloat
-    let generateThumbnail: Bool
 
-    static let standard = FrameSaveOptions(
-        quality: ImageEncoder.fullImageQuality,
-        thumbnailQuality: ImageEncoder.thumbnailQuality,
-        generateThumbnail: false
-    )
-    static let lowPower = FrameSaveOptions(
-        quality: ImageEncoder.lowPowerFullImageQuality,
-        thumbnailQuality: ImageEncoder.lowPowerThumbnailQuality,
-        generateThumbnail: false
-    )
+    static let standard = FrameSaveOptions(quality: ImageEncoder.fullImageQuality)
+    static let lowPower = FrameSaveOptions(quality: ImageEncoder.lowPowerFullImageQuality)
 }
 
 actor FrameStore {
@@ -110,22 +100,14 @@ actor FrameStore {
         let thumbnailFilename = "\(id.uuidString)_thumb.jpg"
 
         let fullPath = framesURL.appendingPathComponent(filename)
-        let thumbPath = framesURL.appendingPathComponent(thumbnailFilename)
 
         // Encode full image
         guard let fullData = ImageEncoder.jpegData(from: cgImage, quality: options.quality) else {
             throw FrameStoreError.imageEncodingFailed
         }
 
-        // Write files
+        // Write full image; thumbnails are generated lazily on first load.
         try fullData.write(to: fullPath)
-        if options.generateThumbnail {
-            guard let thumbnail = ImageEncoder.generateThumbnail(from: cgImage),
-                  let thumbData = ImageEncoder.jpegData(from: thumbnail, quality: options.thumbnailQuality) else {
-                throw FrameStoreError.imageEncodingFailed
-            }
-            try thumbData.write(to: thumbPath)
-        }
 
         let metadata = FrameMetadata(
             id: id,

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -11,7 +11,6 @@ nonisolated struct RetentionTier: Sendable, Equatable {
 }
 
 nonisolated struct RetentionPolicy: Sendable, Equatable {
-    let maximumAge: TimeInterval
     let tiers: [RetentionTier]
 
     static let default24Hours = rewindHistory(RewindHistoryOption.defaultValue)
@@ -48,7 +47,7 @@ nonisolated struct RetentionPolicy: Sendable, Equatable {
             ]
         }
 
-        return RetentionPolicy(maximumAge: maximumAge, tiers: tiers)
+        return RetentionPolicy(tiers: tiers)
     }
 }
 
@@ -70,10 +69,6 @@ final class RetentionManager {
 
         for frame in frames {
             let age = currentTime.timeIntervalSince(frame.timestamp)
-
-            guard age <= policy.maximumAge else {
-                continue
-            }
 
             guard let tierIndex = policy.tiers.firstIndex(where: { age <= $0.maxAge }) else {
                 continue

--- a/JustNow/Storage/TextCache.swift
+++ b/JustNow/Storage/TextCache.swift
@@ -54,19 +54,6 @@ actor TextCache {
         }
     }
 
-    /// Get cached text for a frame, returns nil if not cached
-    func getText(for frameID: UUID) -> String? {
-        try? withPreparedStatement("SELECT text FROM frame_text WHERE frame_id = ? LIMIT 1;") { statement in
-            guard bindFrameID(frameID, to: statement),
-                  sqlite3_step(statement) == SQLITE_ROW,
-                  let cText = sqlite3_column_text(statement, 0) else {
-                return nil
-            }
-
-            return String(cString: cText)
-        }
-    }
-
     func getSearchLayout(for frameID: UUID) -> SearchTextLayout? {
         try? withPreparedStatement(
             "SELECT layout_json FROM frame_search_layout WHERE frame_id = ? LIMIT 1;"
@@ -171,30 +158,6 @@ actor TextCache {
 
             return sqlite3_step(statement) == SQLITE_ROW
         }) ?? false
-    }
-
-    /// Return IDs that already have indexed text
-    func cachedFrameIDs(in frameIDs: [UUID]) -> Set<UUID> {
-        guard !frameIDs.isEmpty else { return [] }
-
-        var cached: Set<UUID> = []
-        for chunk in chunked(frameIDs, size: Self.inClauseChunkSize) {
-            let placeholders = Array(repeating: "?", count: chunk.count).joined(separator: ",")
-            let sql = "SELECT frame_id FROM frame_text WHERE frame_id IN (\(placeholders));"
-            try? withPreparedStatement(sql) { statement in
-                guard bindFrameIDs(chunk, to: statement) else { return }
-
-                while sqlite3_step(statement) == SQLITE_ROW {
-                    guard let cText = sqlite3_column_text(statement, 0) else { continue }
-                    let raw = String(cString: cText)
-                    if let id = UUID(uuidString: raw) {
-                        cached.insert(id)
-                    }
-                }
-            }
-        }
-
-        return cached
     }
 
     /// Search indexed OCR text and return matching frame IDs ordered by recency.
@@ -310,11 +273,6 @@ actor TextCache {
         }
 
         return fallbackIDs
-    }
-
-    /// Save cache to disk (call periodically or on app termination)
-    func save() {
-        // No-op: SQLite writes are committed transactionally.
     }
 
     /// Remove cached text for frames that no longer exist

--- a/JustNow/Storage/ThumbnailGenerator.swift
+++ b/JustNow/Storage/ThumbnailGenerator.swift
@@ -11,7 +11,6 @@ nonisolated enum ImageEncoder {
     static let thumbnailMaxSize: CGFloat = 200
     static let thumbnailQuality: CGFloat = 0.7
     static let fullImageQuality: CGFloat = 0.85
-    static let lowPowerThumbnailQuality: CGFloat = 0.6
     static let lowPowerFullImageQuality: CGFloat = 0.7
 
     /// Generate a thumbnail from a CGImage

--- a/JustNow/UI/KeyboardShortcutRecorder.swift
+++ b/JustNow/UI/KeyboardShortcutRecorder.swift
@@ -11,7 +11,6 @@ struct KeyboardShortcutRecorder: View {
     @Binding var keyCode: Int
     @Binding var modifiers: Int
 
-    var allowsBareKeys: Bool = false
     var allowsEscapeShortcut: Bool = false
     var placeholder: String = "Click to set"
 
@@ -24,7 +23,6 @@ struct KeyboardShortcutRecorder: View {
                 keyCode: $keyCode,
                 modifiers: $modifiers,
                 isRecording: $isRecording,
-                allowsBareKeys: allowsBareKeys,
                 allowsEscapeShortcut: allowsEscapeShortcut,
                 placeholder: placeholder
             )
@@ -58,21 +56,18 @@ struct RecorderField: NSViewRepresentable {
     @Binding var modifiers: Int
     @Binding var isRecording: Bool
 
-    var allowsBareKeys: Bool
     var allowsEscapeShortcut: Bool
     var placeholder: String
 
     func makeNSView(context: Context) -> RecorderNSView {
         let view = RecorderNSView()
         view.delegate = context.coordinator
-        view.allowsBareKeys = allowsBareKeys
         view.allowsEscapeShortcut = allowsEscapeShortcut
         view.placeholder = placeholder
         return view
     }
 
     func updateNSView(_ nsView: RecorderNSView, context: Context) {
-        nsView.allowsBareKeys = allowsBareKeys
         nsView.allowsEscapeShortcut = allowsEscapeShortcut
         nsView.placeholder = placeholder
         nsView.updateDisplay(keyCode: keyCode, modifiers: modifiers, isRecording: isRecording)
@@ -116,7 +111,6 @@ protocol RecorderNSViewDelegate: AnyObject {
 class RecorderNSView: NSView {
     weak var delegate: RecorderNSViewDelegate?
 
-    var allowsBareKeys = false
     var allowsEscapeShortcut = false
     var placeholder = "Click to set"
 
@@ -181,8 +175,8 @@ class RecorderNSView: NSView {
         let isEscape = event.keyCode == UInt16(kVK_Escape)
         let hasModifierOrAllowedEscape = hasModifier || (isEscape && allowsEscapeShortcut)
 
-        // Require at least one modifier unless bare keys are explicitly allowed.
-        guard allowsBareKeys || hasModifierOrAllowedEscape else {
+        // Require at least one modifier (or the escape key when this recorder allows it).
+        guard hasModifierOrAllowedEscape else {
             return
         }
 

--- a/JustNow/UI/OverlayFramePreviewView.swift
+++ b/JustNow/UI/OverlayFramePreviewView.swift
@@ -181,15 +181,9 @@ struct FramePreviewView: View {
         }
     }
 
-    private func aspectRatio(of image: CGImage) -> CGFloat {
-        let width = max(1, CGFloat(image.width))
-        let height = max(1, CGFloat(image.height))
-        return width / height
-    }
-
     private func fittedSize(for image: CGImage, in available: CGSize) -> CGSize {
         guard available.width > 0, available.height > 0 else { return .zero }
-        let aspect = aspectRatio(of: image)
+        let aspect = max(1, CGFloat(image.width)) / max(1, CGFloat(image.height))
         if available.width / available.height > aspect {
             let height = available.height
             return CGSize(width: height * aspect, height: height)

--- a/JustNow/UI/OverlayInstructionViews.swift
+++ b/JustNow/UI/OverlayInstructionViews.swift
@@ -14,10 +14,10 @@ struct InstructionsOverlay: View {
         let dragIcon = isScreenshotMode ? "camera.viewfinder" : "text.viewfinder"
 
         ViewThatFits(in: .horizontal) {
-            instructionPill(dragLabel: dragLabel, dragIcon: dragIcon, showsSearchShortcut: FeatureFlags.isSearchEnabled)
-            instructionPill(dragLabel: shortened(dragLabel, to: 1), dragIcon: dragIcon, showsSearchShortcut: FeatureFlags.isSearchEnabled)
-            instructionPill(dragLabel: shortened(dragLabel, to: 2), dragIcon: dragIcon, showsSearchShortcut: FeatureFlags.isSearchEnabled)
-            instructionPill(dragLabel: "", dragIcon: dragIcon, showsSearchShortcut: FeatureFlags.isSearchEnabled)
+            instructionPill(dragLabel: dragLabel, dragIcon: dragIcon)
+            instructionPill(dragLabel: shortened(dragLabel, to: 1), dragIcon: dragIcon)
+            instructionPill(dragLabel: shortened(dragLabel, to: 2), dragIcon: dragIcon)
+            instructionPill(dragLabel: "", dragIcon: dragIcon)
         }
     }
 
@@ -33,7 +33,7 @@ struct InstructionsOverlay: View {
         }
     }
 
-    private func instructionPill(dragLabel: String, dragIcon: String, showsSearchShortcut: Bool) -> some View {
+    private func instructionPill(dragLabel: String, dragIcon: String) -> some View {
         HStack(spacing: 16) {
             Label("← →", systemImage: "arrow.left.arrow.right")
             if dragLabel.isEmpty {
@@ -44,9 +44,7 @@ struct InstructionsOverlay: View {
                 Label(dragLabel, systemImage: dragIcon)
             }
             Label("\u{2318}S", systemImage: "camera.viewfinder")
-            if showsSearchShortcut {
-                Label("/", systemImage: "magnifyingglass")
-            }
+            Label("/", systemImage: "magnifyingglass")
         }
         .labelStyle(CompactInstructionLabelStyle())
         .font(.system(size: 11, weight: .medium))

--- a/JustNow/UI/OverlaySearchViews.swift
+++ b/JustNow/UI/OverlaySearchViews.swift
@@ -4,6 +4,13 @@ struct SearchBarView: View {
     var viewModel: OverlayViewModel
     @FocusState private var isFocused: Bool
 
+    private var indexPercent: Int {
+        let status = viewModel.searchIndexStatus
+        return status.totalFrames > 0
+            ? Int(round(Double(status.indexedFrames) / Double(status.totalFrames) * 100))
+            : 100
+    }
+
     var body: some View {
         HStack(spacing: 12) {
             Image(systemName: "magnifyingglass")
@@ -24,10 +31,6 @@ struct SearchBarView: View {
             if viewModel.isSearchLoading {
                 SearchingStatusBadge()
             } else if !viewModel.searchResults.isEmpty {
-                let status = viewModel.searchIndexStatus
-                let indexPercent = status.totalFrames > 0
-                    ? Int(round(Double(status.indexedFrames) / Double(status.totalFrames) * 100))
-                    : 100
                 if indexPercent < 100 {
                     Text("\(viewModel.searchResults.count) found · \(indexPercent)% indexed")
                         .font(.caption)
@@ -38,10 +41,6 @@ struct SearchBarView: View {
                         .foregroundStyle(.white.opacity(0.6))
                 }
             } else {
-                let status = viewModel.searchIndexStatus
-                let indexPercent = status.totalFrames > 0
-                    ? Int(round(Double(status.indexedFrames) / Double(status.totalFrames) * 100))
-                    : 100
                 if indexPercent < 100 {
                     Text("\(indexPercent)% indexed")
                         .font(.caption)

--- a/JustNow/UI/OverlayTimeline.swift
+++ b/JustNow/UI/OverlayTimeline.swift
@@ -64,10 +64,6 @@ struct TimelineSlider: View {
         )
     }
 
-    private var currentFrame: StoredFrame? {
-        displayedFrames[safe: viewModel.selectedIndex]
-    }
-
     var body: some View {
         VStack(spacing: 12) {
             TimeLabels(frames: displayedFrames)

--- a/JustNow/UI/OverlayViewModel.swift
+++ b/JustNow/UI/OverlayViewModel.swift
@@ -35,32 +35,6 @@ enum SearchTimeScope: String, CaseIterable {
     case rewindHistory
     case all
 
-    var label: String {
-        switch self {
-        case .fiveMinutes:
-            return "Last 5m"
-        case .oneHour:
-            return "Last 1h"
-        case .rewindHistory:
-            return RewindHistoryOption.defaultValue.searchLabel
-        case .all:
-            return "All"
-        }
-    }
-
-    var compactLabel: String {
-        switch self {
-        case .fiveMinutes:
-            return "5m"
-        case .oneHour:
-            return "1h"
-        case .rewindHistory:
-            return RewindHistoryOption.defaultValue.compactSearchLabel
-        case .all:
-            return "All"
-        }
-    }
-
     func label(using option: RewindHistoryOption) -> String {
         switch self {
         case .fiveMinutes:
@@ -154,7 +128,7 @@ class OverlayViewModel {
     var isRegionScreenshotArmed: Bool = false
 
     var isSearchAvailable: Bool {
-        FeatureFlags.isSearchEnabled
+        true
     }
 
     var hasSearchQuery: Bool {
@@ -600,12 +574,6 @@ class OverlayViewModel {
             guard !Task.isCancelled else { return }
             saveToast = nil
         }
-    }
-
-    func dismissSaveToast() {
-        saveToastTask?.cancel()
-        saveToastTask = nil
-        saveToast = nil
     }
 
     func revealSavedFile(_ url: URL) {

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -46,10 +46,6 @@ struct SettingsView: View {
     @State private var launchAtLoginEnabled = false
     @State private var launchAtLoginAlertMessage: String?
 
-    private var isSearchEnabled: Bool {
-        FeatureFlags.isSearchEnabled
-    }
-
     var body: some View {
         TabView {
             generalSettingsTab
@@ -72,11 +68,7 @@ struct SettingsView: View {
         .task(id: launchAtLoginIdentity) {
             syncLaunchAtLoginState()
         }
-        .task(id: isSearchEnabled) {
-            guard isSearchEnabled else {
-                telemetrySnapshot = .empty
-                return
-            }
+        .task {
             await refreshTelemetryLoop()
         }
         .alert("Clear History?", isPresented: $showClearConfirmation) {
@@ -300,60 +292,44 @@ struct SettingsView: View {
                 }
             }
 
-            if isSearchEnabled {
-                Section("Search Diagnostics") {
-                    DisclosureGroup(isExpanded: $isSearchDiagnosticsExpanded) {
-                        VStack(spacing: 10) {
-                            HStack {
-                                Text("Index queue")
-                                Spacer()
-                                Text("\(telemetrySnapshot.queueDepth) / \(telemetrySnapshot.queueCapacity)")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            HStack {
-                                Text("OCR throughput")
-                                Spacer()
-                                Text("\(formatRate(telemetrySnapshot.ocrPerSecond))")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            HStack {
-                                Text("OCR duration (avg/p95)")
-                                Spacer()
-                                Text("\(formatSeconds(telemetrySnapshot.averageOCRDuration)) / \(formatSeconds(telemetrySnapshot.p95OCRDuration))")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            HStack {
-                                Text("Index lag (avg/p95)")
-                                Spacer()
-                                Text("\(formatSeconds(telemetrySnapshot.averageIndexLag)) / \(formatSeconds(telemetrySnapshot.p95IndexLag))")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            HStack {
-                                Text("Warm search p50")
-                                Spacer()
-                                Text("\(formatSeconds(telemetrySnapshot.warmSearchP50)) · n=\(telemetrySnapshot.warmSearchCount)")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            HStack {
-                                Text("Cold search p50")
-                                Spacer()
-                                Text("\(formatSeconds(telemetrySnapshot.coldSearchP50)) · n=\(telemetrySnapshot.coldSearchCount)")
-                                    .foregroundStyle(.secondary)
-                            }
-
-                            Text("These numbers update every 2 seconds from local telemetry.")
-                                .font(.caption)
+            Section("Search Diagnostics") {
+                DisclosureGroup(isExpanded: $isSearchDiagnosticsExpanded) {
+                    VStack(spacing: 10) {
+                        HStack {
+                            Text("Index queue")
+                            Spacer()
+                            Text("\(telemetrySnapshot.queueDepth) / \(telemetrySnapshot.queueCapacity)")
                                 .foregroundStyle(.secondary)
                         }
-                        .padding(.top, 6)
-                    } label: {
-                        Text("Local search telemetry")
+
+                        HStack {
+                            Text("OCR throughput")
+                            Spacer()
+                            Text("\(formatRate(telemetrySnapshot.ocrPerSecond))")
+                                .foregroundStyle(.secondary)
+                        }
+
+                        HStack {
+                            Text("OCR duration (avg/p95)")
+                            Spacer()
+                            Text("\(formatSeconds(telemetrySnapshot.averageOCRDuration)) / \(formatSeconds(telemetrySnapshot.p95OCRDuration))")
+                                .foregroundStyle(.secondary)
+                        }
+
+                        HStack {
+                            Text("Index lag (avg/p95)")
+                            Spacer()
+                            Text("\(formatSeconds(telemetrySnapshot.averageIndexLag)) / \(formatSeconds(telemetrySnapshot.p95IndexLag))")
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Text("These numbers update every 2 seconds from local telemetry.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
+                    .padding(.top, 6)
+                } label: {
+                    Text("Local search telemetry")
                 }
             }
         }

--- a/JustNow/Utilities/CapturePolicyController.swift
+++ b/JustNow/Utilities/CapturePolicyController.swift
@@ -72,13 +72,6 @@ final class CapturePolicyController {
         lastAppliedPolicy?.isIdle == true
     }
 
-    func currentPolicy(
-        settings: CapturePolicySettings,
-        environment: CapturePolicyEnvironment
-    ) -> CapturePolicy {
-        resolvePolicy(settings: settings, environment: environment)
-    }
-
     func applyIfNeeded(
         settings: CapturePolicySettings,
         environment: CapturePolicyEnvironment,

--- a/JustNow/Utilities/Permiso/PermisoAssistant.swift
+++ b/JustNow/Utilities/Permiso/PermisoAssistant.swift
@@ -24,24 +24,12 @@ final class PermisoAssistant {
         panel: PermisoPanel,
         sourceFrameInScreen: CGRect? = nil
     ) {
-        present(
-            panel: panel,
-            hostApp: .current(),
-            sourceFrameInScreen: sourceFrameInScreen
-        )
-    }
-
-    func present(
-        panel: PermisoPanel,
-        hostApp: PermisoHostApp,
-        sourceFrameInScreen: CGRect? = nil
-    ) {
         dismiss()
 
         activePanel = panel
         pendingSourceFrameInScreen = sourceFrameInScreen
         didPresentCurrentOverlay = false
-        overlayController = PermisoOverlayWindowController(hostApp: hostApp, panel: panel) { [weak self] in
+        overlayController = PermisoOverlayWindowController(hostApp: .current(), panel: panel) { [weak self] in
             self?.dismiss()
         }
         NSWorkspace.shared.open(panel.settingsURL)

--- a/JustNow/Utilities/Permiso/PermisoOverlayWindowController.swift
+++ b/JustNow/Utilities/Permiso/PermisoOverlayWindowController.swift
@@ -10,7 +10,6 @@ final class PermisoOverlayWindowController: NSWindowController {
     private let windowSize = NSSize(width: 530, height: 109)
     private let launchAnimationDuration: TimeInterval = 0.72
     private let launchAnimationResponse: Double = 0.72
-    private let launchAnimationDampingFraction: Double = 1.0
     private let initialAlpha: CGFloat = 0.9
     private var launchDisplayLink: CADisplayLink?
     private var launchStartTime: CFTimeInterval = 0
@@ -125,18 +124,11 @@ final class PermisoOverlayWindowController: NSWindowController {
         launchDisplayLink = nil
     }
 
-    // Hopper shows the transition builder fed with 0.72 and 1.0; model it as a critically damped spring.
+    // Hopper shows the transition builder fed with 0.72; model it as a critically damped spring.
     private func springProgress(at elapsed: TimeInterval) -> CGFloat {
         let omega = (2 * Double.pi) / launchAnimationResponse
         let t = max(0, elapsed)
-        let progress: Double
-
-        if abs(launchAnimationDampingFraction - 1) < 0.0001 {
-            progress = 1 - exp(-omega * t) * (1 + (omega * t))
-        } else {
-            progress = min(1, t / launchAnimationDuration)
-        }
-
+        let progress = 1 - exp(-omega * t) * (1 + (omega * t))
         return min(max(progress, 0), 1)
     }
 

--- a/JustNow/Utilities/SearchTelemetry.swift
+++ b/JustNow/Utilities/SearchTelemetry.swift
@@ -13,10 +13,6 @@ struct SearchTelemetrySnapshot: Sendable {
     let p95OCRDuration: TimeInterval
     let averageIndexLag: TimeInterval
     let p95IndexLag: TimeInterval
-    let warmSearchP50: TimeInterval
-    let warmSearchCount: Int
-    let coldSearchP50: TimeInterval
-    let coldSearchCount: Int
 
     static let empty = SearchTelemetrySnapshot(
         queueDepth: 0,
@@ -25,11 +21,7 @@ struct SearchTelemetrySnapshot: Sendable {
         averageOCRDuration: 0,
         p95OCRDuration: 0,
         averageIndexLag: 0,
-        p95IndexLag: 0,
-        warmSearchP50: 0,
-        warmSearchCount: 0,
-        coldSearchP50: 0,
-        coldSearchCount: 0
+        p95IndexLag: 0
     )
 }
 
@@ -47,9 +39,6 @@ actor SearchTelemetry {
     private var ocrDurationSamples: [TimeInterval] = []
     private var indexLagSamples: [TimeInterval] = []
 
-    private var warmSearchDurations: [TimeInterval] = []
-    private var coldSearchDurations: [TimeInterval] = []
-
     private var lastSummaryLog: Date = .distantPast
 
     func snapshot() -> SearchTelemetrySnapshot {
@@ -63,11 +52,7 @@ actor SearchTelemetry {
             averageOCRDuration: average(ocrDurationSamples),
             p95OCRDuration: percentile(ocrDurationSamples, percentile: 0.95),
             averageIndexLag: average(indexLagSamples),
-            p95IndexLag: percentile(indexLagSamples, percentile: 0.95),
-            warmSearchP50: percentile(warmSearchDurations, percentile: 0.5),
-            warmSearchCount: warmSearchDurations.count,
-            coldSearchP50: percentile(coldSearchDurations, percentile: 0.5),
-            coldSearchCount: coldSearchDurations.count
+            p95IndexLag: percentile(indexLagSamples, percentile: 0.95)
         )
     }
 
@@ -87,40 +72,6 @@ actor SearchTelemetry {
         appendSample(max(indexLag, 0), to: &indexLagSamples)
 
         maybeLogSummary(now: now, reason: "index")
-    }
-
-    func recordSearch(
-        duration: TimeInterval,
-        wasCold: Bool,
-        totalFrames: Int,
-        uncachedFrames: Int,
-        matches: Int,
-        ocrRuns: Int,
-        loadFailures: Int
-    ) {
-        let safeDuration = max(duration, 0)
-
-        if wasCold {
-            appendSample(safeDuration, to: &coldSearchDurations)
-        } else {
-            appendSample(safeDuration, to: &warmSearchDurations)
-        }
-
-        let mode = wasCold ? "cold" : "warm"
-        print(
-            String(
-                format: "[SearchTelemetry] %@ search %.3fs (%d matches, %d/%d uncached, %d OCR runs, %d load failures)",
-                mode,
-                safeDuration,
-                matches,
-                uncachedFrames,
-                totalFrames,
-                ocrRuns,
-                loadFailures
-            )
-        )
-
-        maybeLogSummary(now: Date(), reason: "search")
     }
 
     private func appendSample(_ value: TimeInterval, to samples: inout [TimeInterval]) {
@@ -145,22 +96,15 @@ actor SearchTelemetry {
         let averageLag = average(indexLagSamples)
         let p95Lag = percentile(indexLagSamples, percentile: 0.95)
 
-        let warmP50 = percentile(warmSearchDurations, percentile: 0.5)
-        let coldP50 = percentile(coldSearchDurations, percentile: 0.5)
-
         print(
             String(
-                format: "[SearchTelemetry] summary[%@] queue=%d/%d ocr=%.2f/s lag(avg=%.1fs p95=%.1fs) warm(p50=%.3fs n=%d) cold(p50=%.3fs n=%d)",
+                format: "[SearchTelemetry] summary[%@] queue=%d/%d ocr=%.2f/s lag(avg=%.1fs p95=%.1fs)",
                 reason,
                 queueDepth,
                 queueCapacity,
                 ocrPerSecond,
                 averageLag,
-                p95Lag,
-                warmP50,
-                warmSearchDurations.count,
-                coldP50,
-                coldSearchDurations.count
+                p95Lag
             )
         )
     }

--- a/JustNow/Utilities/TextRecognitionManager.swift
+++ b/JustNow/Utilities/TextRecognitionManager.swift
@@ -18,13 +18,7 @@ enum TextRecognitionMode: Sendable {
 nonisolated enum TextRecognitionManager {
     private static let logger = Logger(subsystem: "sg.tk.JustNow", category: "TextRecognition")
 
-    /// Fast OCR used for background indexing.
-    @concurrent
-    @Sendable
-    static func extractText(from image: CGImage) async -> String {
-        await extractText(from: image, mode: .searchIndex)
-    }
-
+    /// Fast OCR used for background indexing and user-driven text grabs.
     @concurrent
     @Sendable
     static func extractText(from image: CGImage, mode: TextRecognitionMode) async -> String {
@@ -128,17 +122,6 @@ nonisolated enum TextRecognitionManager {
         }
 
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    /// Searches for text in a frame, returns true if found.
-    @concurrent
-    static func frameContainsText(_ searchText: String, in image: CGImage) async -> Bool {
-        let extractedText = await extractText(from: image)
-        let contains = extractedText.localizedCaseInsensitiveContains(searchText)
-        if contains {
-            Self.logger.info("Found '\(searchText)' in frame")
-        }
-        return contains
     }
 
     private static func collapseInlineWhitespace(_ text: String) -> String {

--- a/JustNowTests/CapturePolicyControllerTests.swift
+++ b/JustNowTests/CapturePolicyControllerTests.swift
@@ -2,20 +2,10 @@ import Foundation
 import XCTest
 @testable import JustNow
 
-private enum CapturePolicyControllerTestLifetime {
-    static var retainedControllers: [CapturePolicyController] = []
-
-    static func retain(_ controller: CapturePolicyController) {
-        retainedControllers.append(controller)
-    }
-}
-
 @MainActor
 final class CapturePolicyControllerTests: XCTestCase {
     func testResolvePolicyUsesLowPowerProfileOnBattery() {
         let controller = CapturePolicyController()
-        CapturePolicyControllerTestLifetime.retain(controller)
-
         let policy = controller.resolvePolicy(
             settings: CapturePolicySettings(captureInterval: 2, reduceCaptureOnBattery: true),
             environment: CapturePolicyEnvironment(
@@ -47,8 +37,6 @@ final class CapturePolicyControllerTests: XCTestCase {
 
     func testResolvePolicyDisablesOCRAtCriticalBatteryCharge() {
         let controller = CapturePolicyController()
-        CapturePolicyControllerTestLifetime.retain(controller)
-
         let policy = controller.resolvePolicy(
             settings: CapturePolicySettings(captureInterval: 4, reduceCaptureOnBattery: true),
             environment: CapturePolicyEnvironment(
@@ -79,8 +67,6 @@ final class CapturePolicyControllerTests: XCTestCase {
 
     func testResolvePolicyCombinesIdleAndThermalConstraints() {
         let controller = CapturePolicyController()
-        CapturePolicyControllerTestLifetime.retain(controller)
-
         let policy = controller.resolvePolicy(
             settings: CapturePolicySettings(captureInterval: 2, reduceCaptureOnBattery: true),
             environment: CapturePolicyEnvironment(
@@ -113,7 +99,6 @@ final class CapturePolicyControllerTests: XCTestCase {
 
     func testApplyIfNeededSkipsDuplicatePolicyApplications() {
         let controller = CapturePolicyController()
-        CapturePolicyControllerTestLifetime.retain(controller)
         let settings = CapturePolicySettings(captureInterval: 1, reduceCaptureOnBattery: false)
         let environment = CapturePolicyEnvironment(
             isOnBattery: false,
@@ -156,7 +141,6 @@ final class CapturePolicyControllerTests: XCTestCase {
 
     func testNoteUserActivityOnlyRefreshesWhenComingBackFromIdle() {
         let controller = CapturePolicyController()
-        CapturePolicyControllerTestLifetime.retain(controller)
         let idleSettings = CapturePolicySettings(captureInterval: 1, reduceCaptureOnBattery: true)
         let idleEnvironment = CapturePolicyEnvironment(
             isOnBattery: false,

--- a/JustNowTests/OverlayBackdropPerformanceTests.swift
+++ b/JustNowTests/OverlayBackdropPerformanceTests.swift
@@ -18,29 +18,6 @@ final class OverlayBackdropPerformanceTests: XCTestCase {
         }
     }
 
-    func testBackdropFullResolutionPreparationPerformance() throws {
-        let image = try XCTUnwrap(makeTestImage(width: 3840, height: 2160))
-
-        measure(metrics: [XCTClockMetric()]) {
-            guard let context = CGContext(
-                data: nil,
-                width: image.width,
-                height: image.height,
-                bitsPerComponent: 8,
-                bytesPerRow: 0,
-                space: CGColorSpaceCreateDeviceRGB(),
-                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-            ) else {
-                XCTFail("Failed to create context")
-                return
-            }
-
-            context.interpolationQuality = .medium
-            context.draw(image, in: CGRect(x: 0, y: 0, width: image.width, height: image.height))
-            XCTAssertNotNil(context.makeImage())
-        }
-    }
-
     private func makeTestImage(width: Int, height: Int) -> CGImage? {
         guard let context = CGContext(
             data: nil,


### PR DESCRIPTION
Repo-wide ponytail-audit cleanup. **Net −325 lines, 0 dependencies.** No behaviour change — build compiles and all **87 tests pass**. Three independent adversarial (opus) reviews found no correctness, reference-integrity, or concurrency regressions.

## What changed

**Dead code removed**
- `TextCache.getText` / `cachedFrameIDs` / `save()` (the last a documented no-op)
- `FrameBuffer.getRecentFrames`, `SearchIndexStatus.pendingFrames`
- `TextRecognitionManager.frameContainsText`
- `OverlayViewModel.dismissSaveToast`, `SearchTimeScope` no-arg `label`/`compactLabel`
- `TimelineSlider.currentFrame`; `ScreenCaptureDelegate` empty default impl
- CoreGraphics-only backdrop perf test; `CapturePolicyController` test-retain scaffold

**Single-caller wrappers / indirections inlined**
- `updateOCRIndexQueueState`, `CapturePolicyController.currentPolicy`, `setupHotKey`, `RecentTimelineWindow.timeInterval`, `aspectRatio(of:)`, `PermisoAssistant.present` overload, `TextRecognitionManager.extractText` convenience, duplicated `SearchBarView` index-percent computation

**Dead config / always-on flag removed**
- `FeatureFlags.isSearchEnabled` kill switch (search is always on)
- warm/cold `SearchTelemetry` slice (`recordSearch` was never called) and its permanently-zero Settings diagnostics rows
- `KeyboardShortcutRecorder.allowsBareKeys`, `presentPermissionAlert(force:)`, `FrameSaveOptions` thumbnail fields + `ImageEncoder.lowPowerThumbnailQuality`, `BlackFrameDetector` configurable thresholds, `RetentionPolicy.maximumAge` (redundant prune guard), Permiso launch-animation damping dead branch

**Other**
- `FrameBuffer` image caches store `CGImage` directly instead of a wrapper box

## Deliberately NOT done (2 audit findings skipped)
- **`OverlayWindowLayout` inline** — kept. Its one-line `contentFrame` encodes the window-local-origin invariant from the shipped #35 secondary-display fix and has a dedicated regression test; inlining would trade a real regression guard for ~12 lines.
- **`startCaptureForGrantedLaunchPermission` → `startCaptureIfAllowed` merge** — kept separate. The launch path intentionally omits the leading `canStartCapture()` pre-guard and shows a user-facing error alert (vs only logging); merging would change launch error-handling behaviour.

## Verification
- `xcodebuild ... build` ✅
- `xcodebuild ... test` ✅ 87 passed / 0 failed across 20 suites
- Adversarial opus review ×3 (behaviour change, reference integrity, concurrency/CGImage) — all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)