### PR TITLE
Add high-fidelity capture with progressive history falloff

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -848,7 +848,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
 
     private func currentCapturePolicySettings() -> CapturePolicySettings {
         CapturePolicySettings(
-            captureInterval: captureInterval,
+            captureInterval: CaptureIntervalSetting.resolved(from: captureInterval),
             reduceCaptureOnBattery: reduceCaptureOnBattery
         )
     }

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -12,13 +12,15 @@ import os.log
 private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
 private let inputActivityForwardingInterval: TimeInterval = 1.0
 
-enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
+nonisolated enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
     case oneMinute = 60
     case twoMinutes = 120
     case fiveMinutes = 300
     case tenMinutes = 600
+    case fifteenMinutes = 900
+    case thirtyMinutes = 1800
 
-    static let defaultValue: Self = .fiveMinutes
+    static let defaultValue: Self = .fifteenMinutes
 
     var id: Double { rawValue }
 
@@ -32,6 +34,10 @@ enum RecentTimelineWindow: Double, CaseIterable, Identifiable {
             return "5 min"
         case .tenMinutes:
             return "10 min"
+        case .fifteenMinutes:
+            return "15 min"
+        case .thirtyMinutes:
+            return "30 min"
         }
     }
 
@@ -771,7 +777,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     private func currentRetentionPolicy() -> RetentionPolicy {
-        RewindHistoryOption.resolved(from: rewindHistorySeconds).retentionPolicy
+        RetentionPolicy.rewindHistory(
+            RewindHistoryOption.resolved(from: rewindHistorySeconds),
+            captureInterval: captureInterval,
+            fullDetailWindow: RecentTimelineWindow.resolved(from: recentTimelineWindowSeconds).rawValue
+        )
     }
 
     private func currentCapturePolicy() -> CapturePolicy {

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -26,7 +26,7 @@ struct DuplicateFramePolicy: Sendable, Equatable {
     static let lowPower = DuplicateFramePolicy(hashThreshold: 1, minimumSpacing: 5)
 
     static func exact(atMostEvery interval: TimeInterval) -> DuplicateFramePolicy {
-        let clampedInterval = max(interval, 0.5)
+        let clampedInterval = max(interval, 0.25)
         return DuplicateFramePolicy(hashThreshold: 0, minimumSpacing: clampedInterval)
     }
 }

--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -22,7 +22,7 @@ struct DuplicateFramePolicy: Sendable, Equatable {
     let hashThreshold: Int
     let minimumSpacing: TimeInterval
 
-    static let standard = DuplicateFramePolicy.exact(atMostEvery: 0.5)
+    static let standard = DuplicateFramePolicy.exact(atMostEvery: AppStorageDefault.captureInterval)
     static let lowPower = DuplicateFramePolicy(hashThreshold: 1, minimumSpacing: 5)
 
     static func exact(atMostEvery interval: TimeInterval) -> DuplicateFramePolicy {

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -23,6 +23,8 @@ nonisolated struct FrameSaveOptions: Sendable, Equatable {
 }
 
 actor FrameStore {
+    private nonisolated static let legacyManifestDateFormatter = ISO8601DateFormatter()
+
     private let fileManager = FileManager.default
     private let storageURL: URL
     private let framesURL: URL
@@ -140,8 +142,7 @@ actor FrameStore {
         // Backwards compatibility for manifests written with the old
         // JSONEncoder ISO-8601 date strategy.
         let encodedDate = try container.decode(String.self)
-        let formatter = ISO8601DateFormatter()
-        guard let date = formatter.date(from: encodedDate) else {
+        guard let date = legacyManifestDateFormatter.date(from: encodedDate) else {
             throw DecodingError.dataCorruptedError(
                 in: container,
                 debugDescription: "Invalid manifest date: \(encodedDate)"

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -35,7 +35,10 @@ actor FrameStore {
     private var manifestSaveTask: Task<Void, Never>?
     private let manifestEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
+        // Numeric seconds retain sub-second capture timestamps. The previous
+        // ISO-8601 strategy rounded them to whole seconds, collapsing several
+        // 4 fps frames onto the same timestamp after every relaunch.
+        encoder.dateEncodingStrategy = .secondsSince1970
         return encoder
     }()
 
@@ -60,7 +63,7 @@ actor FrameStore {
         // Load or create manifest
         if fileManager.fileExists(atPath: manifestURL.path) {
             let decoder = JSONDecoder()
-            decoder.dateDecodingStrategy = .iso8601
+            decoder.dateDecodingStrategy = .custom(Self.decodeManifestDate)
             let data = try? Data(contentsOf: manifestURL)
             if let data, let decoded = try? decoder.decode(FrameManifest.self, from: data) {
                 manifest = decoded
@@ -126,6 +129,25 @@ actor FrameStore {
             index[frame.id] = offset
         }
         return index
+    }
+
+    private static func decodeManifestDate(from decoder: Decoder) throws -> Date {
+        let container = try decoder.singleValueContainer()
+        if let timestamp = try? container.decode(TimeInterval.self) {
+            return Date(timeIntervalSince1970: timestamp)
+        }
+
+        // Backwards compatibility for manifests written with the old
+        // JSONEncoder ISO-8601 date strategy.
+        let encodedDate = try container.decode(String.self)
+        let formatter = ISO8601DateFormatter()
+        guard let date = formatter.date(from: encodedDate) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid manifest date: \(encodedDate)"
+            )
+        }
+        return date
     }
 
     private func rebuildManifestIndex() {

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -13,39 +13,49 @@ nonisolated struct RetentionTier: Sendable, Equatable {
 nonisolated struct RetentionPolicy: Sendable, Equatable {
     let tiers: [RetentionTier]
 
-    static let default24Hours = rewindHistory(RewindHistoryOption.defaultValue)
+    static let default24Hours = rewindHistory(
+        RewindHistoryOption.defaultValue,
+        captureInterval: AppStorageDefault.captureInterval,
+        fullDetailWindow: RecentTimelineWindow.defaultValue.rawValue
+    )
 
-    static func rewindHistory(_ option: RewindHistoryOption) -> RetentionPolicy {
+    static func rewindHistory(
+        _ option: RewindHistoryOption,
+        captureInterval: TimeInterval = AppStorageDefault.captureInterval,
+        fullDetailWindow: TimeInterval = RecentTimelineWindow.defaultValue.rawValue
+    ) -> RetentionPolicy {
         let maximumAge = option.retainedDuration
+        let historyEnd = min(option.duration, maximumAge)
+        let detailEnd = min(max(fullDetailWindow, captureInterval), historyEnd)
+        let firstFalloffEnd = min(detailEnd * 2, historyEnd)
+        let secondFalloffEnd = min(max(2 * 60 * 60, firstFalloffEnd), historyEnd)
 
-        let tiers: [RetentionTier]
+        let detailSpacing = max(captureInterval, 0.25)
+        let firstFalloffSpacing = max(detailSpacing * 4, 1)
+        let secondFalloffSpacing = max(firstFalloffSpacing, 5)
+
+        let archiveSpacing: TimeInterval
         switch option {
         case .thirtyMinutes:
-            tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
-                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
-                RetentionTier(maxAge: option.duration, minimumSpacing: 15),
-                RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
-            ]
+            archiveSpacing = 30
         case .twoHours:
-            tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
-                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
-                RetentionTier(maxAge: maximumAge, minimumSpacing: 20),
-            ]
+            archiveSpacing = 20
         case .eightHours:
-            tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
-                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
-                RetentionTier(maxAge: maximumAge, minimumSpacing: 25),
-            ]
+            archiveSpacing = 25
         case .twentyFourHours:
-            tiers = [
-                RetentionTier(maxAge: 5 * 60, minimumSpacing: 0.5),
-                RetentionTier(maxAge: 15 * 60, minimumSpacing: 5),
-                RetentionTier(maxAge: maximumAge, minimumSpacing: 30),
-            ]
+            archiveSpacing = 30
         }
+
+        var tiers: [RetentionTier] = []
+        func appendTier(maxAge: TimeInterval, minimumSpacing: TimeInterval) {
+            guard maxAge > (tiers.last?.maxAge ?? 0) else { return }
+            tiers.append(RetentionTier(maxAge: maxAge, minimumSpacing: minimumSpacing))
+        }
+
+        appendTier(maxAge: detailEnd, minimumSpacing: detailSpacing)
+        appendTier(maxAge: firstFalloffEnd, minimumSpacing: firstFalloffSpacing)
+        appendTier(maxAge: secondFalloffEnd, minimumSpacing: secondFalloffSpacing)
+        appendTier(maxAge: maximumAge, minimumSpacing: max(secondFalloffSpacing, archiveSpacing))
 
         return RetentionPolicy(tiers: tiers)
     }

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -29,7 +29,7 @@ nonisolated struct RetentionPolicy: Sendable, Equatable {
         let captureCadence = CaptureIntervalSetting.resolved(from: captureInterval)
         let detailEnd = min(max(fullDetailWindow, captureCadence), historyEnd)
         let firstFalloffEnd = min(detailEnd * 2, historyEnd)
-        let secondFalloffEnd = min(max(2 * 60 * 60, firstFalloffEnd), historyEnd)
+        let secondFalloffEnd = min(max(60 * 60, firstFalloffEnd), historyEnd)
 
         let detailSpacing: TimeInterval = 0
         // Retention density must not depend on the current capture setting:

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -94,12 +94,10 @@ final class RetentionManager {
 
             let tier = policy.tiers[tierIndex]
             let bucket = SpacingBucket(tierIndex: tierIndex, displayID: frame.displayID)
-            if let lastTime = lastKeptTime[bucket] {
-                if frame.timestamp.timeIntervalSince(lastTime) >= tier.minimumSpacing {
-                    toKeep.insert(frame.id)
-                    lastKeptTime[bucket] = frame.timestamp
-                }
-            } else {
+            let shouldKeep = lastKeptTime[bucket].map {
+                frame.timestamp.timeIntervalSince($0) >= tier.minimumSpacing
+            } ?? true
+            if shouldKeep {
                 toKeep.insert(frame.id)
                 lastKeptTime[bucket] = frame.timestamp
             }

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -26,12 +26,13 @@ nonisolated struct RetentionPolicy: Sendable, Equatable {
     ) -> RetentionPolicy {
         let maximumAge = option.retainedDuration
         let historyEnd = min(option.duration, maximumAge)
-        let detailEnd = min(max(fullDetailWindow, captureInterval), historyEnd)
+        let captureCadence = CaptureIntervalSetting.resolved(from: captureInterval)
+        let detailEnd = min(max(fullDetailWindow, captureCadence), historyEnd)
         let firstFalloffEnd = min(detailEnd * 2, historyEnd)
         let secondFalloffEnd = min(max(2 * 60 * 60, firstFalloffEnd), historyEnd)
 
-        let detailSpacing = max(captureInterval, 0.25)
-        let firstFalloffSpacing = max(detailSpacing * 4, 1)
+        let detailSpacing: TimeInterval = 0
+        let firstFalloffSpacing = max(captureCadence * 4, 1)
         let secondFalloffSpacing = max(firstFalloffSpacing, 5)
 
         let archiveSpacing: TimeInterval
@@ -63,6 +64,11 @@ nonisolated struct RetentionPolicy: Sendable, Equatable {
 
 @MainActor
 final class RetentionManager {
+    private struct SpacingBucket: Hashable {
+        let tierIndex: Int
+        let displayID: UUID?
+    }
+
     private var policy: RetentionPolicy
 
     init(policy: RetentionPolicy = .default24Hours) {
@@ -75,7 +81,7 @@ final class RetentionManager {
 
     func framesToPrune(frames: [StoredFrame], currentTime: Date) -> Set<UUID> {
         var toKeep = Set<UUID>()
-        var lastKeptTime: [Int: Date] = [:]
+        var lastKeptTime: [SpacingBucket: Date] = [:]
 
         for frame in frames {
             let age = currentTime.timeIntervalSince(frame.timestamp)
@@ -85,14 +91,15 @@ final class RetentionManager {
             }
 
             let tier = policy.tiers[tierIndex]
-            if let lastTime = lastKeptTime[tierIndex] {
+            let bucket = SpacingBucket(tierIndex: tierIndex, displayID: frame.displayID)
+            if let lastTime = lastKeptTime[bucket] {
                 if frame.timestamp.timeIntervalSince(lastTime) >= tier.minimumSpacing {
                     toKeep.insert(frame.id)
-                    lastKeptTime[tierIndex] = frame.timestamp
+                    lastKeptTime[bucket] = frame.timestamp
                 }
             } else {
                 toKeep.insert(frame.id)
-                lastKeptTime[tierIndex] = frame.timestamp
+                lastKeptTime[bucket] = frame.timestamp
             }
         }
 

--- a/JustNow/Storage/RetentionManager.swift
+++ b/JustNow/Storage/RetentionManager.swift
@@ -32,8 +32,10 @@ nonisolated struct RetentionPolicy: Sendable, Equatable {
         let secondFalloffEnd = min(max(2 * 60 * 60, firstFalloffEnd), historyEnd)
 
         let detailSpacing: TimeInterval = 0
-        let firstFalloffSpacing = max(captureCadence * 4, 1)
-        let secondFalloffSpacing = max(firstFalloffSpacing, 5)
+        // Retention density must not depend on the current capture setting:
+        // changing future cadence must never recompact existing history.
+        let firstFalloffSpacing: TimeInterval = 1
+        let secondFalloffSpacing: TimeInterval = 5
 
         let archiveSpacing: TimeInterval
         switch option {

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -235,12 +235,10 @@ struct SettingsView: View {
 
                 VStack(alignment: .leading, spacing: 8) {
                     LabeledContent {
-                        Picker(selection: $recentTimelineWindowSeconds) {
+                        Picker("", selection: $recentTimelineWindowSeconds) {
                             ForEach(RecentTimelineWindow.allCases) { window in
                                 Text(window.label).tag(window.rawValue)
                             }
-                        } label: {
-                            EmptyView()
                         }
                         .pickerStyle(.menu)
                         .labelsHidden()

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -202,12 +202,13 @@ struct SettingsView: View {
             Section("Capture") {
                 LabeledContent {
                     HStack(spacing: 8) {
-                        Slider(value: $captureInterval, in: 0.5...5.0, step: 0.5)
+                        Slider(value: $captureInterval, in: 0.25...5.0, step: 0.25)
                             .frame(width: 180)
 
-                        Text("\(captureInterval.formatted(.number.precision(.fractionLength(1))))s")
+                        Text(captureIntervalLabel)
                             .monospacedDigit()
                             .foregroundStyle(.secondary)
+                            .frame(minWidth: 96, alignment: .trailing)
                     }
                 } label: {
                     Text("Capture interval")
@@ -226,7 +227,7 @@ struct SettingsView: View {
                         Text("Rewind history")
                     }
 
-                    Text("Recent history stays at full detail. Older history is compacted automatically.")
+                    Text("Recent history keeps every captured change. Older history gradually uses fewer frames so longer rewind windows stay lightweight.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -241,15 +242,14 @@ struct SettingsView: View {
                         } label: {
                             EmptyView()
                         }
-                        .pickerStyle(.segmented)
+                        .pickerStyle(.menu)
                         .labelsHidden()
                         .accessibilityLabel("Full-detail window")
-                        .frame(width: 220)
                     } label: {
                         Text("Full-detail window")
                     }
 
-                    Text("Keep every stored frame in this most recent window, then collapse visually similar older history.")
+                    Text("Choose how long scrolling stays at the selected capture speed before the gradual falloff begins.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -391,6 +391,16 @@ struct SettingsView: View {
         .tabItem {
             Text("Shortcuts")
         }
+    }
+
+    private var captureIntervalLabel: String {
+        let seconds = captureInterval.formatted(
+            .number.precision(.fractionLength(0...2))
+        )
+        let framesPerSecond = (1 / captureInterval).formatted(
+            .number.precision(.fractionLength(0...1))
+        )
+        return "\(seconds)s · \(framesPerSecond) fps"
     }
 
     private func updateStorageInfo() async {

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -202,7 +202,7 @@ struct SettingsView: View {
             Section("Capture") {
                 LabeledContent {
                     HStack(spacing: 8) {
-                        Slider(value: $captureInterval, in: 0.25...5.0, step: 0.25)
+                        Slider(value: resolvedCaptureInterval, in: CaptureIntervalSetting.allowedRange, step: 0.25)
                             .frame(width: 180)
 
                         Text(captureIntervalLabel)
@@ -227,7 +227,7 @@ struct SettingsView: View {
                         Text("Rewind history")
                     }
 
-                    Text("Recent history keeps every captured change. Older history gradually uses fewer frames so longer rewind windows stay lightweight.")
+                    Text("Recent history keeps every stored frame. Older history gradually uses fewer frames so longer rewind windows stay manageable.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -249,7 +249,7 @@ struct SettingsView: View {
                         Text("Full-detail window")
                     }
 
-                    Text("Choose how long scrolling stays at the selected capture speed before the gradual falloff begins.")
+                    Text("Choose how long scrolling keeps every stored frame before the gradual falloff begins.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -394,13 +394,21 @@ struct SettingsView: View {
     }
 
     private var captureIntervalLabel: String {
-        let seconds = captureInterval.formatted(
+        let resolvedInterval = CaptureIntervalSetting.resolved(from: captureInterval)
+        let seconds = resolvedInterval.formatted(
             .number.precision(.fractionLength(0...2))
         )
-        let framesPerSecond = (1 / captureInterval).formatted(
+        let framesPerSecond = (1 / resolvedInterval).formatted(
             .number.precision(.fractionLength(0...1))
         )
-        return "\(seconds)s · \(framesPerSecond) fps"
+        return "\(seconds)s · up to \(framesPerSecond) fps"
+    }
+
+    private var resolvedCaptureInterval: Binding<Double> {
+        Binding(
+            get: { CaptureIntervalSetting.resolved(from: captureInterval) },
+            set: { captureInterval = CaptureIntervalSetting.resolved(from: $0) }
+        )
     }
 
     private func updateStorageInfo() async {

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -58,7 +58,7 @@ enum RewindDragAction: String, CaseIterable, Identifiable {
 }
 
 enum AppStorageDefault {
-    nonisolated static let captureInterval = 0.5
+    nonisolated static let captureInterval = 0.25
     nonisolated static let rewindHistorySeconds = RewindHistoryOption.defaultValue.rawValue
     nonisolated static let recentTimelineWindowSeconds = RecentTimelineWindow.defaultValue.rawValue
     nonisolated static let reduceCaptureOnBattery = true

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -79,3 +79,12 @@ enum AppStorageDefault {
     nonisolated static let screenshotSaveToClipboard = false
     nonisolated static let hasSeenSaveQualityInfo = false
 }
+
+nonisolated enum CaptureIntervalSetting {
+    static let allowedRange = 0.25...5.0
+
+    static func resolved(from value: Double) -> Double {
+        guard value.isFinite else { return AppStorageDefault.captureInterval }
+        return min(max(value, allowedRange.lowerBound), allowedRange.upperBound)
+    }
+}

--- a/JustNow/Utilities/CapturePolicyController.swift
+++ b/JustNow/Utilities/CapturePolicyController.swift
@@ -117,6 +117,7 @@ final class CapturePolicyController {
         settings: CapturePolicySettings,
         environment: CapturePolicyEnvironment
     ) -> CapturePolicy {
+        let baseInterval = CaptureIntervalSetting.resolved(from: settings.captureInterval)
         let adaptiveEnabled = settings.reduceCaptureOnBattery
         let onBattery = adaptiveEnabled && environment.isOnBattery
         let lowPowerMode = adaptiveEnabled && environment.isLowPowerModeEnabled
@@ -125,10 +126,10 @@ final class CapturePolicyController {
         let thermalState = environment.thermalState
         let isThermalConstrained = adaptiveEnabled && (thermalState == .serious || thermalState == .critical)
 
-        var interval = settings.captureInterval
+        var interval = baseInterval
         var scale = 2
         var saveOptions = FrameSaveOptions.standard
-        var duplicatePolicy = DuplicateFramePolicy.exact(atMostEvery: settings.captureInterval)
+        var duplicatePolicy = DuplicateFramePolicy.exact(atMostEvery: baseInterval)
         var ocrIndexEnabled = true
         var ocrIndexInterval = ocrIndexBaseInterval
         var ocrIndexQueueDepth = ocrIndexBaseQueueDepth

--- a/JustNowTests/CapturePolicyControllerTests.swift
+++ b/JustNowTests/CapturePolicyControllerTests.swift
@@ -4,6 +4,23 @@ import XCTest
 
 @MainActor
 final class CapturePolicyControllerTests: XCTestCase {
+    func testQuarterSecondCaptureKeepsQuarterSecondChanges() {
+        let controller = CapturePolicyController()
+        let policy = controller.resolvePolicy(
+            settings: CapturePolicySettings(captureInterval: 0.25, reduceCaptureOnBattery: false),
+            environment: CapturePolicyEnvironment(
+                isOnBattery: false,
+                isLowPowerModeEnabled: false,
+                batteryChargeFraction: nil,
+                idleDuration: 0,
+                thermalState: .nominal
+            )
+        )
+
+        XCTAssertEqual(policy.interval, 0.25)
+        XCTAssertEqual(policy.duplicatePolicy, .exact(atMostEvery: 0.25))
+    }
+
     func testResolvePolicyUsesLowPowerProfileOnBattery() {
         let controller = CapturePolicyController()
         let policy = controller.resolvePolicy(

--- a/JustNowTests/CapturePolicyControllerTests.swift
+++ b/JustNowTests/CapturePolicyControllerTests.swift
@@ -4,6 +4,33 @@ import XCTest
 
 @MainActor
 final class CapturePolicyControllerTests: XCTestCase {
+    func testCaptureIntervalSettingClampsInvalidPersistedValues() {
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: .nan), 0.25)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: .infinity), 0.25)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: -.infinity), 0.25)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: -1), 0.25)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: 0), 0.25)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: 2), 2)
+        XCTAssertEqual(CaptureIntervalSetting.resolved(from: 10), 5)
+    }
+
+    func testResolvePolicyClampsInvalidCaptureInterval() {
+        let controller = CapturePolicyController()
+        let policy = controller.resolvePolicy(
+            settings: CapturePolicySettings(captureInterval: .infinity, reduceCaptureOnBattery: false),
+            environment: CapturePolicyEnvironment(
+                isOnBattery: false,
+                isLowPowerModeEnabled: false,
+                batteryChargeFraction: nil,
+                idleDuration: 0,
+                thermalState: .nominal
+            )
+        )
+
+        XCTAssertEqual(policy.interval, 0.25)
+        XCTAssertEqual(policy.duplicatePolicy, .exact(atMostEvery: 0.25))
+    }
+
     func testQuarterSecondCaptureKeepsQuarterSecondChanges() {
         let controller = CapturePolicyController()
         let policy = controller.resolvePolicy(

--- a/JustNowTests/FrameBufferTests.swift
+++ b/JustNowTests/FrameBufferTests.swift
@@ -25,6 +25,13 @@ final class FrameBufferTests: XCTestCase {
         )
     }
 
+    func testStandardDuplicatePolicyMatchesDefaultCaptureInterval() {
+        XCTAssertEqual(
+            DuplicateFramePolicy.standard,
+            .exact(atMostEvery: AppStorageDefault.captureInterval)
+        )
+    }
+
     func testAddFrameSyncStoresFrame() async throws {
         let buffer = try await makeBuffer()
         let image = try makeStructuredImage(seed: 1)

--- a/JustNowTests/FrameStoreTests.swift
+++ b/JustNowTests/FrameStoreTests.swift
@@ -102,6 +102,57 @@ final class FrameStoreTests: XCTestCase {
         XCTAssertEqual(metadata.first?.displayName, "Test Display")
     }
 
+    func testManifestPreservesSubSecondTimestamps() async throws {
+        let timestamp = Date(timeIntervalSince1970: 2_000.125)
+        do {
+            let store = try FrameStore(directory: directory)
+            _ = try await store.saveFrame(
+                makeImage(),
+                timestamp: timestamp,
+                hash: 7,
+                displayID: nil,
+                displayName: nil
+            )
+            await store.flushManifest()
+        }
+
+        let reopened = try FrameStore(directory: directory)
+        let persistedMetadata = await reopened.getAllMetadata()
+        let persistedTimestamp = try XCTUnwrap(persistedMetadata.first?.timestamp)
+
+        XCTAssertEqual(persistedTimestamp.timeIntervalSince1970, timestamp.timeIntervalSince1970, accuracy: 0.000_001)
+    }
+
+    func testManifestLoadsLegacyISO8601Dates() async throws {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let legacyTimestamp = Date(timeIntervalSince1970: 2_000)
+        let legacyManifest = FrameManifest(
+            frames: [
+                FrameMetadata(
+                    id: UUID(),
+                    timestamp: legacyTimestamp,
+                    hash: 7,
+                    filename: "legacy.jpg",
+                    thumbnailFilename: "legacy_thumb.jpg",
+                    fileSize: 1,
+                    displayID: nil,
+                    displayName: nil
+                )
+            ],
+            lastModified: legacyTimestamp
+        )
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(legacyManifest).write(
+            to: directory.appendingPathComponent("manifest.json")
+        )
+
+        let reopened = try FrameStore(directory: directory)
+        let metadata = await reopened.getAllMetadata()
+
+        XCTAssertEqual(metadata.first?.timestamp, legacyTimestamp)
+    }
+
     /// A corrupted manifest must not brick the store on every launch. It is
     /// quarantined together with the frames directory and the store starts
     /// empty, so the old JPEGs survive for manual recovery out of reach of

--- a/JustNowTests/RetentionManagerTests.swift
+++ b/JustNowTests/RetentionManagerTests.swift
@@ -86,6 +86,50 @@ final class RetentionManagerTests: XCTestCase {
         XCTAssertEqual(manager.framesToPrune(frames: frames, currentTime: now), [frames[0].id])
     }
 
+    func testHighFidelityDefaultFallsOffProgressively() {
+        let policy = RetentionPolicy.rewindHistory(
+            .twentyFourHours,
+            captureInterval: 0.25,
+            fullDetailWindow: 15 * 60
+        )
+
+        XCTAssertEqual(
+            policy.tiers,
+            [
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 0.25),
+                RetentionTier(maxAge: 30 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 2 * 60 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: 24 * 60 * 60, minimumSpacing: 30),
+            ]
+        )
+    }
+
+    func testThirtyMinuteFullDetailWindowDoesNotCreateEmptyTiers() {
+        let policy = RetentionPolicy.rewindHistory(
+            .thirtyMinutes,
+            captureInterval: 0.25,
+            fullDetailWindow: 30 * 60
+        )
+
+        XCTAssertEqual(
+            policy.tiers,
+            [
+                RetentionTier(maxAge: 30 * 60, minimumSpacing: 0.25),
+                RetentionTier(maxAge: 60 * 60, minimumSpacing: 30),
+            ]
+        )
+    }
+
+    func testSlowerCaptureIntervalKeepsFalloffMonotonic() {
+        let policy = RetentionPolicy.rewindHistory(
+            .twentyFourHours,
+            captureInterval: 5,
+            fullDetailWindow: 15 * 60
+        )
+
+        XCTAssertEqual(policy.tiers.map(\.minimumSpacing), [5, 20, 20, 30])
+    }
+
     private func makeFrames(agesAscendingOldestFirst ages: [TimeInterval]) -> [StoredFrame] {
         ages.map { age in
             StoredFrame(

--- a/JustNowTests/RetentionManagerTests.swift
+++ b/JustNowTests/RetentionManagerTests.swift
@@ -120,14 +120,20 @@ final class RetentionManagerTests: XCTestCase {
         )
     }
 
-    func testSlowerCaptureIntervalKeepsFalloffMonotonic() {
-        let policy = RetentionPolicy.rewindHistory(
+    func testCaptureIntervalChangesDoNotRecompactExistingFalloffTiers() {
+        let fastPolicy = RetentionPolicy.rewindHistory(
+            .twentyFourHours,
+            captureInterval: 0.25,
+            fullDetailWindow: 15 * 60
+        )
+        let slowPolicy = RetentionPolicy.rewindHistory(
             .twentyFourHours,
             captureInterval: 5,
             fullDetailWindow: 15 * 60
         )
 
-        XCTAssertEqual(policy.tiers.map(\.minimumSpacing), [0, 20, 20, 30])
+        XCTAssertEqual(fastPolicy.tiers, slowPolicy.tiers)
+        XCTAssertEqual(slowPolicy.tiers.map(\.minimumSpacing), [0, 1, 5, 30])
     }
 
     func testFullDetailTierKeepsFramesCloserThanCaptureCadence() {

--- a/JustNowTests/RetentionManagerTests.swift
+++ b/JustNowTests/RetentionManagerTests.swift
@@ -98,8 +98,26 @@ final class RetentionManagerTests: XCTestCase {
             [
                 RetentionTier(maxAge: 15 * 60, minimumSpacing: 0),
                 RetentionTier(maxAge: 30 * 60, minimumSpacing: 1),
-                RetentionTier(maxAge: 2 * 60 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: 60 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: 24 * 60 * 60, minimumSpacing: 30),
+            ]
+        )
+    }
+
+    func testTwoHourWindowReachesArchiveFalloff() {
+        let policy = RetentionPolicy.rewindHistory(
+            .twoHours,
+            captureInterval: 0.25,
+            fullDetailWindow: 15 * 60
+        )
+
+        XCTAssertEqual(
+            policy.tiers,
+            [
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 0),
+                RetentionTier(maxAge: 30 * 60, minimumSpacing: 1),
+                RetentionTier(maxAge: 60 * 60, minimumSpacing: 5),
+                RetentionTier(maxAge: 2 * 60 * 60, minimumSpacing: 20),
             ]
         )
     }

--- a/JustNowTests/RetentionManagerTests.swift
+++ b/JustNowTests/RetentionManagerTests.swift
@@ -96,7 +96,7 @@ final class RetentionManagerTests: XCTestCase {
         XCTAssertEqual(
             policy.tiers,
             [
-                RetentionTier(maxAge: 15 * 60, minimumSpacing: 0.25),
+                RetentionTier(maxAge: 15 * 60, minimumSpacing: 0),
                 RetentionTier(maxAge: 30 * 60, minimumSpacing: 1),
                 RetentionTier(maxAge: 2 * 60 * 60, minimumSpacing: 5),
                 RetentionTier(maxAge: 24 * 60 * 60, minimumSpacing: 30),
@@ -114,7 +114,7 @@ final class RetentionManagerTests: XCTestCase {
         XCTAssertEqual(
             policy.tiers,
             [
-                RetentionTier(maxAge: 30 * 60, minimumSpacing: 0.25),
+                RetentionTier(maxAge: 30 * 60, minimumSpacing: 0),
                 RetentionTier(maxAge: 60 * 60, minimumSpacing: 30),
             ]
         )
@@ -127,18 +127,65 @@ final class RetentionManagerTests: XCTestCase {
             fullDetailWindow: 15 * 60
         )
 
-        XCTAssertEqual(policy.tiers.map(\.minimumSpacing), [5, 20, 20, 30])
+        XCTAssertEqual(policy.tiers.map(\.minimumSpacing), [0, 20, 20, 30])
+    }
+
+    func testFullDetailTierKeepsFramesCloserThanCaptureCadence() {
+        let manager = RetentionManager(
+            policy: .rewindHistory(
+                .twentyFourHours,
+                captureInterval: 0.25,
+                fullDetailWindow: 15 * 60
+            )
+        )
+        let frames = makeFrames(agesAscendingOldestFirst: [1, 0.8])
+
+        XCTAssertTrue(manager.framesToPrune(frames: frames, currentTime: now).isEmpty)
+    }
+
+    func testSpacingIsAppliedIndependentlyPerDisplay() {
+        let displayA = UUID()
+        let displayB = UUID()
+        let manager = RetentionManager(
+            policy: RetentionPolicy(tiers: [RetentionTier(maxAge: 100, minimumSpacing: 10)])
+        )
+        let frames = [
+            makeFrame(age: 50, displayID: displayA),
+            makeFrame(age: 49, displayID: displayB),
+            makeFrame(age: 45, displayID: displayA),
+            makeFrame(age: 44, displayID: displayB),
+        ]
+
+        XCTAssertEqual(
+            manager.framesToPrune(frames: frames, currentTime: now),
+            [frames[2].id, frames[3].id]
+        )
+    }
+
+    func testInvalidCaptureIntervalsResolveToSafeFalloff() {
+        for interval in [Double.nan, .infinity, -.infinity, 0, -1, 100] {
+            let policy = RetentionPolicy.rewindHistory(
+                .twentyFourHours,
+                captureInterval: interval,
+                fullDetailWindow: 15 * 60
+            )
+
+            XCTAssertTrue(policy.tiers.allSatisfy { $0.minimumSpacing.isFinite })
+            XCTAssertEqual(policy.tiers.first?.minimumSpacing, 0)
+        }
     }
 
     private func makeFrames(agesAscendingOldestFirst ages: [TimeInterval]) -> [StoredFrame] {
-        ages.map { age in
-            StoredFrame(
-                id: UUID(),
-                timestamp: now.addingTimeInterval(-age),
-                hash: 1,
-                displayID: nil,
-                displayName: nil
-            )
-        }
+        ages.map { makeFrame(age: $0) }
+    }
+
+    private func makeFrame(age: TimeInterval, displayID: UUID? = nil) -> StoredFrame {
+        StoredFrame(
+            id: UUID(),
+            timestamp: now.addingTimeInterval(-age),
+            hash: 1,
+            displayID: displayID,
+            displayName: nil
+        )
     }
 }

--- a/JustNowTests/RewindHistoryOptionTests.swift
+++ b/JustNowTests/RewindHistoryOptionTests.swift
@@ -17,7 +17,7 @@ final class RewindHistoryOptionTests: XCTestCase {
     }
 
     /// RetentionManager assigns each frame to the first tier whose maxAge
-    /// covers it, so tiers must be strictly ascending with positive spacing,
+    /// covers it, so tiers must be strictly ascending with non-negative spacing,
     /// and the deepest tier must reach the full retained duration — otherwise
     /// retained frames would be silently pruned as "beyond all tiers".
     func testEveryOptionProducesWellFormedRetentionTiers() throws {
@@ -32,8 +32,12 @@ final class RewindHistoryOptionTests: XCTestCase {
                     "\(option) tiers must be strictly ascending"
                 )
             }
-            for tier in tiers {
-                XCTAssertGreaterThan(tier.minimumSpacing, 0, "\(option) has non-positive spacing")
+            for (index, tier) in tiers.enumerated() {
+                if index == 0 {
+                    XCTAssertEqual(tier.minimumSpacing, 0, "\(option) must keep full detail")
+                } else {
+                    XCTAssertGreaterThan(tier.minimumSpacing, 0, "\(option) has non-positive falloff spacing")
+                }
             }
 
             let deepest = try XCTUnwrap(tiers.last)


### PR DESCRIPTION
Closes #3

## Summary

- lower the configurable capture interval to 0.25 seconds (up to 4 fps)
- make 15 minutes the default full-detail window, with a 30-minute option
- retain every stored frame in the full-detail window, then fall off to 1-second, 5-second, and archive-level spacing
- keep retention independent per display and stable when capture settings change
- preserve sub-second capture timestamps across relaunches while still loading legacy manifests
- update Settings copy and layout for the expanded controls

## Adversarial review

- three Codex Max reviewers across correctness, edge cases, and macOS UX/operations
- independent `claude -p` and OpenCode reviews
- review findings fixed: multi-display frame loss, sub-second timestamp loss, destructive slider recompaction, invalid persisted intervals, and misleading cadence copy

## Verification

- `xcodebuild test -project JustNow.xcodeproj -scheme JustNow -destination 'platform=macOS,arch=arm64' -derivedDataPath build CODE_SIGNING_ALLOWED=YES DEVELOPMENT_TEAM=PQ6U5ESLN2` — 203 tests, 0 failures
- `./Scripts/local-install-app.sh` — Release build installed and launched from `/Applications/JustNow.app`
- installed app verified with Developer ID signing and the 0.25-second / 15-minute defaults

## Residual risk

Highly dynamic screens can consume several gigabytes per display at the 15- or 30-minute full-detail setting. Adaptive capture and frame deduplication reduce typical usage, but a sustained multi-display storage soak remains useful release follow-up.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 15-minute and 30-minute options for recent timeline detail.
  * Recent history now defaults to a 15-minute full-detail window.
  * Capture intervals can be set as low as 0.25 seconds, with supported values automatically constrained.
  * Capture interval settings now display the corresponding frame rate.

* **Bug Fixes**
  * Improved retention behavior across multiple displays.
  * Preserved fractional timestamps and supported existing saved timeline data.
  * Updated history descriptions to clarify detail falloff behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->