### PR TITLE
feat: project history frame storage

### DIFF
--- a/JustNow/Capture/FrameBuffer.swift
+++ b/JustNow/Capture/FrameBuffer.swift
@@ -455,6 +455,10 @@ class FrameBuffer {
         await frameStore.totalStorageSize()
     }
 
+    func storageStatistics() async -> FrameStorageStatistics {
+        await frameStore.storageStatistics()
+    }
+
     func updateSaveOptions(_ options: FrameSaveOptions, duplicatePolicy: DuplicateFramePolicy) {
         saveOptions = options
         self.duplicatePolicy = duplicatePolicy

--- a/JustNow/Storage/FrameMetadata.swift
+++ b/JustNow/Storage/FrameMetadata.swift
@@ -25,3 +25,17 @@ nonisolated struct FrameManifest: Codable, Sendable {
     var frames: [FrameMetadata] = []
     var lastModified: Date = Date()
 }
+
+nonisolated struct FrameStorageStatistics: Sendable, Equatable {
+    let storedBytes: Int64
+    let frameCount: Int
+    let projectionSamples: [FrameStorageSample]
+
+    static let empty = FrameStorageStatistics(storedBytes: 0, frameCount: 0, projectionSamples: [])
+}
+
+nonisolated struct FrameStorageSample: Sendable, Equatable {
+    let displayID: UUID?
+    let storedBytes: Int64
+    let frameCount: Int
+}

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -23,6 +23,7 @@ nonisolated struct FrameSaveOptions: Sendable, Equatable {
 }
 
 actor FrameStore {
+    private static let projectionSampleLimitPerDisplay = 50
     private nonisolated static let legacyManifestDateFormatter = ISO8601DateFormatter()
 
     private let fileManager = FileManager.default
@@ -390,8 +391,32 @@ actor FrameStore {
         performManifestSave()
     }
 
+    func storageStatistics() -> FrameStorageStatistics {
+        let storedBytes = manifest.frames.reduce(0) { $0 + $1.fileSize }
+        var samples: [UUID?: (storedBytes: Int64, frameCount: Int)] = [:]
+        for frame in manifest.frames.reversed() {
+            let existing = samples[frame.displayID] ?? (storedBytes: 0, frameCount: 0)
+            guard existing.frameCount < Self.projectionSampleLimitPerDisplay else { continue }
+            samples[frame.displayID] = (
+                storedBytes: existing.storedBytes + frame.fileSize,
+                frameCount: existing.frameCount + 1
+            )
+        }
+        return FrameStorageStatistics(
+            storedBytes: storedBytes,
+            frameCount: manifest.frames.count,
+            projectionSamples: samples.map { displayID, sample in
+                FrameStorageSample(
+                    displayID: displayID,
+                    storedBytes: sample.storedBytes,
+                    frameCount: sample.frameCount
+                )
+            }
+        )
+    }
+
     func totalStorageSize() -> Int64 {
-        manifest.frames.reduce(0) { $0 + $1.fileSize }
+        storageStatistics().storedBytes
     }
 
     func flushManifest() {

--- a/JustNow/Storage/FrameStore.swift
+++ b/JustNow/Storage/FrameStore.swift
@@ -394,7 +394,7 @@ actor FrameStore {
     func storageStatistics() -> FrameStorageStatistics {
         let storedBytes = manifest.frames.reduce(0) { $0 + $1.fileSize }
         var samples: [UUID?: (storedBytes: Int64, frameCount: Int)] = [:]
-        for frame in manifest.frames.reversed() {
+        for frame in manifest.frames.sorted(by: { $0.timestamp > $1.timestamp }) {
             let existing = samples[frame.displayID] ?? (storedBytes: 0, frameCount: 0)
             guard existing.frameCount < Self.projectionSampleLimitPerDisplay else { continue }
             samples[frame.displayID] = (

--- a/JustNow/Storage/StorageEstimate.swift
+++ b/JustNow/Storage/StorageEstimate.swift
@@ -13,7 +13,8 @@ nonisolated enum StorageEstimate {
 
         for (index, tier) in policy.tiers.enumerated() {
             let duration = max(0, tier.maxAge - previousMaxAge)
-            let effectiveSpacing = max(captureCadence, tier.minimumSpacing)
+            let captureSteps = max(1, ceil(tier.minimumSpacing / captureCadence))
+            let effectiveSpacing = captureSteps * captureCadence
             if index == 0 {
                 frameCount = floor(duration / effectiveSpacing) + 1
             } else {

--- a/JustNow/Storage/StorageEstimate.swift
+++ b/JustNow/Storage/StorageEstimate.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+nonisolated enum StorageEstimate {
+    static let minimumSampleFrameCount = 10
+
+    static func projectedFrameCountPerDisplay(
+        policy: RetentionPolicy,
+        captureInterval: TimeInterval
+    ) -> Int {
+        let captureCadence = CaptureIntervalSetting.resolved(from: captureInterval)
+        var previousMaxAge: TimeInterval = 0
+        var frameCount = policy.tiers.isEmpty ? 0.0 : 1.0
+
+        for (index, tier) in policy.tiers.enumerated() {
+            let duration = max(0, tier.maxAge - previousMaxAge)
+            let effectiveSpacing = max(captureCadence, tier.minimumSpacing)
+            if index == 0 {
+                frameCount = floor(duration / effectiveSpacing) + 1
+            } else {
+                frameCount += ceil(duration / effectiveSpacing)
+            }
+            previousMaxAge = max(previousMaxAge, tier.maxAge)
+        }
+
+        guard frameCount.isFinite, frameCount < Double(Int.max) else {
+            return Int.max
+        }
+        return Int(frameCount)
+    }
+
+    static func projectedBytes(
+        policy: RetentionPolicy,
+        captureInterval: TimeInterval,
+        samples: [FrameStorageSample],
+        connectedDisplayIDs: [UUID]
+    ) -> Int64? {
+        let fallbackStoredBytes = samples.reduce(Int64(0)) { $0 + $1.storedBytes }
+        let fallbackFrameCount = samples.reduce(0) { $0 + $1.frameCount }
+        guard fallbackFrameCount >= minimumSampleFrameCount,
+              fallbackStoredBytes > 0,
+              !connectedDisplayIDs.isEmpty else {
+            return nil
+        }
+
+        let fallbackAverageFrameSize = Double(fallbackStoredBytes) / Double(fallbackFrameCount)
+        let projectedFrameCount = projectedFrameCountPerDisplay(
+            policy: policy,
+            captureInterval: captureInterval
+        )
+        guard projectedFrameCount > 0 else { return nil }
+        let estimate = connectedDisplayIDs.reduce(0.0) { total, displayID in
+            let sample = samples.first { $0.displayID == displayID }
+            let averageFrameSize: Double
+            if let sample, sample.frameCount >= minimumSampleFrameCount, sample.storedBytes > 0 {
+                averageFrameSize = Double(sample.storedBytes) / Double(sample.frameCount)
+            } else {
+                averageFrameSize = fallbackAverageFrameSize
+            }
+            return total + averageFrameSize * Double(projectedFrameCount)
+        }
+        guard estimate.isFinite, estimate < Double(Int64.max) else { return nil }
+        return Int64(estimate.rounded(.up))
+    }
+}

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -37,6 +37,8 @@ struct SettingsView: View {
 
     @State private var storageSize: Int64 = 0
     @State private var frameCount: Int = 0
+    @State private var projectionSamples: [FrameStorageSample] = []
+    @State private var connectedDisplayIDs: [UUID] = []
     @State private var showClearConfirmation = false
     @State private var telemetrySnapshot: SearchTelemetrySnapshot = .empty
     @State private var isSearchDiagnosticsExpanded = false
@@ -56,9 +58,6 @@ struct SettingsView: View {
         .tabViewStyle(.tabBarOnly)
         .frame(width: 660, height: 520)
         .navigationTitle("JustNow Settings")
-        .task {
-            await updateStorageInfo()
-        }
         .task(id: frameBufferIdentity) {
             await updateStorageInfo()
         }
@@ -69,7 +68,7 @@ struct SettingsView: View {
             syncLaunchAtLoginState()
         }
         .task {
-            await refreshTelemetryLoop()
+            await refreshSettingsLoop()
         }
         .alert("Clear History?", isPresented: $showClearConfirmation) {
             Button("Cancel", role: .cancel) { }
@@ -271,11 +270,26 @@ struct SettingsView: View {
                 }
 
                 HStack {
-                    Text("Storage used")
+                    Text("Frame storage used")
                     Spacer()
                     Text(formatBytes(storageSize))
                         .foregroundStyle(.secondary)
                 }
+
+                LabeledContent("Projected frame storage") {
+                    if let projectedStorage {
+                        Text("≈\(formatBytes(projectedStorage)) total")
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Waiting for samples")
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Text(storageEstimateDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
                     Button("Open Storage Folder") {
@@ -409,16 +423,46 @@ struct SettingsView: View {
         )
     }
 
+    private var projectedStorage: Int64? {
+        StorageEstimate.projectedBytes(
+            policy: .rewindHistory(
+                RewindHistoryOption.resolved(from: rewindHistorySeconds),
+                captureInterval: captureInterval,
+                fullDetailWindow: RecentTimelineWindow.resolved(
+                    from: recentTimelineWindowSeconds
+                ).rawValue
+            ),
+            captureInterval: captureInterval,
+            samples: projectionSamples,
+            connectedDisplayIDs: connectedDisplayIDs
+        )
+    }
+
+    private var storageEstimateDescription: String {
+        if projectedStorage == nil {
+            return "An estimate appears after JustNow saves \(StorageEstimate.minimumSampleFrameCount) frames."
+        }
+        let displayCount = connectedDisplayIDs.count
+        let displayLabel = displayCount == 1 ? "1 display" : "\(displayCount) displays"
+        return "Projected total for \(displayLabel) once your current settings have been in use for the full history window. Actual frame storage varies with screen activity, display resolution, and power saving."
+    }
+
     private func updateStorageInfo() async {
         if let buffer = context.frameBuffer {
             let bufferIdentity = ObjectIdentifier(buffer)
-            let totalStorageSize = await buffer.totalStorageSize()
+            let statistics = await buffer.storageStatistics()
             guard !Task.isCancelled, context.frameBuffer.map(ObjectIdentifier.init) == bufferIdentity else { return }
-            storageSize = totalStorageSize
-            frameCount = buffer.frameCount
+            storageSize = statistics.storedBytes
+            frameCount = statistics.frameCount
+            projectionSamples = statistics.projectionSamples
+            connectedDisplayIDs = NSScreen.screens.compactMap { screen in
+                DisplayIdentity.displayID(for: screen).map { DisplayIdentity.info(for: $0).id }
+            }
         } else {
             storageSize = 0
             frameCount = 0
+            projectionSamples = []
+            connectedDisplayIDs = []
         }
     }
 
@@ -444,9 +488,10 @@ struct SettingsView: View {
         context.launchAtLoginManager.map(ObjectIdentifier.init)
     }
 
-    private func refreshTelemetryLoop() async {
+    private func refreshSettingsLoop() async {
         while !Task.isCancelled {
             let snapshot = await SearchTelemetry.shared.snapshot()
+            await updateStorageInfo()
             guard !Task.isCancelled else { return }
             telemetrySnapshot = snapshot
             try? await Task.sleep(for: .seconds(2))

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -269,9 +269,7 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                 }
 
-                HStack {
-                    Text("Frame storage used")
-                    Spacer()
+                LabeledContent("Frame storage used") {
                     Text(formatBytes(storageSize))
                         .foregroundStyle(.secondary)
                 }

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -262,9 +262,7 @@ struct SettingsView: View {
             }
 
             Section("Storage") {
-                HStack {
-                    Text("Frames stored")
-                    Spacer()
+                LabeledContent("Frames stored") {
                     Text("\(frameCount)")
                         .foregroundStyle(.secondary)
                 }

--- a/JustNowTests/FrameStoreTests.swift
+++ b/JustNowTests/FrameStoreTests.swift
@@ -41,6 +41,34 @@ final class FrameStoreTests: XCTestCase {
         XCTAssertEqual(totalSize, metadata.fileSize)
     }
 
+    func testStorageStatisticsAggregateManifestSnapshot() async throws {
+        let store = try FrameStore(directory: directory)
+        let firstDisplayID = UUID()
+        let secondDisplayID = UUID()
+        let first = try await store.saveFrame(
+            makeImage(), timestamp: Date(), hash: 1,
+            displayID: firstDisplayID, displayName: "Built-in Display"
+        )
+        let second = try await store.saveFrame(
+            makeImage(), timestamp: Date(), hash: 2,
+            displayID: secondDisplayID, displayName: "External Display"
+        )
+        let legacy = try await store.saveFrame(
+            makeImage(), timestamp: Date(), hash: 3,
+            displayID: nil, displayName: nil
+        )
+
+        let statistics = await store.storageStatistics()
+
+        XCTAssertEqual(statistics.storedBytes, first.fileSize + second.fileSize + legacy.fileSize)
+        XCTAssertEqual(statistics.frameCount, 3)
+        XCTAssertEqual(
+            Set(statistics.projectionSamples.map(\.displayID)),
+            Set<UUID?>([firstDisplayID, secondDisplayID, nil])
+        )
+        XCTAssertEqual(statistics.projectionSamples.reduce(0) { $0 + $1.frameCount }, 3)
+    }
+
     func testLoadUnknownFrameThrowsFileNotFound() async throws {
         let store = try FrameStore(directory: directory)
         let unknownID = UUID()

--- a/JustNowTests/FrameStoreTests.swift
+++ b/JustNowTests/FrameStoreTests.swift
@@ -69,6 +69,39 @@ final class FrameStoreTests: XCTestCase {
         XCTAssertEqual(statistics.projectionSamples.reduce(0) { $0 + $1.frameCount }, 3)
     }
 
+    func testStorageStatisticsSamplesNewestFramesByTimestamp() async throws {
+        let store = try FrameStore(directory: directory)
+        let displayID = UUID()
+        let baseDate = Date(timeIntervalSince1970: 1_000)
+        var expectedSampleBytes: Int64 = 0
+
+        for offset in 1...50 {
+            let metadata = try await store.saveFrame(
+                makeImage(),
+                timestamp: baseDate.addingTimeInterval(TimeInterval(offset)),
+                hash: UInt64(offset),
+                displayID: displayID,
+                displayName: "Built-in Display"
+            )
+            expectedSampleBytes += metadata.fileSize
+        }
+        _ = try await store.saveFrame(
+            makeImage(width: 400, height: 300),
+            timestamp: baseDate,
+            hash: 51,
+            displayID: displayID,
+            displayName: "Built-in Display"
+        )
+
+        let statistics = await store.storageStatistics()
+        let sample = try XCTUnwrap(
+            statistics.projectionSamples.first { $0.displayID == displayID }
+        )
+
+        XCTAssertEqual(sample.frameCount, 50)
+        XCTAssertEqual(sample.storedBytes, expectedSampleBytes)
+    }
+
     func testLoadUnknownFrameThrowsFileNotFound() async throws {
         let store = try FrameStore(directory: directory)
         let unknownID = UUID()

--- a/JustNowTests/StorageEstimateTests.swift
+++ b/JustNowTests/StorageEstimateTests.swift
@@ -114,6 +114,21 @@ final class StorageEstimateTests: XCTestCase {
         )
     }
 
+    func testFalloffSpacingRoundsUpToWholeCaptureSteps() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 0),
+            RetentionTier(maxAge: 29, minimumSpacing: 5)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedFrameCountPerDisplay(
+                policy: policy,
+                captureInterval: 4.75
+            ),
+            5
+        )
+    }
+
     func testEstimateWaitsForEnoughSavedFrames() {
         let policy = RetentionPolicy(tiers: [
             RetentionTier(maxAge: 10, minimumSpacing: 1)

--- a/JustNowTests/StorageEstimateTests.swift
+++ b/JustNowTests/StorageEstimateTests.swift
@@ -1,0 +1,204 @@
+import XCTest
+@testable import JustNow
+
+final class StorageEstimateTests: XCTestCase {
+    private let displayID = UUID()
+
+    private func sample(
+        displayID: UUID? = nil,
+        storedBytes: Int64,
+        frameCount: Int
+    ) -> FrameStorageSample {
+        FrameStorageSample(
+            displayID: displayID,
+            storedBytes: storedBytes,
+            frameCount: frameCount
+        )
+    }
+
+    func testMaximumSettingsProjectElevenThousandSevenHundredSixtyOneFramesPerDisplay() {
+        let policy = RetentionPolicy.rewindHistory(
+            .twentyFourHours,
+            captureInterval: 0.25,
+            fullDetailWindow: 30 * 60
+        )
+
+        // The first tier includes the frame at age zero, then:
+        // 30 min × 4 fps + 30 min × 1 fps + 23 hr × 1/30 fps.
+        XCTAssertEqual(
+            StorageEstimate.projectedFrameCountPerDisplay(
+                policy: policy,
+                captureInterval: 0.25
+            ),
+            11_761
+        )
+    }
+
+    func testEstimateUsesAverageSavedFrameSize() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 0)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [sample(displayID: displayID, storedBytes: 5_000, frameCount: 10)],
+                connectedDisplayIDs: [displayID]
+            ),
+            5_500
+        )
+    }
+
+    func testEstimateIncludesEveryDisplay() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 1)
+        ])
+
+        let secondDisplayID = UUID()
+        XCTAssertEqual(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [
+                    sample(displayID: displayID, storedBytes: 5_000, frameCount: 10),
+                    sample(displayID: secondDisplayID, storedBytes: 10_000, frameCount: 10)
+                ],
+                connectedDisplayIDs: [displayID, secondDisplayID]
+            ),
+            16_500
+        )
+    }
+
+    func testEstimateFallsBackToGlobalAverageForANewDisplay() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 1)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [sample(storedBytes: 5_000, frameCount: 10)],
+                connectedDisplayIDs: [displayID]
+            ),
+            5_500
+        )
+    }
+
+    func testEstimateUsesCaptureCadenceWhenItIsSlowerThanTierSpacing() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 20, minimumSpacing: 1)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedFrameCountPerDisplay(
+                policy: policy,
+                captureInterval: 5
+            ),
+            5
+        )
+    }
+
+    func testFirstTierUsesFloorForCadencesThatDoNotDivideItsDuration() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 30 * 60, minimumSpacing: 0)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedFrameCountPerDisplay(
+                policy: policy,
+                captureInterval: 1.75
+            ),
+            1_029
+        )
+    }
+
+    func testEstimateWaitsForEnoughSavedFrames() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 1)
+        ])
+
+        XCTAssertNil(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [sample(
+                    storedBytes: 9_000,
+                    frameCount: StorageEstimate.minimumSampleFrameCount - 1
+                )],
+                connectedDisplayIDs: [displayID]
+            )
+        )
+    }
+
+    func testEstimateRejectsEmptyStorage() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 1)
+        ])
+
+        XCTAssertNil(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [sample(
+                    storedBytes: 0,
+                    frameCount: StorageEstimate.minimumSampleFrameCount
+                )],
+                connectedDisplayIDs: [displayID]
+            )
+        )
+    }
+
+    func testEstimateRejectsMissingDisplaysAndEmptyPolicies() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 1)
+        ])
+
+        XCTAssertNil(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 1,
+                samples: [sample(storedBytes: 5_000, frameCount: 10)],
+                connectedDisplayIDs: []
+            )
+        )
+        XCTAssertNil(
+            StorageEstimate.projectedBytes(
+                policy: RetentionPolicy(tiers: []),
+                captureInterval: 1,
+                samples: [sample(storedBytes: 5_000, frameCount: 10)],
+                connectedDisplayIDs: [displayID]
+            )
+        )
+    }
+
+    func testEstimateRejectsValuesThatWouldOverflowInt64() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: 10, minimumSpacing: 0)
+        ])
+
+        XCTAssertNil(
+            StorageEstimate.projectedBytes(
+                policy: policy,
+                captureInterval: 0.25,
+                samples: [sample(storedBytes: .max, frameCount: 10)],
+                connectedDisplayIDs: (0..<10).map { _ in UUID() }
+            )
+        )
+    }
+
+    func testProjectedFrameCountSaturatesInsteadOfOverflowingInt() {
+        let policy = RetentionPolicy(tiers: [
+            RetentionTier(maxAge: .greatestFiniteMagnitude, minimumSpacing: 0)
+        ])
+
+        XCTAssertEqual(
+            StorageEstimate.projectedFrameCountPerDisplay(
+                policy: policy,
+                captureInterval: 0.25
+            ),
+            Int.max
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- add a live projected frame-storage total to Capture settings after ten saved-frame samples
- model the configured progressive retention tiers, including the inclusive current frame
- use recent per-display frame sizes and only displays connected now, with an aggregate fallback for new displays
- refresh storage statistics atomically every two seconds and expose the projection as native labelled content

## Upgrade behaviour

No preference keys or migration logic change. Existing capture interval, rewind history, and full-detail-window settings remain preserved on upgrade.

## Verification

- `xcodebuild test -scheme JustNow -derivedDataPath /tmp/justnow-storage-estimate-dd.OYH2y9 -resultBundlePath /tmp/justnow-storage-full-v3.xcresult CODE_SIGNING_ALLOWED=NO`
- 222 tests passed, 0 failures
- three clean Codex Max adversarial review gates on `02fc49f`
- Claude Code and OpenCode adversarial review/fix passes
- installed and launched `/Applications/JustNow.app` with the existing Developer ID signature
