### PR TITLE
fix: prevent repeated screen recording prompts

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -665,7 +665,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 updateCaptureStatus("Active")
             }
         case .coolingDown:
-            updateCaptureStatus("Recovering…")
+            if captureEventController.blockedStatus() == nil {
+                updateCaptureStatus("Recovering…")
+            }
         }
     }
 

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -655,6 +655,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         captureEventController.handleUnexpectedStop()
     }
 
+    func captureCoordinator(
+        _ coordinator: CaptureCoordinator,
+        didChangeRecoveryState state: CaptureRequestBrokerRecoveryState
+    ) {
+        switch state {
+        case .normal:
+            if coordinator.isCapturing, captureEventController.blockedStatus() == nil {
+                updateCaptureStatus("Active")
+            }
+        case .coolingDown:
+            updateCaptureStatus("Recovering…")
+        }
+    }
+
     @objc private func toggleCapturePause() {
         captureEventController.toggleCapturePause()
     }

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -39,6 +39,9 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
 
     weak var delegate: CaptureCoordinatorDelegate?
 
+    /// All display managers share one broker so a ScreenCaptureKit false TCC
+    /// denial pauses the whole process before another display can retry.
+    private let captureRequestBroker = CaptureRequestBroker()
     private var managed: [UUID: ManagedDisplay] = [:]
     private var captureInterval: TimeInterval = 1.0
     private var captureScale: Int = 2
@@ -163,7 +166,10 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         if startNewManagers {
             for (id, info) in desired where managed[id] == nil {
                 guard let physicalDisplayID = info.displayID else { continue }
-                let manager = ScreenCaptureManager(targetDisplayID: physicalDisplayID)
+                let manager = ScreenCaptureManager(
+                    targetDisplayID: physicalDisplayID,
+                    captureRequestBroker: captureRequestBroker
+                )
                 manager.delegate = self
                 manager.updateCaptureInterval(captureInterval)
                 manager.updateCaptureScale(captureScale)

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -116,8 +116,9 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         reconcileTask = nil
         let snapshot = Array(managed.values)
         managed.removeAll()
-        for entry in snapshot {
-            await entry.manager.stopCapture()
+        let previousLoops = snapshot.map { $0.manager.beginStoppingCapture() }
+        for previousLoop in previousLoops {
+            await previousLoop?.value
         }
         delegate?.captureCoordinatorDidUpdateDisplays(self)
     }

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -21,10 +21,18 @@ protocol CaptureCoordinatorDelegate: AnyObject {
     )
     func captureCoordinatorDidStopUnexpectedly(_ coordinator: CaptureCoordinator)
     func captureCoordinatorDidUpdateDisplays(_ coordinator: CaptureCoordinator)
+    func captureCoordinator(
+        _ coordinator: CaptureCoordinator,
+        didChangeRecoveryState state: CaptureRequestBrokerRecoveryState
+    )
 }
 
 extension CaptureCoordinatorDelegate {
     func captureCoordinatorDidUpdateDisplays(_ coordinator: CaptureCoordinator) {}
+    func captureCoordinator(
+        _ coordinator: CaptureCoordinator,
+        didChangeRecoveryState state: CaptureRequestBrokerRecoveryState
+    ) {}
 }
 
 /// Owns one ScreenCaptureManager per physical display and fans capture
@@ -41,7 +49,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
 
     /// All display managers share one broker so a ScreenCaptureKit false TCC
     /// denial pauses the whole process before another display can retry.
-    private let captureRequestBroker = CaptureRequestBroker()
+    private let captureRequestBroker: CaptureRequestBroker
     private var managed: [UUID: ManagedDisplay] = [:]
     private var captureInterval: TimeInterval = 1.0
     private var captureScale: Int = 2
@@ -50,7 +58,17 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     private var reconcileTask: Task<Void, Never>?
 
     override init() {
+        let captureRequestBroker = CaptureRequestBroker()
+        self.captureRequestBroker = captureRequestBroker
         super.init()
+        captureRequestBroker.recoveryStateDidChange = { [weak self] state in
+            // Sleep, lock, overlay and user-pause flows mark the coordinator
+            // stopped before awaiting an in-flight ScreenCaptureKit request.
+            // Do not let a late broker result overwrite those more specific
+            // menu states.
+            guard let self, self.isRunning else { return }
+            self.delegate?.captureCoordinator(self, didChangeRecoveryState: state)
+        }
         screenParamsObserver = NotificationCenter.default.addObserver(
             forName: NSApplication.didChangeScreenParametersNotification,
             object: nil,

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -173,12 +173,12 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
 
         // Remove managers for displays that are no longer connected.
         let removedIDs = managed.keys.filter { desired[$0] == nil }
-        for id in removedIDs {
-            if let entry = managed.removeValue(forKey: id) {
-                await entry.manager.stopCapture()
-                captureLogger.info("Capture stopped for removed display: \(entry.info.name, privacy: .public)")
-                DiagnosticsLog.shared.log("Capture", "Capture stopped for removed display: \(entry.info.name)")
-            }
+        let removedEntries = removedIDs.compactMap { managed.removeValue(forKey: $0) }
+        let previousLoops = removedEntries.map { $0.manager.beginStoppingCapture() }
+        for (entry, previousLoop) in zip(removedEntries, previousLoops) {
+            await previousLoop?.value
+            captureLogger.info("Capture stopped for removed display: \(entry.info.name, privacy: .public)")
+            DiagnosticsLog.shared.log("Capture", "Capture stopped for removed display: \(entry.info.name)")
         }
 
         // Start managers for newly seen displays.

--- a/JustNow/Capture/CaptureRequestBroker.swift
+++ b/JustNow/Capture/CaptureRequestBroker.swift
@@ -1,0 +1,279 @@
+//
+//  CaptureRequestBroker.swift
+//  JustNow
+//
+
+import CoreGraphics
+import Foundation
+import os.log
+
+private let captureBrokerLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
+
+/// The reason a one-shot request was not allowed to reach ScreenCaptureKit.
+/// These are expected, temporary results and must not count as capture errors.
+enum CaptureRequestBrokerError: Error, Equatable {
+    /// A false ScreenCaptureKit permission denial opened the process-wide circuit.
+    case cooldown(until: Date)
+    /// A periodic tick arrived while another request was active. The next tick
+    /// will capture a fresh frame instead of catching up stale work later.
+    case droppedPeriodicRequest
+}
+
+enum CaptureRequestKind: Equatable {
+    case periodic
+    case interactive
+}
+
+/// Serialises all one-shot ScreenCaptureKit calls made by this process.
+///
+/// ScreenCaptureKit can momentarily return `SCStreamErrorDomain/-3801` even
+/// when TCC remains granted. The broker sees that result before releasing a
+/// waiting display, opens one shared circuit, and makes callers fail fast
+/// until a single half-open probe succeeds.
+@MainActor
+final class CaptureRequestBroker {
+    private struct Waiter {
+        let id: UUID
+        let owner: UUID
+        let continuation: CheckedContinuation<WaitResult, Never>
+    }
+
+    private enum WaitResult {
+        case acquired
+        case cancelled
+        case cooldown(Date)
+    }
+
+    private enum CircuitState {
+        case closed
+        case open(until: Date)
+        case halfOpen
+    }
+
+    private let now: @MainActor () -> Date
+    private let hasScreenRecordingPermission: @MainActor () -> Bool
+    private let log: @MainActor (String) -> Void
+    private let cooldown: TimeInterval
+
+    private var circuitState: CircuitState = .closed
+    private var isRequestInFlight = false
+    private var waiters: [Waiter] = []
+    /// The next periodic owner to admit after it lost a concurrent tick. This
+    /// is a single fairness token, not a backlog: the losing tick is still
+    /// dropped and only a later fresh tick can consume the token.
+    private var preferredPeriodicOwner: UUID?
+    private var openedCircuitCount = 0
+
+    init(
+        now: @escaping @MainActor () -> Date = Date.init,
+        hasScreenRecordingPermission: @escaping @MainActor () -> Bool = {
+            ScreenCaptureManager.hasScreenRecordingPermission()
+        },
+        cooldown: TimeInterval = CaptureFailureRecovery.falsePermissionDenialDelay,
+        log: @escaping @MainActor (String) -> Void = { message in
+            captureBrokerLogger.warning("\(message, privacy: .public)")
+            DiagnosticsLog.shared.log("Capture", message)
+        }
+    ) {
+        self.now = now
+        self.hasScreenRecordingPermission = hasScreenRecordingPermission
+        self.cooldown = cooldown
+        self.log = log
+    }
+
+    /// Runs a single one-shot request after process-wide admission.
+    ///
+    /// Interactive requests may wait for the one currently in progress, so an
+    /// overlay refresh can still get the newest image. Periodic requests are
+    /// intentionally dropped while busy, preventing per-display backlogs.
+    func perform<Value>(
+        owner: UUID,
+        kind: CaptureRequestKind,
+        operation: @escaping @MainActor () async throws -> Value
+    ) async throws -> Value {
+        try await acquireTurn(owner: owner, kind: kind)
+
+        do {
+            let value = try await operation()
+            finishTurn(after: .success)
+            return value
+        } catch {
+            finishTurn(after: .failure(error))
+            throw error
+        }
+    }
+
+    /// Removes only requests owned by the manager being stopped or unplugged.
+    /// It deliberately does not mutate a shared circuit or another manager's
+    /// work.
+    func cancelRequests(for owner: UUID) {
+        let matching = waiters.filter { $0.owner == owner }
+        waiters.removeAll { $0.owner == owner }
+        if preferredPeriodicOwner == owner {
+            preferredPeriodicOwner = nil
+        }
+        for waiter in matching {
+            waiter.continuation.resume(returning: .cancelled)
+        }
+    }
+
+    // MARK: - Admission
+
+    private func acquireTurn(owner: UUID, kind: CaptureRequestKind) async throws {
+        try Task.checkCancellation()
+
+        if case .open(let deadline) = circuitState {
+            guard now() >= deadline else {
+                throw CaptureRequestBrokerError.cooldown(until: deadline)
+            }
+            // The first request after expiry is the only half-open probe. It
+            // cannot race another request because the broker is main-actor
+            // isolated and an open circuit never releases queued work.
+            circuitState = .halfOpen
+        }
+
+        if kind == .periodic, let preferredPeriodicOwner {
+            guard preferredPeriodicOwner == owner else {
+                // A competing display was dropped on the previous aligned
+                // tick. Let it receive the next fresh periodic turn rather
+                // than allowing this owner to win every 0.25-second race.
+                throw CaptureRequestBrokerError.droppedPeriodicRequest
+            }
+            self.preferredPeriodicOwner = nil
+        }
+
+        if isRequestInFlight {
+            guard kind == .interactive else {
+                // Preserve the first losing owner until it receives a later
+                // turn. Do not enqueue this stale periodic request.
+                if preferredPeriodicOwner == nil {
+                    preferredPeriodicOwner = owner
+                }
+                throw CaptureRequestBrokerError.droppedPeriodicRequest
+            }
+            try await waitForTurn(owner: owner)
+            return
+        }
+
+        isRequestInFlight = true
+    }
+
+    private func waitForTurn(owner: UUID) async throws {
+        let id = UUID()
+        let result = await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { (continuation: CheckedContinuation<WaitResult, Never>) in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: .cancelled)
+                    return
+                }
+                waiters.append(Waiter(id: id, owner: owner, continuation: continuation))
+            }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelWaiter(id: id)
+            }
+        })
+
+        switch result {
+        case .acquired:
+            return
+        case .cancelled:
+            throw CancellationError()
+        case .cooldown(let deadline):
+            throw CaptureRequestBrokerError.cooldown(until: deadline)
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        let waiter = waiters.remove(at: index)
+        waiter.continuation.resume(returning: .cancelled)
+    }
+
+    // MARK: - Completion
+
+    private enum TurnOutcome {
+        case success
+        case failure(Error)
+    }
+
+    private func finishTurn(after outcome: TurnOutcome) {
+        switch outcome {
+        case .success:
+            if case .halfOpen = circuitState {
+                circuitState = .closed
+                logCircuitRecovery()
+            }
+            releaseNextWaiter()
+
+        case .failure(let error):
+            let recovery = CaptureFailureRecovery.disposition(
+                for: error,
+                hasScreenRecordingPermission: hasScreenRecordingPermission()
+            )
+            if case .backOff(let delay) = recovery {
+                let isHalfOpenProbe: Bool
+                if case .halfOpen = circuitState {
+                    isHalfOpenProbe = true
+                } else {
+                    isHalfOpenProbe = false
+                }
+                openCircuit(for: delay, isReopen: isHalfOpenProbe)
+                return
+            }
+
+            if case .halfOpen = circuitState {
+                if error is CancellationError {
+                    // A display disappearing during the probe must not let it
+                    // reset the circuit for every other display. Keep the
+                    // shared protection in place and retry with a future owner.
+                    openCircuit(for: cooldown, isReopen: true)
+                    return
+                }
+                // This was not the beta false-denial signature. Preserve the
+                // manager's normal error handling and let later requests run.
+                circuitState = .closed
+            }
+            releaseNextWaiter()
+        }
+    }
+
+    private func openCircuit(for delay: TimeInterval, isReopen: Bool = false) {
+        let deadline = now().addingTimeInterval(delay)
+        circuitState = .open(until: deadline)
+        openedCircuitCount += 1
+
+        let queuedCount = waiters.count
+        let event = isReopen ? "reopened" : "opened"
+        log(
+            "Global ScreenCaptureKit capture circuit \(event) for \(delay) seconds "
+                + "(queuedRequests=\(queuedCount), circuitOpenCount=\(openedCircuitCount))"
+        )
+
+        let pending = waiters
+        waiters.removeAll()
+        isRequestInFlight = false
+        for waiter in pending {
+            waiter.continuation.resume(returning: .cooldown(deadline))
+        }
+    }
+
+    private func releaseNextWaiter() {
+        guard !waiters.isEmpty else {
+            isRequestInFlight = false
+            return
+        }
+
+        let waiter = waiters.removeFirst()
+        // Keep the permit held while the waiter resumes, so no unrelated
+        // caller can steal it before the queued request starts its OS call.
+        waiter.continuation.resume(returning: .acquired)
+    }
+
+    private func logCircuitRecovery() {
+        log(
+            "Global ScreenCaptureKit capture circuit recovered "
+                + "(queuedRequests=\(waiters.count), circuitOpenCount=\(openedCircuitCount))"
+        )
+    }
+}

--- a/JustNow/Capture/CaptureRequestBroker.swift
+++ b/JustNow/Capture/CaptureRequestBroker.swift
@@ -14,14 +14,11 @@ private let captureBrokerLogger = Logger(subsystem: "sg.tk.JustNow", category: "
 enum CaptureRequestBrokerError: Error, Equatable {
     /// A false ScreenCaptureKit permission denial opened the process-wide circuit.
     case cooldown(until: Date)
-    /// A periodic tick arrived while another request was active. The next tick
-    /// will capture a fresh frame instead of catching up stale work later.
-    case droppedPeriodicRequest
 }
 
-enum CaptureRequestKind: Equatable {
-    case periodic
-    case interactive
+enum CaptureRequestBrokerRecoveryState: Equatable {
+    case normal
+    case coolingDown(until: Date)
 }
 
 /// Serialises all one-shot ScreenCaptureKit calls made by this process.
@@ -46,26 +43,28 @@ final class CaptureRequestBroker {
 
     private enum CircuitState {
         case closed
-        case open(until: Date)
+        case open(monotonicDeadline: TimeInterval, wallDeadline: Date)
         case halfOpen
     }
 
-    private let now: @MainActor () -> Date
+    private let wallNow: @MainActor () -> Date
+    private let monotonicNow: @MainActor () -> TimeInterval
     private let hasScreenRecordingPermission: @MainActor () -> Bool
     private let log: @MainActor (String) -> Void
     private let cooldown: TimeInterval
 
+    var recoveryStateDidChange: @MainActor (CaptureRequestBrokerRecoveryState) -> Void = { _ in }
+
     private var circuitState: CircuitState = .closed
     private var isRequestInFlight = false
     private var waiters: [Waiter] = []
-    /// The next periodic owner to admit after it lost a concurrent tick. This
-    /// is a single fairness token, not a backlog: the losing tick is still
-    /// dropped and only a later fresh tick can consume the token.
-    private var preferredPeriodicOwner: UUID?
     private var openedCircuitCount = 0
 
     init(
-        now: @escaping @MainActor () -> Date = Date.init,
+        wallNow: @escaping @MainActor () -> Date = Date.init,
+        monotonicNow: @escaping @MainActor () -> TimeInterval = {
+            TimeInterval(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
+        },
         hasScreenRecordingPermission: @escaping @MainActor () -> Bool = {
             ScreenCaptureManager.hasScreenRecordingPermission()
         },
@@ -75,7 +74,8 @@ final class CaptureRequestBroker {
             DiagnosticsLog.shared.log("Capture", message)
         }
     ) {
-        self.now = now
+        self.wallNow = wallNow
+        self.monotonicNow = monotonicNow
         self.hasScreenRecordingPermission = hasScreenRecordingPermission
         self.cooldown = cooldown
         self.log = log
@@ -83,15 +83,14 @@ final class CaptureRequestBroker {
 
     /// Runs a single one-shot request after process-wide admission.
     ///
-    /// Interactive requests may wait for the one currently in progress, so an
-    /// overlay refresh can still get the newest image. Periodic requests are
-    /// intentionally dropped while busy, preventing per-display backlogs.
+    /// Each manager's periodic loop is serial, so waiting here preserves the
+    /// configured per-display cadence without allowing stale per-owner work to
+    /// accumulate. Interactive refreshes use the same FIFO admission path.
     func perform<Value>(
         owner: UUID,
-        kind: CaptureRequestKind,
         operation: @escaping @MainActor () async throws -> Value
     ) async throws -> Value {
-        try await acquireTurn(owner: owner, kind: kind)
+        try await acquireTurn(owner: owner)
 
         do {
             let value = try await operation()
@@ -109,9 +108,6 @@ final class CaptureRequestBroker {
     func cancelRequests(for owner: UUID) {
         let matching = waiters.filter { $0.owner == owner }
         waiters.removeAll { $0.owner == owner }
-        if preferredPeriodicOwner == owner {
-            preferredPeriodicOwner = nil
-        }
         for waiter in matching {
             waiter.continuation.resume(returning: .cancelled)
         }
@@ -119,12 +115,16 @@ final class CaptureRequestBroker {
 
     // MARK: - Admission
 
-    private func acquireTurn(owner: UUID, kind: CaptureRequestKind) async throws {
+    private func acquireTurn(owner: UUID) async throws {
         try Task.checkCancellation()
 
-        if case .open(let deadline) = circuitState {
-            guard now() >= deadline else {
-                throw CaptureRequestBrokerError.cooldown(until: deadline)
+        if case .open(let monotonicDeadline, let wallDeadline) = circuitState {
+            guard monotonicNow() >= monotonicDeadline else {
+                // Capture may have been paused and restarted while the shared
+                // circuit was still open. Re-publish the state so the new run
+                // does not briefly present itself as healthy.
+                recoveryStateDidChange(.coolingDown(until: wallDeadline))
+                throw CaptureRequestBrokerError.cooldown(until: wallDeadline)
             }
             // The first request after expiry is the only half-open probe. It
             // cannot race another request because the broker is main-actor
@@ -132,25 +132,7 @@ final class CaptureRequestBroker {
             circuitState = .halfOpen
         }
 
-        if kind == .periodic, let preferredPeriodicOwner {
-            guard preferredPeriodicOwner == owner else {
-                // A competing display was dropped on the previous aligned
-                // tick. Let it receive the next fresh periodic turn rather
-                // than allowing this owner to win every 0.25-second race.
-                throw CaptureRequestBrokerError.droppedPeriodicRequest
-            }
-            self.preferredPeriodicOwner = nil
-        }
-
         if isRequestInFlight {
-            guard kind == .interactive else {
-                // Preserve the first losing owner until it receives a later
-                // turn. Do not enqueue this stale periodic request.
-                if preferredPeriodicOwner == nil {
-                    preferredPeriodicOwner = owner
-                }
-                throw CaptureRequestBrokerError.droppedPeriodicRequest
-            }
             try await waitForTurn(owner: owner)
             return
         }
@@ -203,6 +185,7 @@ final class CaptureRequestBroker {
             if case .halfOpen = circuitState {
                 circuitState = .closed
                 logCircuitRecovery()
+                recoveryStateDidChange(.normal)
             }
             releaseNextWaiter()
 
@@ -233,14 +216,19 @@ final class CaptureRequestBroker {
                 // This was not the beta false-denial signature. Preserve the
                 // manager's normal error handling and let later requests run.
                 circuitState = .closed
+                recoveryStateDidChange(.normal)
             }
             releaseNextWaiter()
         }
     }
 
     private func openCircuit(for delay: TimeInterval, isReopen: Bool = false) {
-        let deadline = now().addingTimeInterval(delay)
-        circuitState = .open(until: deadline)
+        let wallDeadline = wallNow().addingTimeInterval(delay)
+        let monotonicDeadline = monotonicNow() + delay
+        circuitState = .open(
+            monotonicDeadline: monotonicDeadline,
+            wallDeadline: wallDeadline
+        )
         openedCircuitCount += 1
 
         let queuedCount = waiters.count
@@ -249,12 +237,13 @@ final class CaptureRequestBroker {
             "Global ScreenCaptureKit capture circuit \(event) for \(delay) seconds "
                 + "(queuedRequests=\(queuedCount), circuitOpenCount=\(openedCircuitCount))"
         )
+        recoveryStateDidChange(.coolingDown(until: wallDeadline))
 
         let pending = waiters
         waiters.removeAll()
         isRequestInFlight = false
         for waiter in pending {
-            waiter.continuation.resume(returning: .cooldown(deadline))
+            waiter.continuation.resume(returning: .cooldown(wallDeadline))
         }
     }
 

--- a/JustNow/Capture/CaptureRequestBroker.swift
+++ b/JustNow/Capture/CaptureRequestBroker.swift
@@ -13,12 +13,12 @@ private let captureBrokerLogger = Logger(subsystem: "sg.tk.JustNow", category: "
 /// These are expected, temporary results and must not count as capture errors.
 enum CaptureRequestBrokerError: Error, Equatable {
     /// A false ScreenCaptureKit permission denial opened the process-wide circuit.
-    case cooldown(until: Date)
+    case cooldown(untilMonotonicTime: TimeInterval)
 }
 
 enum CaptureRequestBrokerRecoveryState: Equatable {
     case normal
-    case coolingDown(until: Date)
+    case coolingDown
 }
 
 /// Serialises all one-shot ScreenCaptureKit calls made by this process.
@@ -38,16 +38,15 @@ final class CaptureRequestBroker {
     private enum WaitResult {
         case acquired
         case cancelled
-        case cooldown(Date)
+        case cooldown(TimeInterval)
     }
 
     private enum CircuitState {
         case closed
-        case open(monotonicDeadline: TimeInterval, wallDeadline: Date)
+        case open(monotonicDeadline: TimeInterval)
         case halfOpen
     }
 
-    private let wallNow: @MainActor () -> Date
     private let monotonicNow: @MainActor () -> TimeInterval
     private let hasScreenRecordingPermission: @MainActor () -> Bool
     private let log: @MainActor (String) -> Void
@@ -61,7 +60,6 @@ final class CaptureRequestBroker {
     private var openedCircuitCount = 0
 
     init(
-        wallNow: @escaping @MainActor () -> Date = Date.init,
         monotonicNow: @escaping @MainActor () -> TimeInterval = {
             TimeInterval(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
         },
@@ -74,7 +72,6 @@ final class CaptureRequestBroker {
             DiagnosticsLog.shared.log("Capture", message)
         }
     ) {
-        self.wallNow = wallNow
         self.monotonicNow = monotonicNow
         self.hasScreenRecordingPermission = hasScreenRecordingPermission
         self.cooldown = cooldown
@@ -118,13 +115,15 @@ final class CaptureRequestBroker {
     private func acquireTurn(owner: UUID) async throws {
         try Task.checkCancellation()
 
-        if case .open(let monotonicDeadline, let wallDeadline) = circuitState {
+        if case .open(let monotonicDeadline) = circuitState {
             guard monotonicNow() >= monotonicDeadline else {
                 // Capture may have been paused and restarted while the shared
                 // circuit was still open. Re-publish the state so the new run
                 // does not briefly present itself as healthy.
-                recoveryStateDidChange(.coolingDown(until: wallDeadline))
-                throw CaptureRequestBrokerError.cooldown(until: wallDeadline)
+                recoveryStateDidChange(.coolingDown)
+                throw CaptureRequestBrokerError.cooldown(
+                    untilMonotonicTime: monotonicDeadline
+                )
             }
             // The first request after expiry is the only half-open probe. It
             // cannot race another request because the broker is main-actor
@@ -161,8 +160,10 @@ final class CaptureRequestBroker {
             return
         case .cancelled:
             throw CancellationError()
-        case .cooldown(let deadline):
-            throw CaptureRequestBrokerError.cooldown(until: deadline)
+        case .cooldown(let monotonicDeadline):
+            throw CaptureRequestBrokerError.cooldown(
+                untilMonotonicTime: monotonicDeadline
+            )
         }
     }
 
@@ -214,21 +215,16 @@ final class CaptureRequestBroker {
                     return
                 }
                 // This was not the beta false-denial signature. Preserve the
-                // manager's normal error handling and let later requests run.
-                circuitState = .closed
-                recoveryStateDidChange(.normal)
+                // manager's normal error handling and let later requests run,
+                // but remain half-open until a capture actually succeeds.
             }
             releaseNextWaiter()
         }
     }
 
     private func openCircuit(for delay: TimeInterval, isReopen: Bool = false) {
-        let wallDeadline = wallNow().addingTimeInterval(delay)
         let monotonicDeadline = monotonicNow() + delay
-        circuitState = .open(
-            monotonicDeadline: monotonicDeadline,
-            wallDeadline: wallDeadline
-        )
+        circuitState = .open(monotonicDeadline: monotonicDeadline)
         openedCircuitCount += 1
 
         let queuedCount = waiters.count
@@ -237,13 +233,13 @@ final class CaptureRequestBroker {
             "Global ScreenCaptureKit capture circuit \(event) for \(delay) seconds "
                 + "(queuedRequests=\(queuedCount), circuitOpenCount=\(openedCircuitCount))"
         )
-        recoveryStateDidChange(.coolingDown(until: wallDeadline))
+        recoveryStateDidChange(.coolingDown)
 
         let pending = waiters
         waiters.removeAll()
         isRequestInFlight = false
         for waiter in pending {
-            waiter.continuation.resume(returning: .cooldown(wallDeadline))
+            waiter.continuation.resume(returning: .cooldown(monotonicDeadline))
         }
     }
 
@@ -265,4 +261,10 @@ final class CaptureRequestBroker {
                 + "(queuedRequests=\(waiters.count), circuitOpenCount=\(openedCircuitCount))"
         )
     }
+
+#if DEBUG
+    var queuedRequestCountForTesting: Int {
+        waiters.count
+    }
+#endif
 }

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -15,9 +15,30 @@ enum CaptureError: Error {
     case noDisplay
 }
 
-private enum CaptureTurnWaitResult {
-    case acquired
-    case cancelled
+enum CaptureFailureRecovery: Equatable {
+    case countTowardsStop
+    case backOff(TimeInterval)
+
+    nonisolated static let falsePermissionDenialDelay: TimeInterval = 30
+
+    nonisolated static func disposition(
+        for error: Error,
+        hasScreenRecordingPermission: Bool
+    ) -> CaptureFailureRecovery {
+        let nsError = error as NSError
+        guard hasScreenRecordingPermission,
+              nsError.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+              nsError.code == -3801 else {
+            return .countTowardsStop
+        }
+
+        // On current macOS betas, ScreenCaptureKit can briefly report that the
+        // user declined capture while CoreGraphics and tccd still say the app
+        // is authorised. Rapid retries make that OS-side mismatch worse and
+        // can surface another native permission prompt. Leave the existing
+        // capture session intact and give replayd time to settle instead.
+        return .backOff(falsePermissionDenialDelay)
+    }
 }
 
 @MainActor
@@ -42,9 +63,12 @@ class ScreenCaptureManager: NSObject {
     private(set) var isCapturing = false
     private(set) var captureInterval: TimeInterval = 1.0
     let targetDisplayID: CGDirectDisplayID
+    private let captureRequestBroker: CaptureRequestBroker
+    private let captureRequestOwner = UUID()
 
-    init(targetDisplayID: CGDirectDisplayID) {
+    init(targetDisplayID: CGDirectDisplayID, captureRequestBroker: CaptureRequestBroker) {
         self.targetDisplayID = targetDisplayID
+        self.captureRequestBroker = captureRequestBroker
         super.init()
     }
 
@@ -57,9 +81,6 @@ class ScreenCaptureManager: NSObject {
     private var nextCaptureAt: Date?
     private var captureWakeTask: Task<Void, Never>?
     private var captureWakeContinuation: CheckedContinuation<Void, Never>?
-    /// Global gate so periodic capture and overlay refreshes never issue overlapping screenshot requests.
-    private var isCaptureRequestInFlight = false
-    private var captureRequestWaiters: [(id: UUID, continuation: CheckedContinuation<CaptureTurnWaitResult, Never>)] = []
     private var consecutiveCaptureFailures = 0
 
     static func hasScreenRecordingPermission() -> Bool {
@@ -135,7 +156,7 @@ class ScreenCaptureManager: NSObject {
         nextCaptureAt = nil
         captureLoopTask = nil
         previousLoop?.cancel()
-        cancelQueuedCaptureRequests()
+        captureRequestBroker.cancelRequests(for: captureRequestOwner)
         wakeCaptureLoop()
         if wasCapturing {
             captureLogger.info("Capture stopped")
@@ -165,7 +186,10 @@ class ScreenCaptureManager: NSObject {
     func captureNow() async -> CGImage? {
         let requestLoopSerial = captureLoopSerial
         guard isCapturing else { return nil }
-        return try? await captureImageSerially(expectedLoopSerial: requestLoopSerial)
+        return try? await captureImageSerially(
+            expectedLoopSerial: requestLoopSerial,
+            kind: .interactive
+        )
     }
 
     // MARK: - Private
@@ -241,73 +265,40 @@ class ScreenCaptureManager: NSObject {
         continuation.resume()
     }
 
-    private func acquireCaptureTurn() async throws {
-        if !isCaptureRequestInFlight {
-            isCaptureRequestInFlight = true
-            return
-        }
-
-        let waiterID = UUID()
-        let result = await withTaskCancellationHandler(operation: {
-            await withCheckedContinuation { continuation in
-                captureRequestWaiters.append((id: waiterID, continuation: continuation))
-                if Task.isCancelled {
-                    cancelCaptureRequestWaiter(id: waiterID)
-                }
-            }
-        }, onCancel: {
-            Task { @MainActor [weak self] in
-                self?.cancelCaptureRequestWaiter(id: waiterID)
-            }
-        })
-
-        if case .cancelled = result {
-            throw CancellationError()
-        }
-    }
-
-    private func cancelCaptureRequestWaiter(id: UUID) {
-        guard let index = captureRequestWaiters.firstIndex(where: { $0.id == id }) else { return }
-        let continuation = captureRequestWaiters.remove(at: index).continuation
-        continuation.resume(returning: .cancelled)
-    }
-
-    private func cancelQueuedCaptureRequests() {
-        let waiters = captureRequestWaiters
-        captureRequestWaiters.removeAll()
-        for waiter in waiters {
-            waiter.continuation.resume(returning: .cancelled)
-        }
-    }
-
-    private func releaseCaptureTurn() {
-        guard !captureRequestWaiters.isEmpty else {
-            isCaptureRequestInFlight = false
-            return
-        }
-
-        let continuation = captureRequestWaiters.removeFirst().continuation
-        continuation.resume(returning: .acquired)
-    }
-
-    private func captureImageSerially(expectedLoopSerial: Int? = nil) async throws -> CGImage {
-        try await acquireCaptureTurn()
-        defer { releaseCaptureTurn() }
-
-        try Task.checkCancellation()
-        guard let filter, let config else {
-            throw CancellationError()
-        }
-        if let expectedLoopSerial {
-            guard isCapturing, captureLoopSerial == expectedLoopSerial else {
+    private func captureImageSerially(
+        expectedLoopSerial: Int? = nil,
+        kind: CaptureRequestKind
+    ) async throws -> CGImage {
+        let image = try await captureRequestBroker.perform(
+            owner: captureRequestOwner,
+            kind: kind
+        ) { [weak self] in
+            guard let self else { throw CancellationError() }
+            try Task.checkCancellation()
+            guard let filter = self.filter, let config = self.config else {
                 throw CancellationError()
             }
-        }
+            if let expectedLoopSerial {
+                guard self.isCapturing, self.captureLoopSerial == expectedLoopSerial else {
+                    throw CancellationError()
+                }
+            }
 
-        let image = try await SCScreenshotManager.captureImage(
-            contentFilter: filter,
-            configuration: config
-        )
+            let image = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: config
+            )
+            // Keep cancellation inside the brokered operation. If a display
+            // disappears while a half-open probe is in ScreenCaptureKit, a
+            // late successful return must not close the global circuit.
+            try Task.checkCancellation()
+            if let expectedLoopSerial {
+                guard self.isCapturing, self.captureLoopSerial == expectedLoopSerial else {
+                    throw CancellationError()
+                }
+            }
+            return image
+        }
         try Task.checkCancellation()
         if let expectedLoopSerial {
             guard isCapturing, captureLoopSerial == expectedLoopSerial else {
@@ -320,11 +311,16 @@ class ScreenCaptureManager: NSObject {
     private func captureSingleFrameAndDeliver(loopSerial: Int) async {
         guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
         do {
-            let image = try await captureImageSerially(expectedLoopSerial: loopSerial)
+            let image = try await captureImageSerially(
+                expectedLoopSerial: loopSerial,
+                kind: .periodic
+            )
             guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
             consecutiveCaptureFailures = 0
             let timestamp = Date()
             delegate?.captureManager(self, didCaptureFrame: image, at: timestamp)
+        } catch let error as CaptureRequestBrokerError {
+            handleCaptureRequestDeferral(error, loopSerial: loopSerial)
         } catch is CancellationError {
             // Expected when stopping capture.
         } catch {
@@ -332,12 +328,45 @@ class ScreenCaptureManager: NSObject {
         }
     }
 
+    private func handleCaptureRequestDeferral(
+        _ error: CaptureRequestBrokerError,
+        loopSerial: Int
+    ) {
+        guard isCapturing, loopSerial == captureLoopSerial else { return }
+        guard case .cooldown(let deadline) = error else {
+            // A periodic tick was already superseded by a newer one. Do not
+            // queue catch-up work or count this as a capture failure.
+            return
+        }
+
+        captureScheduleRevision += 1
+        nextCaptureAt = deadline
+    }
+
     private func handleCaptureFailure(_ error: Error, loopSerial: Int) {
         guard isCapturing, loopSerial == captureLoopSerial else { return }
 
+        let detail = DiagnosticsLogFormat.describe(error)
+        let recovery = CaptureFailureRecovery.disposition(
+            for: error,
+            hasScreenRecordingPermission: Self.hasScreenRecordingPermission()
+        )
+        if case .backOff(let delay) = recovery {
+            consecutiveCaptureFailures = 0
+            captureScheduleRevision += 1
+            nextCaptureAt = Date().addingTimeInterval(delay)
+            captureLogger.warning(
+                "ScreenCaptureKit reported a false permission denial; backing off for \(delay, privacy: .public) seconds"
+            )
+            DiagnosticsLog.shared.log(
+                "Capture",
+                "ScreenCaptureKit reported a permission denial while preflight remained granted; backing off for \(delay) seconds: \(detail)"
+            )
+            return
+        }
+
         consecutiveCaptureFailures += 1
         let failureCount = consecutiveCaptureFailures
-        let detail = DiagnosticsLogFormat.describe(error)
         captureLogger.error("Screenshot capture failed (\(failureCount, privacy: .public)/\(self.maximumConsecutiveCaptureFailures, privacy: .public)): \(detail, privacy: .public)")
         DiagnosticsLog.shared.log(
             "Capture",

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -79,6 +79,7 @@ class ScreenCaptureManager: NSObject {
     /// Bumped whenever the desired cadence changes so the live loop can adopt a new deadline without restarting.
     private var captureScheduleRevision = 0
     private var nextCaptureAt: Date?
+    private var captureCooldownDeadline: TimeInterval?
     private var captureWakeTask: Task<Void, Never>?
     private var captureWakeContinuation: CheckedContinuation<Void, Never>?
     private var consecutiveCaptureFailures = 0
@@ -142,8 +143,15 @@ class ScreenCaptureManager: NSObject {
     }
 
     func stopCapture() async {
-        let previousLoop = stopCaptureLoop()
+        let previousLoop = beginStoppingCapture()
         await previousLoop?.value
+    }
+
+    /// Cancels this manager and its broker-owned waiters synchronously. The
+    /// coordinator uses this for two-phase shutdown so no queued display can
+    /// start another OS request while an earlier display is being awaited.
+    func beginStoppingCapture() -> Task<Void, Never>? {
+        stopCaptureLoop()
     }
 
     private func stopCaptureLoop() -> Task<Void, Never>? {
@@ -154,6 +162,7 @@ class ScreenCaptureManager: NSObject {
         isCapturing = false
         consecutiveCaptureFailures = 0
         nextCaptureAt = nil
+        captureCooldownDeadline = nil
         captureLoopTask = nil
         previousLoop?.cancel()
         captureRequestBroker.cancelRequests(for: captureRequestOwner)
@@ -206,6 +215,16 @@ class ScreenCaptureManager: NSObject {
 
     private func runPeriodicCaptureLoop(loopSerial: Int) async {
         while !Task.isCancelled, isCapturing {
+            if let captureCooldownDeadline {
+                let remaining = captureCooldownDeadline - Self.monotonicTime()
+                if remaining > 0 {
+                    await waitForCaptureWake(for: remaining)
+                    continue
+                }
+                self.captureCooldownDeadline = nil
+                nextCaptureAt = Date()
+            }
+
             let now = Date()
             let deadline = nextCaptureAt ?? now
             if deadline > now {
@@ -232,6 +251,12 @@ class ScreenCaptureManager: NSObject {
 
     private func waitForCaptureWake(until deadline: Date) async {
         let delay = deadline.timeIntervalSinceNow
+        guard delay > 0 else { return }
+
+        await waitForCaptureWake(for: delay)
+    }
+
+    private func waitForCaptureWake(for delay: TimeInterval) async {
         guard delay > 0 else { return }
 
         await withCheckedContinuation { continuation in
@@ -329,10 +354,11 @@ class ScreenCaptureManager: NSObject {
         loopSerial: Int
     ) {
         guard isCapturing, loopSerial == captureLoopSerial else { return }
-        guard case .cooldown(let deadline) = error else { return }
+        guard case .cooldown(let monotonicDeadline) = error else { return }
 
         captureScheduleRevision += 1
-        nextCaptureAt = deadline
+        captureCooldownDeadline = monotonicDeadline
+        nextCaptureAt = nil
     }
 
     private func handleCaptureFailure(_ error: Error, loopSerial: Int) {
@@ -395,6 +421,10 @@ class ScreenCaptureManager: NSObject {
             return max(1, screen.backingScaleFactor)
         }
         return 1
+    }
+
+    private static func monotonicTime() -> TimeInterval {
+        TimeInterval(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
     }
 }
 

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -372,7 +372,8 @@ class ScreenCaptureManager: NSObject {
         if case .backOff(let delay) = recovery {
             consecutiveCaptureFailures = 0
             captureScheduleRevision += 1
-            nextCaptureAt = Date().addingTimeInterval(delay)
+            captureCooldownDeadline = Self.monotonicTime() + delay
+            nextCaptureAt = nil
             captureLogger.warning(
                 "ScreenCaptureKit reported a false permission denial; backing off for \(delay, privacy: .public) seconds"
             )

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -187,8 +187,7 @@ class ScreenCaptureManager: NSObject {
         let requestLoopSerial = captureLoopSerial
         guard isCapturing else { return nil }
         return try? await captureImageSerially(
-            expectedLoopSerial: requestLoopSerial,
-            kind: .interactive
+            expectedLoopSerial: requestLoopSerial
         )
     }
 
@@ -266,12 +265,10 @@ class ScreenCaptureManager: NSObject {
     }
 
     private func captureImageSerially(
-        expectedLoopSerial: Int? = nil,
-        kind: CaptureRequestKind
+        expectedLoopSerial: Int? = nil
     ) async throws -> CGImage {
         let image = try await captureRequestBroker.perform(
-            owner: captureRequestOwner,
-            kind: kind
+            owner: captureRequestOwner
         ) { [weak self] in
             guard let self else { throw CancellationError() }
             try Task.checkCancellation()
@@ -312,8 +309,7 @@ class ScreenCaptureManager: NSObject {
         guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
         do {
             let image = try await captureImageSerially(
-                expectedLoopSerial: loopSerial,
-                kind: .periodic
+                expectedLoopSerial: loopSerial
             )
             guard isCapturing, !Task.isCancelled, loopSerial == captureLoopSerial else { return }
             consecutiveCaptureFailures = 0
@@ -333,11 +329,7 @@ class ScreenCaptureManager: NSObject {
         loopSerial: Int
     ) {
         guard isCapturing, loopSerial == captureLoopSerial else { return }
-        guard case .cooldown(let deadline) = error else {
-            // A periodic tick was already superseded by a newer one. Do not
-            // queue catch-up work or count this as a capture failure.
-            return
-        }
+        guard case .cooldown(let deadline) = error else { return }
 
         captureScheduleRevision += 1
         nextCaptureAt = deadline

--- a/JustNowTests/CaptureFailureRecoveryTests.swift
+++ b/JustNowTests/CaptureFailureRecoveryTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import JustNow
+
+final class CaptureFailureRecoveryTests: XCTestCase {
+    func testBacksOffWhenScreenCaptureKitFalselyReportsPermissionDenial() {
+        let error = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801
+        )
+
+        XCTAssertEqual(
+            CaptureFailureRecovery.disposition(
+                for: error,
+                hasScreenRecordingPermission: true
+            ),
+            .backOff(CaptureFailureRecovery.falsePermissionDenialDelay)
+        )
+    }
+
+    func testCountsRealPermissionDenialTowardsStop() {
+        let error = NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801
+        )
+
+        XCTAssertEqual(
+            CaptureFailureRecovery.disposition(
+                for: error,
+                hasScreenRecordingPermission: false
+            ),
+            .countTowardsStop
+        )
+    }
+
+    func testCountsOtherScreenCaptureKitErrorsTowardsStop() {
+        let error = NSError(
+            domain: "com.apple.ScreenCaptureKit.CoreGraphicsErrorDomain",
+            code: 1004
+        )
+
+        XCTAssertEqual(
+            CaptureFailureRecovery.disposition(
+                for: error,
+                hasScreenRecordingPermission: true
+            ),
+            .countTowardsStop
+        )
+    }
+}

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -391,10 +391,13 @@ final class CaptureRequestBrokerTests: XCTestCase {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)
         var calls = 0
+        let expectedDeadline = clock.monotonicTime
+            + CaptureFailureRecovery.falsePermissionDenialDelay
 
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay / 2)
 
         let error = await captureError(from: broker, owner: UUID()) {
             calls += 1
@@ -403,10 +406,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         XCTAssertEqual(calls, 0)
         XCTAssertEqual(
             error as? CaptureRequestBrokerError,
-            .cooldown(
-                untilMonotonicTime: clock.monotonicTime
-                    + CaptureFailureRecovery.falsePermissionDenialDelay
-            )
+            .cooldown(untilMonotonicTime: expectedDeadline)
         )
     }
 

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -15,7 +15,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         var maximumActiveRequests = 0
 
         let first = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: firstOwner, kind: .interactive) {
+            try await broker.perform(owner: firstOwner) {
                 started.append("first")
                 activeRequests += 1
                 maximumActiveRequests = max(maximumActiveRequests, activeRequests)
@@ -27,7 +27,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         await waitUntil { gate.waiterCount == 1 }
 
         let second = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: secondOwner, kind: .interactive) {
+            try await broker.perform(owner: secondOwner) {
                 started.append("second")
                 activeRequests += 1
                 maximumActiveRequests = max(maximumActiveRequests, activeRequests)
@@ -57,7 +57,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
 
         let first = Task { @MainActor () -> Error? in
             do {
-                try await broker.perform(owner: UUID(), kind: .interactive) {
+                try await broker.perform(owner: UUID()) {
                     await gate.wait()
                     throw self.falsePermissionDenial()
                 }
@@ -70,7 +70,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
 
         let second = Task { @MainActor () -> Error? in
             do {
-                try await broker.perform(owner: UUID(), kind: .interactive) {
+                try await broker.perform(owner: UUID()) {
                     secondOSCalls += 1
                 }
                 return nil
@@ -122,10 +122,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
-        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
 
         let probe = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: UUID(), kind: .interactive) {
+            try await broker.perform(owner: UUID()) {
                 started.append("probe")
                 await probeGate.wait()
                 return "probe"
@@ -134,7 +134,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         await waitUntil { probeGate.waiterCount == 1 }
 
         let queued = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: UUID(), kind: .interactive) {
+            try await broker.perform(owner: UUID()) {
                 started.append("queued")
                 return "queued"
             }
@@ -160,7 +160,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
-        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
 
         let probeError = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
@@ -186,7 +186,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
-        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
 
         let probe = Task { @MainActor () -> Error? in
             await self.captureError(from: broker, owner: UUID()) {
@@ -220,7 +220,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         var started: [String] = []
 
         let first = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: firstOwner, kind: .interactive) {
+            try await broker.perform(owner: firstOwner) {
                 started.append("first")
                 await gate.wait()
                 return "first"
@@ -234,7 +234,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
             }
         }
         let surviving = Task { @MainActor () throws -> String in
-            try await broker.perform(owner: survivingOwner, kind: .interactive) {
+            try await broker.perform(owner: survivingOwner) {
                 started.append("surviving")
                 return "surviving"
             }
@@ -285,7 +285,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         }
         XCTAssertEqual((firstError as NSError?)?.code, 1004)
 
-        try await broker.perform(owner: UUID(), kind: .interactive) {
+        try await broker.perform(owner: UUID()) {
             calls += 1
         }
         XCTAssertEqual(calls, 1)
@@ -301,77 +301,133 @@ final class CaptureRequestBrokerTests: XCTestCase {
         }
         XCTAssertEqual((denialError as NSError?)?.code, -3801)
 
-        try await broker.perform(owner: UUID(), kind: .interactive) {
+        try await broker.perform(owner: UUID()) {
             nextRequestCalls += 1
         }
         XCTAssertEqual(nextRequestCalls, 1)
     }
 
-    func testPeriodicRequestIsDroppedRatherThanQueuedBehindActiveRequest() async throws {
+    func testPeriodicRequestWaitsBehindActiveRequest() async throws {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)
         let gate = BrokerTestGate()
         var periodicCalls = 0
 
         let active = Task { @MainActor () throws -> Void in
-            try await broker.perform(owner: UUID(), kind: .interactive) {
+            try await broker.perform(owner: UUID()) {
                 await gate.wait()
             }
         }
         await waitUntil { gate.waiterCount == 1 }
 
-        let error = await captureError(from: broker, owner: UUID(), kind: .periodic) {
-            periodicCalls += 1
+        let periodic = Task { @MainActor () throws -> Void in
+            try await broker.perform(owner: UUID()) {
+                periodicCalls += 1
+            }
         }
-        XCTAssertEqual(error as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+        await settleTasks()
         XCTAssertEqual(periodicCalls, 0)
 
         gate.resumeNext()
         try await active.value
+        try await periodic.value
+        XCTAssertEqual(periodicCalls, 1)
     }
 
-    func testPeriodicOwnerThatLosesAlignedTickGetsNextFreshTurn() async throws {
+    func testThreeAlignedPeriodicOwnersRunInFIFOOrder() async throws {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)
         let gate = BrokerTestGate()
         let firstOwner = UUID()
-        let losingOwner = UUID()
+        let secondOwner = UUID()
+        let thirdOwner = UUID()
         var calls: [String] = []
 
         let first = Task { @MainActor () throws -> Void in
-            try await broker.perform(owner: firstOwner, kind: .periodic) {
+            try await broker.perform(owner: firstOwner) {
                 calls.append("first")
                 await gate.wait()
             }
         }
         await waitUntil { gate.waiterCount == 1 }
 
-        let losingTick = await captureError(
-            from: broker,
-            owner: losingOwner,
-            kind: .periodic
-        ) {
-            calls.append("losing-stale")
+        let second = Task { @MainActor () throws -> Void in
+            try await broker.perform(owner: secondOwner) {
+                calls.append("second")
+            }
         }
-        XCTAssertEqual(losingTick as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+        await settleTasks()
+        let third = Task { @MainActor () throws -> Void in
+            try await broker.perform(owner: thirdOwner) {
+                calls.append("third")
+            }
+        }
+        await settleTasks()
         XCTAssertEqual(calls, ["first"])
 
         gate.resumeNext()
         try await first.value
+        try await second.value
+        try await third.value
+        XCTAssertEqual(calls, ["first", "second", "third"])
+    }
 
-        let winnerNextTick = await captureError(
-            from: broker,
-            owner: firstOwner,
-            kind: .periodic
-        ) {
-            calls.append("first-again")
-        }
-        XCTAssertEqual(winnerNextTick as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+    func testWallClockJumpDoesNotExpireCooldown() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var calls = 0
 
-        try await broker.perform(owner: losingOwner, kind: .periodic) {
-            calls.append("losing-fresh")
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
         }
-        XCTAssertEqual(calls, ["first", "losing-fresh"])
+        clock.date = clock.date.addingTimeInterval(3_600)
+
+        let error = await captureError(from: broker, owner: UUID()) {
+            calls += 1
+        }
+
+        XCTAssertEqual(calls, 0)
+        XCTAssertNotNil(error as? CaptureRequestBrokerError)
+    }
+
+    func testRecoveryStateReportsCooldownAndRecovery() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var states: [CaptureRequestBrokerRecoveryState] = []
+        broker.recoveryStateDidChange = { states.append($0) }
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        XCTAssertEqual(
+            states,
+            [.coolingDown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))]
+        )
+
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+        try await broker.perform(owner: UUID()) {}
+        XCTAssertEqual(states.last, .normal)
+    }
+
+    func testOpenCircuitRepublishesRecoveryStateAfterCaptureRestart() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var states: [CaptureRequestBrokerRecoveryState] = []
+        broker.recoveryStateDidChange = { states.append($0) }
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        states.removeAll()
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            XCTFail("An open circuit must not call the OS request")
+        }
+
+        XCTAssertEqual(
+            states,
+            [.coolingDown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))]
+        )
     }
 
     private func makeBroker(
@@ -380,7 +436,8 @@ final class CaptureRequestBrokerTests: XCTestCase {
         log: @escaping @MainActor (String) -> Void = { _ in }
     ) -> CaptureRequestBroker {
         CaptureRequestBroker(
-            now: { clock.date },
+            wallNow: { clock.date },
+            monotonicNow: { clock.monotonicTime },
             hasScreenRecordingPermission: { hasScreenRecordingPermission },
             log: log
         )
@@ -389,11 +446,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
     private func captureError(
         from broker: CaptureRequestBroker,
         owner: UUID,
-        kind: CaptureRequestKind = .interactive,
         operation: @escaping @MainActor () async throws -> Void
     ) async -> Error? {
         do {
-            try await broker.perform(owner: owner, kind: kind, operation: operation)
+            try await broker.perform(owner: owner, operation: operation)
             return nil
         } catch {
             return error
@@ -435,6 +491,12 @@ final class CaptureRequestBrokerTests: XCTestCase {
 @MainActor
 private final class BrokerTestClock {
     var date = Date(timeIntervalSinceReferenceDate: 1_000)
+    var monotonicTime: TimeInterval = 1_000
+
+    func advance(by interval: TimeInterval) {
+        date = date.addingTimeInterval(interval)
+        monotonicTime += interval
+    }
 }
 
 @MainActor

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -35,7 +35,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 return "second"
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 1 }
 
         XCTAssertEqual(started, ["first"])
         XCTAssertEqual(maximumActiveRequests, 1)
@@ -78,7 +78,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 return error
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 1 }
 
         gate.resumeNext()
         let firstError = await first.value
@@ -88,7 +88,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         XCTAssertEqual(secondOSCalls, 0)
         XCTAssertEqual(
             secondError as? CaptureRequestBrokerError,
-            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
         )
     }
 
@@ -108,7 +111,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         XCTAssertEqual(calls, 0)
         XCTAssertEqual(
             error as? CaptureRequestBrokerError,
-            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
         )
     }
 
@@ -139,7 +145,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 return "queued"
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 1 }
         XCTAssertEqual(started, ["probe"])
 
         probeGate.resumeNext()
@@ -172,7 +178,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         }
         XCTAssertEqual(
             blockedError as? CaptureRequestBrokerError,
-            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
         )
         XCTAssertEqual(logs.filter { $0.contains("circuit opened") }.count, 1)
         XCTAssertEqual(logs.filter { $0.contains("circuit reopened") }.count, 1)
@@ -206,7 +215,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         }
         XCTAssertEqual(
             otherOwnerError as? CaptureRequestBrokerError,
-            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
         )
     }
 
@@ -239,7 +251,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 return "surviving"
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 2 }
 
         broker.cancelRequests(for: cancelledOwner)
         let cancelledError = await cancelled.value
@@ -268,7 +280,10 @@ final class CaptureRequestBrokerTests: XCTestCase {
         }
         XCTAssertEqual(
             otherOwnerError as? CaptureRequestBrokerError,
-            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
         )
     }
 
@@ -325,7 +340,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 periodicCalls += 1
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 1 }
         XCTAssertEqual(periodicCalls, 0)
 
         gate.resumeNext()
@@ -356,13 +371,13 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 calls.append("second")
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 1 }
         let third = Task { @MainActor () throws -> Void in
             try await broker.perform(owner: thirdOwner) {
                 calls.append("third")
             }
         }
-        await settleTasks()
+        await waitUntil { broker.queuedRequestCountForTesting == 2 }
         XCTAssertEqual(calls, ["first"])
 
         gate.resumeNext()
@@ -372,7 +387,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         XCTAssertEqual(calls, ["first", "second", "third"])
     }
 
-    func testWallClockJumpDoesNotExpireCooldown() async {
+    func testCooldownDeadlineUsesMonotonicTime() async {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)
         var calls = 0
@@ -380,14 +395,19 @@ final class CaptureRequestBrokerTests: XCTestCase {
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
-        clock.date = clock.date.addingTimeInterval(3_600)
 
         let error = await captureError(from: broker, owner: UUID()) {
             calls += 1
         }
 
         XCTAssertEqual(calls, 0)
-        XCTAssertNotNil(error as? CaptureRequestBrokerError)
+        XCTAssertEqual(
+            error as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
+        )
     }
 
     func testRecoveryStateReportsCooldownAndRecovery() async throws {
@@ -399,10 +419,7 @@ final class CaptureRequestBrokerTests: XCTestCase {
         _ = await captureError(from: broker, owner: UUID()) {
             throw self.falsePermissionDenial()
         }
-        XCTAssertEqual(
-            states,
-            [.coolingDown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))]
-        )
+        XCTAssertEqual(states, [.coolingDown])
 
         clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
         try await broker.perform(owner: UUID()) {}
@@ -424,10 +441,75 @@ final class CaptureRequestBrokerTests: XCTestCase {
             XCTFail("An open circuit must not call the OS request")
         }
 
-        XCTAssertEqual(
-            states,
-            [.coolingDown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))]
-        )
+        XCTAssertEqual(states, [.coolingDown])
+    }
+
+    func testFailedHalfOpenProbeDoesNotReportHealthyUntilSuccess() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var states: [CaptureRequestBrokerRecoveryState] = []
+        broker.recoveryStateDidChange = { states.append($0) }
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw NSError(
+                domain: "com.apple.ScreenCaptureKit.CoreGraphicsErrorDomain",
+                code: 1004
+            )
+        }
+        XCTAssertEqual(states, [.coolingDown])
+
+        try await broker.perform(owner: UUID()) {}
+        XCTAssertEqual(states.last, .normal)
+    }
+
+    func testCancellingAllQueuedOwnersBeforeActiveCompletionPreventsHandoff() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let activeOwner = UUID()
+        let secondOwner = UUID()
+        let thirdOwner = UUID()
+        let gate = BrokerTestGate()
+        var started: [String] = []
+
+        let active = Task { @MainActor () -> Error? in
+            await captureError(from: broker, owner: activeOwner) {
+                started.append("active")
+                await gate.wait()
+                try Task.checkCancellation()
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let second = Task { @MainActor () -> Error? in
+            await captureError(from: broker, owner: secondOwner) {
+                started.append("second")
+            }
+        }
+        let third = Task { @MainActor () -> Error? in
+            await captureError(from: broker, owner: thirdOwner) {
+                started.append("third")
+            }
+        }
+        await waitUntil { broker.queuedRequestCountForTesting == 2 }
+
+        active.cancel()
+        broker.cancelRequests(for: activeOwner)
+        broker.cancelRequests(for: secondOwner)
+        broker.cancelRequests(for: thirdOwner)
+        gate.resumeNext()
+
+        let activeError = await active.value
+        let secondError = await second.value
+        let thirdError = await third.value
+        XCTAssertTrue(activeError is CancellationError)
+        XCTAssertTrue(secondError is CancellationError)
+        XCTAssertTrue(thirdError is CancellationError)
+        XCTAssertEqual(started, ["active"])
     }
 
     private func makeBroker(
@@ -436,7 +518,6 @@ final class CaptureRequestBrokerTests: XCTestCase {
         log: @escaping @MainActor (String) -> Void = { _ in }
     ) -> CaptureRequestBroker {
         CaptureRequestBroker(
-            wallNow: { clock.date },
             monotonicNow: { clock.monotonicTime },
             hasScreenRecordingPermission: { hasScreenRecordingPermission },
             log: log
@@ -490,11 +571,9 @@ final class CaptureRequestBrokerTests: XCTestCase {
 
 @MainActor
 private final class BrokerTestClock {
-    var date = Date(timeIntervalSinceReferenceDate: 1_000)
     var monotonicTime: TimeInterval = 1_000
 
     func advance(by interval: TimeInterval) {
-        date = date.addingTimeInterval(interval)
         monotonicTime += interval
     }
 }

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -1,0 +1,456 @@
+import Foundation
+import XCTest
+@testable import JustNow
+
+@MainActor
+final class CaptureRequestBrokerTests: XCTestCase {
+    func testSerialisesInteractiveRequestsAcrossOwners() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let firstOwner = UUID()
+        let secondOwner = UUID()
+        let gate = BrokerTestGate()
+        var started: [String] = []
+        var activeRequests = 0
+        var maximumActiveRequests = 0
+
+        let first = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: firstOwner, kind: .interactive) {
+                started.append("first")
+                activeRequests += 1
+                maximumActiveRequests = max(maximumActiveRequests, activeRequests)
+                await gate.wait()
+                activeRequests -= 1
+                return "first"
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let second = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: secondOwner, kind: .interactive) {
+                started.append("second")
+                activeRequests += 1
+                maximumActiveRequests = max(maximumActiveRequests, activeRequests)
+                activeRequests -= 1
+                return "second"
+            }
+        }
+        await settleTasks()
+
+        XCTAssertEqual(started, ["first"])
+        XCTAssertEqual(maximumActiveRequests, 1)
+
+        gate.resumeNext()
+        let firstValue = try await first.value
+        let secondValue = try await second.value
+        XCTAssertEqual(firstValue, "first")
+        XCTAssertEqual(secondValue, "second")
+        XCTAssertEqual(started, ["first", "second"])
+        XCTAssertEqual(maximumActiveRequests, 1)
+    }
+
+    func testFalseDenialOpensCircuitBeforeQueuedOwnerCanReachOS() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let gate = BrokerTestGate()
+        var secondOSCalls = 0
+
+        let first = Task { @MainActor () -> Error? in
+            do {
+                try await broker.perform(owner: UUID(), kind: .interactive) {
+                    await gate.wait()
+                    throw self.falsePermissionDenial()
+                }
+                return nil
+            } catch {
+                return error
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let second = Task { @MainActor () -> Error? in
+            do {
+                try await broker.perform(owner: UUID(), kind: .interactive) {
+                    secondOSCalls += 1
+                }
+                return nil
+            } catch {
+                return error
+            }
+        }
+        await settleTasks()
+
+        gate.resumeNext()
+        let firstError = await first.value
+        let secondError = await second.value
+
+        XCTAssertEqual((firstError as NSError?)?.code, -3801)
+        XCTAssertEqual(secondOSCalls, 0)
+        XCTAssertEqual(
+            secondError as? CaptureRequestBrokerError,
+            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+        )
+    }
+
+    func testCooldownFailsFastWithoutCallingOSRequest() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var calls = 0
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        let error = await captureError(from: broker, owner: UUID()) {
+            calls += 1
+        }
+
+        XCTAssertEqual(calls, 0)
+        XCTAssertEqual(
+            error as? CaptureRequestBrokerError,
+            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+        )
+    }
+
+    func testOnlyOneHalfOpenProbeRunsAndSuccessClosesCircuit() async throws {
+        let clock = BrokerTestClock()
+        var logs: [String] = []
+        let broker = makeBroker(clock: clock, log: { logs.append($0) })
+        let probeGate = BrokerTestGate()
+        var started: [String] = []
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+
+        let probe = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: UUID(), kind: .interactive) {
+                started.append("probe")
+                await probeGate.wait()
+                return "probe"
+            }
+        }
+        await waitUntil { probeGate.waiterCount == 1 }
+
+        let queued = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: UUID(), kind: .interactive) {
+                started.append("queued")
+                return "queued"
+            }
+        }
+        await settleTasks()
+        XCTAssertEqual(started, ["probe"])
+
+        probeGate.resumeNext()
+        let probeValue = try await probe.value
+        let queuedValue = try await queued.value
+        XCTAssertEqual(probeValue, "probe")
+        XCTAssertEqual(queuedValue, "queued")
+        XCTAssertEqual(started, ["probe", "queued"])
+        XCTAssertEqual(logs.filter { $0.contains("circuit opened") }.count, 1)
+        XCTAssertEqual(logs.filter { $0.contains("circuit recovered") }.count, 1)
+    }
+
+    func testFalseDenialFromHalfOpenProbeReopensCircuit() async {
+        let clock = BrokerTestClock()
+        var logs: [String] = []
+        let broker = makeBroker(clock: clock, log: { logs.append($0) })
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+
+        let probeError = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        XCTAssertEqual((probeError as NSError?)?.code, -3801)
+
+        let blockedError = await captureError(from: broker, owner: UUID()) {
+            XCTFail("A reopened circuit must not call the OS request")
+        }
+        XCTAssertEqual(
+            blockedError as? CaptureRequestBrokerError,
+            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+        )
+        XCTAssertEqual(logs.filter { $0.contains("circuit opened") }.count, 1)
+        XCTAssertEqual(logs.filter { $0.contains("circuit reopened") }.count, 1)
+    }
+
+    func testCancelledHalfOpenProbeKeepsSharedCircuitOpen() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let gate = BrokerTestGate()
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.date = clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay)
+
+        let probe = Task { @MainActor () -> Error? in
+            await self.captureError(from: broker, owner: UUID()) {
+                await gate.wait()
+                try Task.checkCancellation()
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        probe.cancel()
+        gate.resumeNext()
+        let probeError = await probe.value
+        XCTAssertTrue(probeError is CancellationError)
+
+        let otherOwnerError = await captureError(from: broker, owner: UUID()) {
+            XCTFail("A cancelled probe must not clear the shared circuit")
+        }
+        XCTAssertEqual(
+            otherOwnerError as? CaptureRequestBrokerError,
+            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+        )
+    }
+
+    func testCancellingOneOwnerLeavesOtherQueuedOwnerIntact() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let firstOwner = UUID()
+        let cancelledOwner = UUID()
+        let survivingOwner = UUID()
+        let gate = BrokerTestGate()
+        var started: [String] = []
+
+        let first = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: firstOwner, kind: .interactive) {
+                started.append("first")
+                await gate.wait()
+                return "first"
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let cancelled = Task { @MainActor () -> Error? in
+            await captureError(from: broker, owner: cancelledOwner) {
+                started.append("cancelled")
+            }
+        }
+        let surviving = Task { @MainActor () throws -> String in
+            try await broker.perform(owner: survivingOwner, kind: .interactive) {
+                started.append("surviving")
+                return "surviving"
+            }
+        }
+        await settleTasks()
+
+        broker.cancelRequests(for: cancelledOwner)
+        let cancelledError = await cancelled.value
+        XCTAssertTrue(cancelledError is CancellationError)
+
+        gate.resumeNext()
+        let firstValue = try await first.value
+        let survivingValue = try await surviving.value
+        XCTAssertEqual(firstValue, "first")
+        XCTAssertEqual(survivingValue, "surviving")
+        XCTAssertEqual(started, ["first", "surviving"])
+    }
+
+    func testCancellingAnOwnerDoesNotResetSharedCooldown() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let stoppedOwner = UUID()
+
+        _ = await captureError(from: broker, owner: stoppedOwner) {
+            throw self.falsePermissionDenial()
+        }
+        broker.cancelRequests(for: stoppedOwner)
+
+        let otherOwnerError = await captureError(from: broker, owner: UUID()) {
+            XCTFail("A stopped owner must not clear the shared circuit")
+        }
+        XCTAssertEqual(
+            otherOwnerError as? CaptureRequestBrokerError,
+            .cooldown(until: clock.date.addingTimeInterval(CaptureFailureRecovery.falsePermissionDenialDelay))
+        )
+    }
+
+    func testNonMismatchErrorDoesNotOpenCircuitOrBlockNextRequest() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var calls = 0
+
+        let firstError = await captureError(from: broker, owner: UUID()) {
+            throw NSError(
+                domain: "com.apple.ScreenCaptureKit.CoreGraphicsErrorDomain",
+                code: 1004
+            )
+        }
+        XCTAssertEqual((firstError as NSError?)?.code, 1004)
+
+        try await broker.perform(owner: UUID(), kind: .interactive) {
+            calls += 1
+        }
+        XCTAssertEqual(calls, 1)
+    }
+
+    func testRealPermissionDenialDoesNotOpenBrokerCircuit() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock, hasScreenRecordingPermission: false)
+        var nextRequestCalls = 0
+
+        let denialError = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        XCTAssertEqual((denialError as NSError?)?.code, -3801)
+
+        try await broker.perform(owner: UUID(), kind: .interactive) {
+            nextRequestCalls += 1
+        }
+        XCTAssertEqual(nextRequestCalls, 1)
+    }
+
+    func testPeriodicRequestIsDroppedRatherThanQueuedBehindActiveRequest() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let gate = BrokerTestGate()
+        var periodicCalls = 0
+
+        let active = Task { @MainActor () throws -> Void in
+            try await broker.perform(owner: UUID(), kind: .interactive) {
+                await gate.wait()
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let error = await captureError(from: broker, owner: UUID(), kind: .periodic) {
+            periodicCalls += 1
+        }
+        XCTAssertEqual(error as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+        XCTAssertEqual(periodicCalls, 0)
+
+        gate.resumeNext()
+        try await active.value
+    }
+
+    func testPeriodicOwnerThatLosesAlignedTickGetsNextFreshTurn() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let gate = BrokerTestGate()
+        let firstOwner = UUID()
+        let losingOwner = UUID()
+        var calls: [String] = []
+
+        let first = Task { @MainActor () throws -> Void in
+            try await broker.perform(owner: firstOwner, kind: .periodic) {
+                calls.append("first")
+                await gate.wait()
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        let losingTick = await captureError(
+            from: broker,
+            owner: losingOwner,
+            kind: .periodic
+        ) {
+            calls.append("losing-stale")
+        }
+        XCTAssertEqual(losingTick as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+        XCTAssertEqual(calls, ["first"])
+
+        gate.resumeNext()
+        try await first.value
+
+        let winnerNextTick = await captureError(
+            from: broker,
+            owner: firstOwner,
+            kind: .periodic
+        ) {
+            calls.append("first-again")
+        }
+        XCTAssertEqual(winnerNextTick as? CaptureRequestBrokerError, .droppedPeriodicRequest)
+
+        try await broker.perform(owner: losingOwner, kind: .periodic) {
+            calls.append("losing-fresh")
+        }
+        XCTAssertEqual(calls, ["first", "losing-fresh"])
+    }
+
+    private func makeBroker(
+        clock: BrokerTestClock,
+        hasScreenRecordingPermission: Bool = true,
+        log: @escaping @MainActor (String) -> Void = { _ in }
+    ) -> CaptureRequestBroker {
+        CaptureRequestBroker(
+            now: { clock.date },
+            hasScreenRecordingPermission: { hasScreenRecordingPermission },
+            log: log
+        )
+    }
+
+    private func captureError(
+        from broker: CaptureRequestBroker,
+        owner: UUID,
+        kind: CaptureRequestKind = .interactive,
+        operation: @escaping @MainActor () async throws -> Void
+    ) async -> Error? {
+        do {
+            try await broker.perform(owner: owner, kind: kind, operation: operation)
+            return nil
+        } catch {
+            return error
+        }
+    }
+
+    private func falsePermissionDenial() -> NSError {
+        NSError(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3801
+        )
+    }
+
+    private func settleTasks() async {
+        await Task.yield()
+        await Task.yield()
+        await Task.yield()
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let continuousClock = ContinuousClock()
+        let deadline = continuousClock.now + timeout
+
+        while continuousClock.now < deadline {
+            if condition() { return }
+            await settleTasks()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}
+
+@MainActor
+private final class BrokerTestClock {
+    var date = Date(timeIntervalSinceReferenceDate: 1_000)
+}
+
+@MainActor
+private final class BrokerTestGate {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var waiterCount: Int { continuations.count }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func resumeNext() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+}


### PR DESCRIPTION
## Summary

- serialise one-shot ScreenCaptureKit requests through a process-wide FIFO broker
- open a global monotonic cooldown after the macOS false-denial signature, then recover through a single half-open probe
- expose recovery state in the menu and cancel queued capture owners safely during stop and multi-display hot-unplug
- add deterministic coverage for broker fairness, cancellation, circuit transitions, permission classification, and recovery

## Verification

- xcodebuild test -scheme JustNow -derivedDataPath /tmp/justnow-final-nosign.5G6mfK CODE_SIGNING_ALLOWED=NO — 242 tests passed, 0 failed
- focused capture recovery suite — 20 tests passed, 0 failed
- ./Scripts/local-install-app.sh — Release build succeeded; Developer ID signature verified; installed and launched from /Applications/JustNow.app
- git diff --check origin/main...HEAD — passed

## Adversarial review

Three independent high-reasoning Codex reviewers examined correctness/regressions, tests/edge cases, and scope/operational risk before PR creation. Iterative findings led to fixes for multi-display cadence, monotonic cooldown scheduling, recovery status, deterministic queue tests, full-stop cancellation, and simultaneous hot-unplug. The final review pass reported no blocker, P1, or P2 findings.

## Residual platform risk

ScreenCaptureKit provides no safe force-cancel API for an OS call that never returns. The broker therefore retains its permit until completion rather than risking overlapping capture calls and recreating the prompt storm. This recovery suppresses follow-on requests after a false denial, but macOS may still present the initial erroneous prompt before JustNow receives the error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic recovery handling for temporary screen-capture permission failures.
  * Capture status now indicates when the app is actively capturing or recovering.
  * Screen-capture requests are coordinated to prevent conflicts and unnecessary system calls.
  * Display capture starts and stops more reliably when monitors are connected or removed.

* **Bug Fixes**
  * Reduced capture interruptions caused by temporary permission-denial errors.
  * Improved cancellation and shutdown behavior for active capture operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->