### PR TITLE
Publish JustNow v1.4.0 release metadata

### DIFF
--- a/site/appcast.xml
+++ b/site/appcast.xml
@@ -3,6 +3,22 @@
     <channel>
         <title>JustNow</title>
         <item>
+            <title>1.4.0</title>
+            <pubDate>Sat, 18 Jul 2026 21:11:23 +0800</pubDate>
+            <link>https://justnow.tk.sg</link>
+            <sparkle:fullReleaseNotesLink>https://justnow.tk.sg/releases/</sparkle:fullReleaseNotesLink>
+            <sparkle:version>19</sparkle:version>
+            <sparkle:shortVersionString>1.4.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description sparkle:format="markdown">- Capture screen history as often as every 0.25 seconds, with full-detail windows up to 30 minutes and rewind history up to 24 hours.
+- Keep long rewind windows manageable with progressive falloff that gradually retains fewer older frames.
+- See a live projected-storage estimate alongside the Capture settings that affect it.
+- Preserve existing capture, history, and shortcut settings when upgrading.
+- Refined Settings layout and wording for screenshot destinations, storage, and keyboard shortcuts.
+</description>
+            <enclosure url="https://github.com/yjsoon/justnow/releases/download/v1.4.0/JustNow-v1.4.0-macos.zip" length="5394522" type="application/octet-stream" sparkle:edSignature="jFNkA6oEHpflDOHdYcgkirxvWtf0XiMQ2/TX6Mz1AuvWBlnTeYVPhAiyGvo/fjf0CB3TAo5ug6FvIWbVFk15Bw==" />
+        </item>
+        <item>
             <title>1.3.4</title>
             <pubDate>Mon, 13 Jul 2026 08:27:12 +0800</pubDate>
             <link>https://justnow.tk.sg</link>

--- a/site/releases.json
+++ b/site/releases.json
@@ -11,10 +11,23 @@
   },
   "releases": [
     {
+      "tag": "v1.4.0",
+      "version": "1.4.0",
+      "published_at": "2026-07-18",
+      "status": "Current public build",
+      "notes": [
+        "Capture screen history as often as every 0.25 seconds, with full-detail windows up to 30 minutes and rewind history up to 24 hours.",
+        "Keep long rewind windows manageable with progressive falloff that gradually retains fewer older frames.",
+        "See a live projected-storage estimate alongside the Capture settings that affect it.",
+        "Preserve existing capture, history, and shortcut settings when upgrading.",
+        "Refined Settings layout and wording for screenshot destinations, storage, and keyboard shortcuts."
+      ]
+    },
+    {
       "tag": "v1.3.4",
       "version": "1.3.4",
       "published_at": "2026-07-13",
-      "status": "Current public build",
+      "status": "Previous release",
       "notes": [
         "Capture now pauses when the screen locks instead of stopping outright, and resumes on unlock",
         "Added a persistent diagnostics log for capture failures at `~/Library/Logs/JustNow/diagnostics.log` (capped at 512 KB per file)",

--- a/site/releases/index.html
+++ b/site/releases/index.html
@@ -38,9 +38,23 @@
 
       <main class="release-list">
         <article class="release-card">
-          <h2>v1.3.4</h2>
+          <h2>v1.4.0</h2>
           <div class="release-meta">
             <span>Current public build</span>
+            <span>July 18, 2026</span>
+          </div>
+          <ul>
+            <li>Capture screen history as often as every 0.25 seconds, with full-detail windows up to 30 minutes and rewind history up to 24 hours.</li>
+            <li>Keep long rewind windows manageable with progressive falloff that gradually retains fewer older frames.</li>
+            <li>See a live projected-storage estimate alongside the Capture settings that affect it.</li>
+            <li>Preserve existing capture, history, and shortcut settings when upgrading.</li>
+            <li>Refined Settings layout and wording for screenshot destinations, storage, and keyboard shortcuts.</li>
+          </ul>
+        </article>
+        <article class="release-card">
+          <h2>v1.3.4</h2>
+          <div class="release-meta">
+            <span>Previous release</span>
             <span>July 13, 2026</span>
           </div>
           <ul>


### PR DESCRIPTION
## Summary

- publish v1.4.0 in the public release metadata and release-notes page
- add the signed v1.4.0 ZIP enclosure to the Sparkle appcast
- mark v1.3.4 as the previous release

## Validation

- GitHub release v1.4.0 is published with notarised ZIP and DMG assets
- generated appcast reports version 1.4.0, build 19, and the uploaded ZIP size/signature
- `git diff --check` passes

## Deployment note

The live `justnow.tk.sg` deployment is blocked because the authenticated Cloudflare account does not contain the configured `justnow-site` Pages project. No replacement project or DNS change was created.
