### PR TITLE
Refine Settings layout and copy

### DIFF
--- a/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
+++ b/JustNow/UI/ScreenshotSaveLocationSettingsSection.swift
@@ -57,13 +57,6 @@ struct ScreenshotSaveLocationSettingsSection: View {
                         saveToClipboard = true
                     }
                 }
-            Toggle("Copy to clipboard", isOn: $saveToClipboard)
-                .onChange(of: saveToClipboard) { _, newValue in
-                    if !newValue && !saveToFolder {
-                        saveToFolder = true
-                    }
-                }
-            Toggle("Play sound when saving screenshot", isOn: $saveScreenshotSoundEnabled)
 
             if saveToFolder {
                 VStack(alignment: .leading, spacing: 12) {
@@ -104,6 +97,14 @@ struct ScreenshotSaveLocationSettingsSection: View {
                     }
                 }
             }
+
+            Toggle("Copy to clipboard", isOn: $saveToClipboard)
+                .onChange(of: saveToClipboard) { _, newValue in
+                    if !newValue && !saveToFolder {
+                        saveToFolder = true
+                    }
+                }
+            Toggle("Play sound when saving screenshot", isOn: $saveScreenshotSoundEnabled)
 
             Text(captionText)
                 .font(.caption)

--- a/JustNow/UI/SettingsView.swift
+++ b/JustNow/UI/SettingsView.swift
@@ -198,7 +198,7 @@ struct SettingsView: View {
 
     private var captureSettingsTab: some View {
         Form {
-            Section("Capture") {
+            Section("History") {
                 LabeledContent {
                     HStack(spacing: 8) {
                         Slider(value: resolvedCaptureInterval, in: CaptureIntervalSetting.allowedRange, step: 0.25)
@@ -384,7 +384,7 @@ struct SettingsView: View {
                     .onChange(of: overlayDismissModifiers) { _, _ in context.notifyShortcutChanged() }
                 }
 
-                Text("These shortcuts work across macOS while JustNow is running. Keep each action on a distinct shortcut.")
+                Text("These shortcuts work across macOS while JustNow is running.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
## Summary

- place the resolved screenshot destination directly beneath “Save to folder”
- rename the duplicated Capture section heading to “History”
- remove the redundant distinct-shortcut guidance while retaining the Keyboard Shortcuts heading

## Validation

- `xcodebuild test -project JustNow.xcodeproj -scheme JustNow -destination 'platform=macOS' -derivedDataPath /tmp/JustNow-tidy-settings-layout CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO` (222 tests)
- installed and launched the Developer ID-signed build from `/Applications/JustNow.app`
- visually verified the Rewind, Capture, and Shortcuts tabs in the running app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Repositioned the “Copy to clipboard” setting for a clearer settings layout.
  * Renamed the Capture section to “History.”
  * Simplified the keyboard shortcut guidance text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->