### PR TITLE
Move projected storage into capture settings

### DIFF
--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -251,6 +251,23 @@ struct SettingsView: View {
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    LabeledContent("Projected storage") {
+                        if let projectedStorage {
+                            Text("≈\(formatBytes(projectedStorage)) total")
+                                .foregroundStyle(.secondary)
+                        } else {
+                            Text("Waiting for samples")
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
+                    Text(storageEstimateDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
 
             Section("Battery") {
@@ -271,21 +288,6 @@ struct SettingsView: View {
                     Text(formatBytes(storageSize))
                         .foregroundStyle(.secondary)
                 }
-
-                LabeledContent("Projected frame storage") {
-                    if let projectedStorage {
-                        Text("≈\(formatBytes(projectedStorage)) total")
-                            .foregroundStyle(.secondary)
-                    } else {
-                        Text("Waiting for samples")
-                            .foregroundStyle(.secondary)
-                    }
-                }
-
-                Text(storageEstimateDescription)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .fixedSize(horizontal: false, vertical: true)
 
                 HStack(spacing: 8) {
                     Button("Open Storage Folder") {


### PR DESCRIPTION
## Summary

- move the live storage projection beside the capture settings that determine it
- rename the row from “Projected frame storage” to “Projected storage”
- keep current usage and history-management controls in the Storage section

## Validation

- `xcodebuild test -project JustNow.xcodeproj -scheme JustNow -destination 'platform=macOS' -derivedDataPath /tmp/JustNow-move-projected-storage CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` (222 tests)
- installed and launched the Developer ID-signed build from `/Applications/JustNow.app`
- visually verified both Capture and Storage sections in the running app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Moved the “Projected storage” estimate to the Capture section, directly below the “Full-detail window” setting.
  * Updated the estimate to show either the approximate storage amount or “Waiting for samples.”
  * Retained the supporting storage estimate information in the new location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->