### PR TITLE
Preserve existing settings across high-fidelity upgrade

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -156,6 +156,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         guard !isRunningUnderXCTest else { return }
 
+        migrateLegacyDefaultSettingsIfNeeded()
         DiagnosticsLog.shared.logSessionStart()
         setupStatusItem()
         updaterController.startUpdater()
@@ -225,6 +226,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     // MARK: - Setup
+
+    private func migrateLegacyDefaultSettingsIfNeeded() {
+        let defaults = UserDefaults.standard
+        let persistentDomain = Bundle.main.bundleIdentifier.flatMap {
+            defaults.persistentDomain(forName: $0)
+        }
+        let storageDirectoryExists = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first.map {
+            FileManager.default.fileExists(
+                atPath: $0.appendingPathComponent("JustNow", isDirectory: true).path
+            )
+        } ?? false
+
+        AppSettingsMigration.migrateIfNeeded(
+            defaults: defaults,
+            existingInstall: AppSettingsMigration.isExistingInstall(
+                persistentDomain: persistentDomain,
+                storageDirectoryExists: storageDirectoryExists
+            )
+        )
+    }
 
     private func setupStatusItem() {
         statusItemController = StatusItemController(

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -237,7 +237,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             in: .userDomainMask
         ).first.map {
             FileManager.default.fileExists(
-                atPath: $0.appendingPathComponent("JustNow", isDirectory: true).path
+                atPath: $0.appendingPathComponent("JustNow", isDirectory: true)
+                    .path(percentEncoded: false)
             )
         } ?? false
 

--- a/JustNow/Utilities/AppStorageSettings.swift
+++ b/JustNow/Utilities/AppStorageSettings.swift
@@ -22,6 +22,7 @@ enum AppStorageKey {
     nonisolated static let screenshotSaveToClipboard = "screenshotSaveToClipboard"
     nonisolated static let hasSeenSaveQualityInfo = "hasSeenSaveQualityInfo"
     nonisolated static let regionScreenshotShortcutHintCount = "regionScreenshotShortcutHintCount"
+    nonisolated static let settingsMigrationVersion = "settingsMigrationVersion"
 }
 
 enum RewindDragAction: String, CaseIterable, Identifiable {
@@ -86,5 +87,38 @@ nonisolated enum CaptureIntervalSetting {
     static func resolved(from value: Double) -> Double {
         guard value.isFinite else { return AppStorageDefault.captureInterval }
         return min(max(value, allowedRange.lowerBound), allowedRange.upperBound)
+    }
+}
+
+nonisolated enum AppSettingsMigration {
+    private static let currentVersion = 1
+    private static let legacyCaptureInterval = 0.5
+    private static let legacyRecentTimelineWindowSeconds = 300.0
+
+    static func isExistingInstall(
+        persistentDomain: [String: Any]?,
+        storageDirectoryExists: Bool
+    ) -> Bool {
+        storageDirectoryExists || persistentDomain?.isEmpty == false
+    }
+
+    static func migrateIfNeeded(defaults: UserDefaults, existingInstall: Bool) {
+        guard defaults.integer(forKey: AppStorageKey.settingsMigrationVersion) < currentVersion else {
+            return
+        }
+
+        if existingInstall {
+            if defaults.object(forKey: AppStorageKey.captureInterval) == nil {
+                defaults.set(legacyCaptureInterval, forKey: AppStorageKey.captureInterval)
+            }
+            if defaults.object(forKey: AppStorageKey.recentTimelineWindowSeconds) == nil {
+                defaults.set(
+                    legacyRecentTimelineWindowSeconds,
+                    forKey: AppStorageKey.recentTimelineWindowSeconds
+                )
+            }
+        }
+
+        defaults.set(currentVersion, forKey: AppStorageKey.settingsMigrationVersion)
     }
 }

--- a/JustNowTests/AppSettingsMigrationTests.swift
+++ b/JustNowTests/AppSettingsMigrationTests.swift
@@ -1,0 +1,81 @@
+import XCTest
+@testable import JustNow
+
+final class AppSettingsMigrationTests: XCTestCase {
+    func testExistingInstallReceivesLegacyDefaultsWhenValuesWereNeverStored() {
+        let defaults = makeDefaults()
+
+        AppSettingsMigration.migrateIfNeeded(defaults: defaults, existingInstall: true)
+
+        XCTAssertEqual(defaults.double(forKey: AppStorageKey.captureInterval), 0.5)
+        XCTAssertEqual(defaults.double(forKey: AppStorageKey.recentTimelineWindowSeconds), 300)
+        XCTAssertEqual(defaults.integer(forKey: AppStorageKey.settingsMigrationVersion), 1)
+    }
+
+    func testExistingInstallKeepsExplicitValues() {
+        let defaults = makeDefaults()
+        defaults.set(2.0, forKey: AppStorageKey.captureInterval)
+        defaults.set(600.0, forKey: AppStorageKey.recentTimelineWindowSeconds)
+
+        AppSettingsMigration.migrateIfNeeded(defaults: defaults, existingInstall: true)
+
+        XCTAssertEqual(defaults.double(forKey: AppStorageKey.captureInterval), 2)
+        XCTAssertEqual(defaults.double(forKey: AppStorageKey.recentTimelineWindowSeconds), 600)
+    }
+
+    func testNewInstallKeepsNewDefaultsUnstored() {
+        let defaults = makeDefaults()
+
+        AppSettingsMigration.migrateIfNeeded(defaults: defaults, existingInstall: false)
+
+        XCTAssertNil(defaults.object(forKey: AppStorageKey.captureInterval))
+        XCTAssertNil(defaults.object(forKey: AppStorageKey.recentTimelineWindowSeconds))
+        XCTAssertEqual(defaults.integer(forKey: AppStorageKey.settingsMigrationVersion), 1)
+    }
+
+    func testMigrationOnlyRunsOnce() {
+        let defaults = makeDefaults()
+        AppSettingsMigration.migrateIfNeeded(defaults: defaults, existingInstall: false)
+
+        AppSettingsMigration.migrateIfNeeded(defaults: defaults, existingInstall: true)
+
+        XCTAssertNil(defaults.object(forKey: AppStorageKey.captureInterval))
+        XCTAssertNil(defaults.object(forKey: AppStorageKey.recentTimelineWindowSeconds))
+    }
+
+    func testExistingInstallDetectionUsesPreferencesOrStorage() {
+        XCTAssertFalse(
+            AppSettingsMigration.isExistingInstall(
+                persistentDomain: nil,
+                storageDirectoryExists: false
+            )
+        )
+        XCTAssertFalse(
+            AppSettingsMigration.isExistingInstall(
+                persistentDomain: [:],
+                storageDirectoryExists: false
+            )
+        )
+        XCTAssertTrue(
+            AppSettingsMigration.isExistingInstall(
+                persistentDomain: ["existingPreference": true],
+                storageDirectoryExists: false
+            )
+        )
+        XCTAssertTrue(
+            AppSettingsMigration.isExistingInstall(
+                persistentDomain: nil,
+                storageDirectoryExists: true
+            )
+        )
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "AppSettingsMigrationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
+    }
+}


### PR DESCRIPTION
## Summary

- preserve the previous effective `0.5s` capture interval and `5 min` full-detail window for existing installations that never stored those settings
- leave every explicitly stored user value untouched
- retain the new `0.25s` and `15 min` defaults for genuinely new installations
- stamp the migration once so later launches are idempotent

## Verification

- `xcodebuild test -project JustNow.xcodeproj -scheme JustNow -destination 'platform=macOS' ...` — 208 tests, 0 failures
- `git diff --check`
- `./Scripts/local-install-app.sh` — Developer ID build installed and launched from `/Applications/JustNow.app`
- live preferences check confirmed the migration marker and preservation of this machine's explicit capture/full-detail values

## Review

Three independent Codex Max adversarial reviews covered correctness, test/edge cases, and upgrade/operational safety. Claude and OpenCode also reviewed the migration. No blocking findings remained; a Claude test-coverage nit for an empty preferences domain was added before publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved legacy capture interval and timeline settings when upgrading existing installations.
  * Prevented stored preferences from being overwritten during migration.
  * Ensured new installations receive only the appropriate default settings.
  * Applied settings migration only once during app startup.

* **Tests**
  * Added coverage for existing installs, new installs, preserved values, and repeat migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->