### PR TITLE
fix: harden screen recording recovery

### DIFF
--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -689,6 +689,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     ) {
         switch state {
         case .normal:
+            captureStartController.completeDeferredStart()
             captureRecoveryNeedsAttention = false
             updatePermissionHelpMenuItem()
             if coordinator.isCapturing, captureEventController.blockedStatus() == nil {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -604,6 +604,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         }
 
         do {
+            // Stop and start requests are scheduled by separate lifecycle
+            // tasks. A later resume must wait for any already-queued stop so
+            // the newest user/system intent wins deterministically.
+            await captureStopController.waitForPendingStop()
+            guard !Task.isCancelled, captureEventController.canStartCapture() else {
+                applyBlockedCaptureStatusIfAvailable()
+                return .failed
+            }
             try await captureCoordinator.startCapture()
             guard !Task.isCancelled else { return .failed }
             guard captureEventController.canStartCapture() else {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -578,31 +578,35 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         captureEventController.handleScreenUnlock()
     }
 
-    private func startCaptureIfAllowed(successMessage: String, failurePrefix: String, failureStatus: String) async -> Bool {
-        guard !Task.isCancelled else { return false }
+    private func startCaptureIfAllowed(
+        successMessage: String,
+        failurePrefix: String,
+        failureStatus: String
+    ) async -> CaptureStartResult {
+        guard !Task.isCancelled else { return .failed }
         guard captureEventController.canStartCapture() else {
             // Without this update, the caller's transient "Resuming..."
             // (or similar) status would stick forever when the lifecycle
             // says we shouldn't start.
             applyBlockedCaptureStatusIfAvailable()
-            return false
+            return .failed
         }
 
         do {
             try await captureCoordinator.startCapture()
-            guard !Task.isCancelled else { return false }
+            guard !Task.isCancelled else { return .failed }
             guard captureEventController.canStartCapture() else {
                 await captureCoordinator.stopCapture()
                 applyBlockedCaptureStatusIfAvailable()
-                return false
+                return .failed
             }
             handleSuccessfulCaptureStart(successMessage: successMessage)
-            return true
+            return .started
         } catch is CancellationError {
-            return false
+            return .failed
         } catch CaptureError.permissionDenied {
             presentPermissionAlert(status: "No Permission")
-            return false
+            return .failed
         } catch is CaptureRequestBrokerError {
             // Deferred, not failed: the coordinator reconciles again once the
             // shared circuit's cooldown expires, so don't burn retry budget or
@@ -614,13 +618,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             updateCaptureStatus(
                 captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
             )
-            return false
+            return .deferred
         } catch {
             let detail = DiagnosticsLogFormat.describe(error)
             captureLogger.error("\(failurePrefix, privacy: .public): \(detail, privacy: .public)")
             DiagnosticsLog.shared.log("Capture", "\(failurePrefix): \(detail); \(CaptureSystemState.summary())")
             updateCaptureStatus(failureStatus)
-            return false
+            return .failed
         }
     }
 
@@ -654,7 +658,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 self?.updateCaptureStatus(status)
             },
             startCapture: { [weak self] attempt in
-                guard let self else { return false }
+                guard let self else { return .failed }
                 return await self.startCaptureIfAllowed(
                     successMessage: attempt.successMessage,
                     failurePrefix: attempt.failurePrefix,

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -121,11 +121,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         updateStatus: { [weak self] in self?.updateCaptureStatus($0) },
         stopCapture: { [weak self] in
             await self?.captureCoordinator.stopCapture()
-            // A broker cooldown callback can arrive after lifecycle code
-            // cancels a pending start but before this queued stop flips the
-            // coordinator to stopped. Clear any deferred marker restored in
-            // that window once coordinator recovery is definitively cancelled.
-            self?.captureStartController.cancelPendingStart()
         },
         endForegroundActivity: { [weak self] in
             self?.appNapPreventer.stopActivity()
@@ -153,7 +148,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         },
         scheduleStart: { [weak self] in self?.scheduleCaptureStart($0) },
         cancelPendingStart: { [weak self] in self?.captureStartController.cancelPendingStart() },
-        scheduleStop: { [weak self] in self?.captureStopController.scheduleStop($0) },
+        scheduleStop: { [weak self] request in
+            guard let self else { return }
+            // Capture this synchronously, immediately after the lifecycle
+            // controller cancelled its old start. A newer resume advances the
+            // generation while the queued stop awaits and must survive.
+            let startGeneration = self.captureStartController.generationSnapshot()
+            self.captureStopController.scheduleStop(request) { [weak self] in
+                self?.captureStartController.completeDeferredStartIfNoNewerRequest(
+                    since: startGeneration
+                )
+            }
+        },
         updateStatus: { [weak self] in self?.updateCaptureStatus($0) },
         enableBlackFrameFilter: { [weak self] in self?.frameBuffer?.enableBlackFrameFilter(for: $0) },
         endForegroundActivity: { [weak self] in self?.appNapPreventer.stopActivity() },
@@ -623,6 +629,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             updateCaptureStatus(
                 captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
             )
+            if captureRecoveryNeedsAttention {
+                schedulePersistentCaptureRecoveryAlert()
+            }
             return .deferred
         } catch {
             let detail = DiagnosticsLogFormat.describe(error)
@@ -701,7 +710,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 // probe succeeds, before a display manager necessarily starts.
                 // Keep deferred lifecycle ownership until capture is truly live.
                 captureStartController.completeDeferredStart()
-                updateCaptureStatus("Active")
+                handleSuccessfulCaptureStart()
             }
         case .coolingDown:
             if captureEventController.blockedStatus() == nil {
@@ -714,7 +723,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             if captureEventController.blockedStatus() == nil {
                 captureStartController.beginDeferredStart()
                 updateCaptureStatus("Capture Help Needed")
-                showPersistentCaptureRecoveryAlert()
+                schedulePersistentCaptureRecoveryAlert()
             }
         }
     }
@@ -1018,6 +1027,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             panel: .screenRecording,
             sourceFrameInScreen: sourceFrame.isEmpty ? nil : sourceFrame
         )
+    }
+
+    private func schedulePersistentCaptureRecoveryAlert() {
+        // Broker recovery callbacks run while its request permit is still held.
+        // Defer modal presentation so queued callers are released first.
+        Task { @MainActor [weak self] in
+            self?.showPersistentCaptureRecoveryAlert()
+        }
     }
 
     private func presentPermissionAlert(status: String) {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -113,6 +113,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     private var isTerminationFlushInProgress = false
     private var idleTransitionTimer: Timer?
     private var screenRecordingPermission = ScreenRecordingPermissionState()
+    private var captureRecoveryNeedsAttention = false
+    private var hasPresentedPersistentCaptureRecoveryAlert = false
     private let capturePolicyController = CapturePolicyController()
     private let captureStartController = CaptureStartController()
     private lazy var captureStopController = CaptureStopController(
@@ -387,6 +389,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             return
         } catch CaptureError.permissionDenied {
             presentPermissionAlert(status: "No Permission")
+        } catch is CaptureRequestBrokerError {
+            // The shared ScreenCaptureKit circuit is cooling down after a
+            // false permission denial; the coordinator retries when it ends.
+            DiagnosticsLog.shared.log(
+                "Capture",
+                "Launch capture start deferred while the shared ScreenCaptureKit circuit cools down; \(CaptureSystemState.summary())"
+            )
+            updateCaptureStatus(
+                captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
+            )
         } catch {
             DiagnosticsLog.shared.log(
                 "Capture",
@@ -591,6 +603,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         } catch CaptureError.permissionDenied {
             presentPermissionAlert(status: "No Permission")
             return false
+        } catch is CaptureRequestBrokerError {
+            // Deferred, not failed: the coordinator reconciles again once the
+            // shared circuit's cooldown expires, so don't burn retry budget or
+            // report a hard stop.
+            DiagnosticsLog.shared.log(
+                "Capture",
+                "\(failurePrefix): deferred while the shared ScreenCaptureKit circuit cools down"
+            )
+            updateCaptureStatus(
+                captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
+            )
+            return false
         } catch {
             let detail = DiagnosticsLogFormat.describe(error)
             captureLogger.error("\(failurePrefix, privacy: .public): \(detail, privacy: .public)")
@@ -661,12 +685,21 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     ) {
         switch state {
         case .normal:
+            captureRecoveryNeedsAttention = false
+            updatePermissionHelpMenuItem()
             if coordinator.isCapturing, captureEventController.blockedStatus() == nil {
                 updateCaptureStatus("Active")
             }
         case .coolingDown:
             if captureEventController.blockedStatus() == nil {
                 updateCaptureStatus("Recovering…")
+            }
+        case .needsAttention:
+            captureRecoveryNeedsAttention = true
+            updatePermissionHelpMenuItem()
+            if captureEventController.blockedStatus() == nil {
+                updateCaptureStatus("Capture Help Needed")
+                showPersistentCaptureRecoveryAlert()
             }
         }
     }
@@ -937,8 +970,39 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     }
 
     private func updatePermissionHelpMenuItem() {
-        let needsPermissionHelp = !ScreenCaptureManager.hasScreenRecordingPermission()
+        let needsPermissionHelp = captureRecoveryNeedsAttention
+            || !ScreenCaptureManager.hasScreenRecordingPermission()
         statusItemController?.setPermissionHelpVisible(needsPermissionHelp)
+    }
+
+    private func showPersistentCaptureRecoveryAlert() {
+        guard !hasPresentedPersistentCaptureRecoveryAlert else { return }
+        hasPresentedPersistentCaptureRecoveryAlert = true
+
+        DiagnosticsLog.shared.log(
+            "Permission",
+            "Presenting persistent ScreenCaptureKit recovery guidance after maximum cooldown; \(CaptureSystemState.summary())"
+        )
+
+        let alert = NSAlert()
+        alert.messageText = "JustNow Still Can't Capture"
+        alert.informativeText = """
+        macOS continues to reject screen capture even though Screen Recording appears enabled. JustNow has slowed its retries to avoid repeated permission prompts and will keep trying in the background.
+
+        If capture does not recover, open Screen Recording settings, remove the existing JustNow entry, then relaunch JustNow once so macOS can create a fresh permission record.
+        """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Open System Settings")
+        alert.addButton(withTitle: "Keep Retrying")
+
+        NSApp.activate(ignoringOtherApps: true)
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        let sourceFrame = alert.window.frame
+        PermisoAssistant.shared.present(
+            panel: .screenRecording,
+            sourceFrameInScreen: sourceFrame.isEmpty ? nil : sourceFrame
+        )
     }
 
     private func presentPermissionAlert(status: String) {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -629,10 +629,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 applyBlockedCaptureStatusIfAvailable()
                 return .failed
             }
-            if captureCoordinator.isCapturing {
-                handleSuccessfulCaptureStart(successMessage: successMessage)
-                return .started
-            }
             try await captureCoordinator.startCapture()
             guard !Task.isCancelled else { return .failed }
             guard captureEventController.canStartCapture() else {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -715,7 +715,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         case .coolingDown:
             if captureEventController.blockedStatus() == nil {
                 captureStartController.beginDeferredStart()
-                updateCaptureStatus("Recovering…")
+                updateCaptureStatus(
+                    captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
+                )
             }
         case .needsAttention:
             captureRecoveryNeedsAttention = true
@@ -1033,7 +1035,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         // Broker recovery callbacks run while its request permit is still held.
         // Defer modal presentation so queued callers are released first.
         Task { @MainActor [weak self] in
-            self?.showPersistentCaptureRecoveryAlert()
+            guard let self, self.captureRecoveryNeedsAttention else { return }
+            self.showPersistentCaptureRecoveryAlert()
         }
     }
 

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -689,10 +689,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
     ) {
         switch state {
         case .normal:
-            captureStartController.completeDeferredStart()
             captureRecoveryNeedsAttention = false
             updatePermissionHelpMenuItem()
             if coordinator.isCapturing, captureEventController.blockedStatus() == nil {
+                // The broker publishes .normal when its half-open discovery
+                // probe succeeds, before a display manager necessarily starts.
+                // Keep deferred lifecycle ownership until capture is truly live.
+                captureStartController.completeDeferredStart()
                 updateCaptureStatus("Active")
             }
         case .coolingDown:

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -121,6 +121,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         updateStatus: { [weak self] in self?.updateCaptureStatus($0) },
         stopCapture: { [weak self] in
             await self?.captureCoordinator.stopCapture()
+            // A broker cooldown callback can arrive after lifecycle code
+            // cancels a pending start but before this queued stop flips the
+            // coordinator to stopped. Clear any deferred marker restored in
+            // that window once coordinator recovery is definitively cancelled.
+            self?.captureStartController.cancelPendingStart()
         },
         endForegroundActivity: { [weak self] in
             self?.appNapPreventer.stopActivity()
@@ -699,15 +704,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 updateCaptureStatus("Active")
             }
         case .coolingDown:
-            captureStartController.beginDeferredStart()
             if captureEventController.blockedStatus() == nil {
+                captureStartController.beginDeferredStart()
                 updateCaptureStatus("Recovering…")
             }
         case .needsAttention:
-            captureStartController.beginDeferredStart()
             captureRecoveryNeedsAttention = true
             updatePermissionHelpMenuItem()
             if captureEventController.blockedStatus() == nil {
+                captureStartController.beginDeferredStart()
                 updateCaptureStatus("Capture Help Needed")
                 showPersistentCaptureRecoveryAlert()
             }

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -699,10 +699,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 updateCaptureStatus("Active")
             }
         case .coolingDown:
+            captureStartController.beginDeferredStart()
             if captureEventController.blockedStatus() == nil {
                 updateCaptureStatus("Recovering…")
             }
         case .needsAttention:
+            captureStartController.beginDeferredStart()
             captureRecoveryNeedsAttention = true
             updatePermissionHelpMenuItem()
             if captureEventController.blockedStatus() == nil {

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -612,6 +612,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         }
 
         do {
+            // A resume requested during launch setup is real intent, but it
+            // must not overtake frame-buffer/coordinator configuration or
+            // start a second reconciliation against partially installed state.
+            let startupTask = setupCaptureTask
+            await startupTask?.value
+            guard !Task.isCancelled, captureEventController.canStartCapture() else {
+                applyBlockedCaptureStatusIfAvailable()
+                return .failed
+            }
             // Stop and start requests are scheduled by separate lifecycle
             // tasks. A later resume must wait for any already-queued stop so
             // the newest user/system intent wins deterministically.
@@ -619,6 +628,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             guard !Task.isCancelled, captureEventController.canStartCapture() else {
                 applyBlockedCaptureStatusIfAvailable()
                 return .failed
+            }
+            if captureCoordinator.isCapturing {
+                handleSuccessfulCaptureStart(successMessage: successMessage)
+                return .started
             }
             try await captureCoordinator.startCapture()
             guard !Task.isCancelled else { return .failed }

--- a/JustNow/AppDelegate.swift
+++ b/JustNow/AppDelegate.swift
@@ -400,6 +400,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
             return
         } catch CaptureError.permissionDenied {
             presentPermissionAlert(status: "No Permission")
+        } catch CaptureError.noDisplay {
+            captureStartController.beginDeferredStart()
+            DiagnosticsLog.shared.log(
+                "Capture",
+                "Launch capture found no usable display; deferred recovery remains scheduled"
+            )
+            updateCaptureStatus("Recovering…")
         } catch is CaptureRequestBrokerError {
             // The shared ScreenCaptureKit circuit is cooling down after a
             // false permission denial; the coordinator retries when it ends.
@@ -407,6 +414,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
                 "Capture",
                 "Launch capture start deferred while the shared ScreenCaptureKit circuit cools down; \(CaptureSystemState.summary())"
             )
+            captureStartController.beginDeferredStart()
             updateCaptureStatus(
                 captureRecoveryNeedsAttention ? "Capture Help Needed" : "Recovering…"
             )
@@ -626,6 +634,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, CaptureCoordinatorDelegate {
         } catch CaptureError.permissionDenied {
             presentPermissionAlert(status: "No Permission")
             return .failed
+        } catch CaptureError.noDisplay {
+            DiagnosticsLog.shared.log(
+                "Capture",
+                "\(failurePrefix): no usable display; deferred recovery remains scheduled"
+            )
+            updateCaptureStatus("Recovering…")
+            return .deferred
         } catch is CaptureRequestBrokerError {
             // Deferred, not failed: the coordinator reconciles again once the
             // shared circuit's cooldown expires, so don't burn retry budget or

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -122,6 +122,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     private var isRunning = false
     private var screenParamsObserver: NSObjectProtocol?
     private var reconcileTask: Task<Void, Never>?
+    private var reconcileTaskGeneration = 0
     private let reconciliationGate = CaptureReconciliationGate()
     /// Broker recovery can occur midway through display discovery/startup.
     /// Suppress that intermediate healthy signal until the full reconciliation
@@ -228,6 +229,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
 
     func stopCapture() async {
         isRunning = false
+        reconcileTaskGeneration += 1
         reconcileTask?.cancel()
         reconcileTask = nil
         cancelCooldownRestart()
@@ -272,9 +274,16 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
 
     private func scheduleReconcile() {
         guard isRunning else { return }
+        reconcileTaskGeneration += 1
+        let generation = reconcileTaskGeneration
         reconcileTask?.cancel()
         reconcileTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            defer {
+                if generation == self.reconcileTaskGeneration {
+                    self.reconcileTask = nil
+                }
+            }
             do {
                 try await self.reconcileDisplays(startNewManagers: true)
             } catch {
@@ -285,12 +294,12 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
                     self.delegate?.captureCoordinatorDidStopUnexpectedly(self)
                 }
             }
-            self.reconcileTask = nil
         }
     }
 
     private func reconcileDisplays(startNewManagers: Bool) async throws {
         try await reconciliationGate.withPermit { [self] in
+            guard isRunning, !Task.isCancelled else { throw CancellationError() }
             try await reconcileDisplaysWithPermit(startNewManagers: startNewManagers)
         }
     }

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -17,6 +17,64 @@ enum CaptureCoordinatorStartReadiness: Equatable {
     case noDisplay
 }
 
+/// Owns the cancellable timer used to retry capture after a broker cooldown.
+/// Keeping the timer bookkeeping separate makes replacement and re-entrant
+/// rescheduling deterministic without pulling ScreenCaptureKit into tests.
+@MainActor
+final class CaptureCooldownRestartScheduler {
+    typealias Sleep = @MainActor (Duration) async throws -> Void
+
+    private let sleep: Sleep
+    private var task: Task<Void, Never>?
+    private var generation = 0
+    private(set) var scheduledDeadline: TimeInterval?
+
+    init(sleep: @escaping Sleep = { try await Task.sleep(for: $0) }) {
+        self.sleep = sleep
+    }
+
+    func schedule(
+        deadline: TimeInterval,
+        delay: Duration,
+        retry: @escaping @MainActor () async -> Void
+    ) {
+        guard scheduledDeadline != deadline else { return }
+
+        task?.cancel()
+        scheduledDeadline = deadline
+        generation += 1
+        let taskGeneration = generation
+        task = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await self.sleep(delay)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+
+            // A retry may synchronously schedule its replacement. Clear the
+            // current deadline first so even an identical new deadline can be
+            // registered, and let the generation guard protect that new state.
+            self.scheduledDeadline = nil
+            defer {
+                if self.generation == taskGeneration {
+                    self.task = nil
+                    self.scheduledDeadline = nil
+                }
+            }
+            await retry()
+        }
+    }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+        scheduledDeadline = nil
+        generation += 1
+    }
+}
+
 @MainActor
 protocol CaptureCoordinatorDelegate: AnyObject {
     func captureCoordinator(
@@ -67,16 +125,12 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     /// Retries display reconciliation shortly after the shared circuit's
     /// cooldown expires, so a restart blocked mid-episode is not stranded in
     /// "Stopped" until the next unrelated system event.
-    private var cooldownRestartTask: Task<Void, Never>?
-    private var cooldownRestartDeadline: TimeInterval?
-    /// Identifies the current restart so a finished task only clears state it
-    /// still owns, even when a reopened circuit scheduled a replacement while
-    /// the task was reconciling.
-    private var cooldownRestartGeneration = 0
+    private let cooldownRestartScheduler: CaptureCooldownRestartScheduler
 
     override init() {
         let captureRequestBroker = CaptureRequestBroker()
         self.captureRequestBroker = captureRequestBroker
+        self.cooldownRestartScheduler = CaptureCooldownRestartScheduler()
         super.init()
         captureRequestBroker.recoveryStateDidChange = { [weak self] state in
             // Sleep, lock, overlay and user-pause flows mark the coordinator
@@ -318,34 +372,19 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         guard isRunning else { return }
         guard let deadline = captureRequestBroker.openCircuitMonotonicDeadline,
               let remaining = captureRequestBroker.remainingCooldown() else { return }
-        guard cooldownRestartDeadline != deadline else { return }
+        guard cooldownRestartScheduler.scheduledDeadline != deadline else { return }
 
-        cooldownRestartTask?.cancel()
-        cooldownRestartDeadline = deadline
-        cooldownRestartGeneration += 1
-        let generation = cooldownRestartGeneration
         let delay = remaining + 1
         DiagnosticsLog.shared.log(
             "Capture",
             "Capture start deferred; retrying in \(Int(delay)) seconds when the shared ScreenCaptureKit circuit cooldown ends"
         )
-        cooldownRestartTask = Task { @MainActor [weak self] in
-            try? await Task.sleep(for: .seconds(delay))
+        cooldownRestartScheduler.schedule(
+            deadline: deadline,
+            delay: .seconds(delay)
+        ) { [weak self] in
             guard let self else { return }
-            // Keep the task handle registered until this task finishes so
-            // stopCapture() can still cancel it while the reconcile below is
-            // in flight. Only clear state this generation still owns: the
-            // reconcile may reopen the circuit and schedule a replacement.
-            defer {
-                if self.cooldownRestartGeneration == generation {
-                    self.cooldownRestartTask = nil
-                    self.cooldownRestartDeadline = nil
-                }
-            }
             guard !Task.isCancelled, self.isRunning else { return }
-            // Allow a reopen during this reconcile to schedule the next
-            // restart even if the broker lands on an identical deadline.
-            self.cooldownRestartDeadline = nil
             do {
                 try await self.reconcileDisplays(startNewManagers: true)
                 guard self.isRunning, !Task.isCancelled else { return }
@@ -377,12 +416,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     }
 
     private func cancelCooldownRestart() {
-        cooldownRestartTask?.cancel()
-        cooldownRestartTask = nil
-        cooldownRestartDeadline = nil
-        // Invalidate any restart task that is past its cancellation checks so
-        // its deferred cleanup cannot clear state from a later schedule.
-        cooldownRestartGeneration += 1
+        cooldownRestartScheduler.cancel()
     }
 
     // MARK: - ScreenCaptureDelegate

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -122,6 +122,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     private var isRunning = false
     private var screenParamsObserver: NSObjectProtocol?
     private var reconcileTask: Task<Void, Never>?
+    private let reconciliationGate = CaptureReconciliationGate()
     /// Broker recovery can occur midway through display discovery/startup.
     /// Suppress that intermediate healthy signal until the full reconciliation
     /// confirms capture is live and the circuit stayed closed.
@@ -230,11 +231,13 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         reconcileTask?.cancel()
         reconcileTask = nil
         cancelCooldownRestart()
-        let snapshot = Array(managed.values)
-        managed.removeAll()
-        let previousLoops = snapshot.map { $0.manager.beginStoppingCapture() }
-        for previousLoop in previousLoops {
-            await previousLoop?.value
+        await reconciliationGate.withPermitIgnoringCancellation { [self] in
+            let snapshot = Array(managed.values)
+            managed.removeAll()
+            let previousLoops = snapshot.map { $0.manager.beginStoppingCapture() }
+            for previousLoop in previousLoops {
+                await previousLoop?.value
+            }
         }
         delegate?.captureCoordinatorDidUpdateDisplays(self)
     }
@@ -287,6 +290,12 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     }
 
     private func reconcileDisplays(startNewManagers: Bool) async throws {
+        try await reconciliationGate.withPermit { [self] in
+            try await reconcileDisplaysWithPermit(startNewManagers: startNewManagers)
+        }
+    }
+
+    private func reconcileDisplaysWithPermit(startNewManagers: Bool) async throws {
         activeReconciliationCount += 1
         defer { activeReconciliationCount -= 1 }
 
@@ -319,6 +328,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             throw error
         }
         try Task.checkCancellation()
+        guard isRunning else { throw CancellationError() }
 
         var desired: [UUID: DisplayInfo] = [:]
         for display in content.displays {
@@ -332,6 +342,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         let previousLoops = removedEntries.map { $0.manager.beginStoppingCapture() }
         for (entry, previousLoop) in zip(removedEntries, previousLoops) {
             await previousLoop?.value
+            guard isRunning, !Task.isCancelled else { throw CancellationError() }
             captureLogger.info("Capture stopped for removed display: \(entry.info.name, privacy: .public)")
             DiagnosticsLog.shared.log("Capture", "Capture stopped for removed display: \(entry.info.name)")
         }
@@ -350,10 +361,21 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
                 managed[id] = ManagedDisplay(info: info, manager: manager)
                 do {
                     try await manager.startCapture()
+                    guard isRunning, !Task.isCancelled else {
+                        if managed[id]?.manager === manager {
+                            managed.removeValue(forKey: id)
+                        }
+                        let previousLoop = manager.beginStoppingCapture()
+                        await previousLoop?.value
+                        throw CancellationError()
+                    }
                     captureLogger.info("Capture started for display: \(info.name, privacy: .public)")
                     DiagnosticsLog.shared.log("Capture", "Capture started for display: \(info.name)")
                 } catch {
-                    managed.removeValue(forKey: id)
+                    if managed[id]?.manager === manager {
+                        managed.removeValue(forKey: id)
+                    }
+                    guard isRunning, !Task.isCancelled else { throw CancellationError() }
                     let isPermissionDenied: Bool
                     if case CaptureError.permissionDenied = error {
                         isPermissionDenied = true

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -122,6 +122,10 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     private var isRunning = false
     private var screenParamsObserver: NSObjectProtocol?
     private var reconcileTask: Task<Void, Never>?
+    /// Broker recovery can occur midway through display discovery/startup.
+    /// Suppress that intermediate healthy signal until the full reconciliation
+    /// confirms capture is live and the circuit stayed closed.
+    private var activeReconciliationCount = 0
     /// Retries display reconciliation shortly after the shared circuit's
     /// cooldown expires, so a restart blocked mid-episode is not stranded in
     /// "Stopped" until the next unrelated system event.
@@ -138,6 +142,10 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             // Do not let a late broker result overwrite those more specific
             // menu states.
             guard let self, self.isRunning else { return }
+            guard Self.shouldForwardBrokerRecoveryState(
+                state,
+                activeReconciliationCount: self.activeReconciliationCount
+            ) else { return }
             self.delegate?.captureCoordinator(self, didChangeRecoveryState: state)
         }
         screenParamsObserver = NotificationCenter.default.addObserver(
@@ -202,6 +210,13 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         return isCapturing ? .ready : .noDisplay
     }
 
+    nonisolated static func shouldForwardBrokerRecoveryState(
+        _ state: CaptureRequestBrokerRecoveryState,
+        activeReconciliationCount: Int
+    ) -> Bool {
+        state != .normal || activeReconciliationCount == 0
+    }
+
     func stopCapture() async {
         isRunning = false
         reconcileTask?.cancel()
@@ -264,6 +279,9 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     }
 
     private func reconcileDisplays(startNewManagers: Bool) async throws {
+        activeReconciliationCount += 1
+        defer { activeReconciliationCount -= 1 }
+
         // If permission has genuinely been revoked, surface that immediately
         // instead of letting the request be classified as a cooldown deferral
         // (or touching ScreenCaptureKit at all).
@@ -360,6 +378,13 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         }
 
         delegate?.captureCoordinatorDidUpdateDisplays(self)
+        if activeReconciliationCount == 1,
+           isCapturing,
+           captureRequestBroker.isCircuitClosed {
+            // This is the authoritative ready signal. A broker half-open probe
+            // may report healthy earlier, before every missing display starts.
+            delegate?.captureCoordinator(self, didChangeRecoveryState: .normal)
+        }
     }
 
     // MARK: - Cooldown restart
@@ -388,14 +413,6 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             do {
                 try await self.reconcileDisplays(startNewManagers: true)
                 guard self.isRunning, !Task.isCancelled else { return }
-                if self.isCapturing, self.captureRequestBroker.isCircuitClosed {
-                    // The broker publishes .normal when its half-open probe
-                    // succeeds, which happens before any display is capturing,
-                    // so the app skips the "Active" status update. Re-publish
-                    // now that capture is actually running again — but only if
-                    // no later display start reopened the circuit.
-                    self.delegate?.captureCoordinator(self, didChangeRecoveryState: .normal)
-                }
             } catch {
                 guard self.isRunning, !(error is CancellationError) else { return }
                 if case CaptureError.permissionDenied = error {

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -128,6 +128,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     /// Suppress that intermediate healthy signal until the full reconciliation
     /// confirms capture is live and the circuit stayed closed.
     private var activeReconciliationCount = 0
+    private var fallbackRestartToken: TimeInterval = -1
     /// Retries display reconciliation shortly after the shared circuit's
     /// cooldown expires, so a restart blocked mid-episode is not stranded in
     /// "Stopped" until the next unrelated system event.
@@ -445,15 +446,33 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             "Capture",
             "Capture start deferred; retrying in \(Int(delay)) seconds when the shared ScreenCaptureKit circuit cooldown ends"
         )
-        cooldownRestartScheduler.schedule(
-            deadline: deadline,
+        scheduleCaptureRestart(deadline: deadline, delay: .seconds(delay))
+    }
+
+    private func scheduleFallbackRestart() {
+        guard isRunning, !isCapturing else { return }
+        fallbackRestartToken -= 1
+        let delay = CaptureFailureRecovery.falsePermissionDenialDelay
+        DiagnosticsLog.shared.log(
+            "Capture",
+            "Capture recovery found no usable display; retrying reconciliation in \(Int(delay)) seconds"
+        )
+        scheduleCaptureRestart(
+            deadline: fallbackRestartToken,
             delay: .seconds(delay)
-        ) { [weak self] in
+        )
+    }
+
+    private func scheduleCaptureRestart(deadline: TimeInterval, delay: Duration) {
+        cooldownRestartScheduler.schedule(deadline: deadline, delay: delay) { [weak self] in
             guard let self else { return }
             guard !Task.isCancelled, self.isRunning else { return }
             do {
                 try await self.reconcileDisplays(startNewManagers: true)
                 guard self.isRunning, !Task.isCancelled else { return }
+                if !self.isCapturing {
+                    self.scheduleFallbackRestart()
+                }
             } catch {
                 guard self.isRunning, !(error is CancellationError) else { return }
                 if case CaptureError.permissionDenied = error {
@@ -465,10 +484,11 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
                         "Cooldown restart found screen recording permission revoked; \(CaptureSystemState.summary())"
                     )
                     self.delegate?.captureCoordinatorDidStopUnexpectedly(self)
+                } else if self.captureRequestBroker.openCircuitMonotonicDeadline == nil {
+                    self.scheduleFallbackRestart()
                 }
                 // Cooldown failures already rescheduled another restart from
-                // inside reconcileDisplays; other errors keep the existing
-                // reconcile-on-system-event behaviour.
+                // inside reconcileDisplays.
             }
         }
     }

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -217,6 +217,14 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         state != .normal || activeReconciliationCount == 0
     }
 
+    nonisolated static func shouldPublishReconciledReadiness(
+        isRunning: Bool,
+        isCapturing: Bool,
+        isCircuitClosed: Bool
+    ) -> Bool {
+        isRunning && isCapturing && isCircuitClosed
+    }
+
     func stopCapture() async {
         isRunning = false
         reconcileTask?.cancel()
@@ -378,9 +386,11 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         }
 
         delegate?.captureCoordinatorDidUpdateDisplays(self)
-        if activeReconciliationCount == 1,
-           isCapturing,
-           captureRequestBroker.isCircuitClosed {
+        if Self.shouldPublishReconciledReadiness(
+            isRunning: isRunning,
+            isCapturing: isCapturing,
+            isCircuitClosed: captureRequestBroker.isCircuitClosed
+        ) {
             // This is the authoritative ready signal. A broker half-open probe
             // may report healthy earlier, before every missing display starts.
             delegate?.captureCoordinator(self, didChangeRecoveryState: .normal)

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -199,6 +199,7 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             // partial multi-display start overwrite "Recovering…" with "Active".
             throw CaptureRequestBrokerError.cooldown(untilMonotonicTime: deadline)
         case .noDisplay:
+            scheduleFallbackRestart()
             throw CaptureError.noDisplay
         }
     }

--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -11,6 +11,12 @@ import os.log
 
 private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Capture")
 
+enum CaptureCoordinatorStartReadiness: Equatable {
+    case ready
+    case coolingDown(untilMonotonicTime: TimeInterval)
+    case noDisplay
+}
+
 @MainActor
 protocol CaptureCoordinatorDelegate: AnyObject {
     func captureCoordinator(
@@ -50,12 +56,23 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     /// All display managers share one broker so a ScreenCaptureKit false TCC
     /// denial pauses the whole process before another display can retry.
     private let captureRequestBroker: CaptureRequestBroker
+    /// Owner token for the coordinator's own brokered content-discovery calls.
+    private let reconcileRequestOwner = UUID()
     private var managed: [UUID: ManagedDisplay] = [:]
     private var captureInterval: TimeInterval = 1.0
     private var captureScale: Int = 2
     private var isRunning = false
     private var screenParamsObserver: NSObjectProtocol?
     private var reconcileTask: Task<Void, Never>?
+    /// Retries display reconciliation shortly after the shared circuit's
+    /// cooldown expires, so a restart blocked mid-episode is not stranded in
+    /// "Stopped" until the next unrelated system event.
+    private var cooldownRestartTask: Task<Void, Never>?
+    private var cooldownRestartDeadline: TimeInterval?
+    /// Identifies the current restart so a finished task only clears state it
+    /// still owns, even when a reopened circuit scheduled a replacement while
+    /// the task was reconciling.
+    private var cooldownRestartGeneration = 0
 
     override init() {
         let captureRequestBroker = CaptureRequestBroker()
@@ -105,15 +122,37 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
     func startCapture() async throws {
         isRunning = true
         try await reconcileDisplays(startNewManagers: true)
-        if !isCapturing {
+        switch Self.startReadiness(
+            isCapturing: isCapturing,
+            openCircuitDeadline: captureRequestBroker.openCircuitMonotonicDeadline
+        ) {
+        case .ready:
+            return
+        case .coolingDown(let deadline):
+            // A process-wide cooldown blocks every display, including managers
+            // that started earlier in this reconciliation pass. Do not let a
+            // partial multi-display start overwrite "Recovering…" with "Active".
+            throw CaptureRequestBrokerError.cooldown(untilMonotonicTime: deadline)
+        case .noDisplay:
             throw CaptureError.noDisplay
         }
+    }
+
+    nonisolated static func startReadiness(
+        isCapturing: Bool,
+        openCircuitDeadline: TimeInterval?
+    ) -> CaptureCoordinatorStartReadiness {
+        if let openCircuitDeadline {
+            return .coolingDown(untilMonotonicTime: openCircuitDeadline)
+        }
+        return isCapturing ? .ready : .noDisplay
     }
 
     func stopCapture() async {
         isRunning = false
         reconcileTask?.cancel()
         reconcileTask = nil
+        cancelCooldownRestart()
         let snapshot = Array(managed.values)
         managed.removeAll()
         let previousLoops = snapshot.map { $0.manager.beginStoppingCapture() }
@@ -156,13 +195,49 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         reconcileTask?.cancel()
         reconcileTask = Task { @MainActor [weak self] in
             guard let self else { return }
-            try? await self.reconcileDisplays(startNewManagers: true)
+            do {
+                try await self.reconcileDisplays(startNewManagers: true)
+            } catch {
+                if self.isRunning, !(error is CancellationError),
+                   case CaptureError.permissionDenied = error {
+                    // A revocation found during a system-event reconcile must
+                    // reach the app's restart/permission flow, not vanish.
+                    self.delegate?.captureCoordinatorDidStopUnexpectedly(self)
+                }
+            }
             self.reconcileTask = nil
         }
     }
 
     private func reconcileDisplays(startNewManagers: Bool) async throws {
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        // If permission has genuinely been revoked, surface that immediately
+        // instead of letting the request be classified as a cooldown deferral
+        // (or touching ScreenCaptureKit at all).
+        guard ScreenCaptureManager.hasScreenRecordingPermission() else {
+            throw CaptureError.permissionDenied
+        }
+        let content: SCShareableContent
+        do {
+            // Brokered so reconcile and restart respect the shared circuit:
+            // while it is cooling down after a false TCC denial, no code path
+            // may touch ScreenCaptureKit and risk another native prompt.
+            content = try await captureRequestBroker.perform(owner: reconcileRequestOwner) {
+                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+            }
+        } catch {
+            // A genuine revocation must reach the app's permission flow even
+            // when a circuit from an earlier false-denial episode is open.
+            if CaptureFailureRecovery.isPermissionDenial(error),
+               !ScreenCaptureManager.hasScreenRecordingPermission() {
+                throw CaptureError.permissionDenied
+            }
+            if !(error is CancellationError),
+               let deadline = captureRequestBroker.openCircuitMonotonicDeadline {
+                scheduleCooldownRestart()
+                throw CaptureRequestBrokerError.cooldown(untilMonotonicTime: deadline)
+            }
+            throw error
+        }
         try Task.checkCancellation()
 
         var desired: [UUID: DisplayInfo] = [:]
@@ -198,14 +273,32 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
                     captureLogger.info("Capture started for display: \(info.name, privacy: .public)")
                     DiagnosticsLog.shared.log("Capture", "Capture started for display: \(info.name)")
                 } catch {
+                    managed.removeValue(forKey: id)
+                    let isPermissionDenied: Bool
+                    if case CaptureError.permissionDenied = error {
+                        isPermissionDenied = true
+                    } else {
+                        isPermissionDenied = false
+                    }
+                    // A genuine permission denial must never be downgraded to
+                    // a cooldown deferral, even if a circuit from an earlier
+                    // false-denial episode happens to be open.
+                    if !isPermissionDenied,
+                       !(error is CancellationError),
+                       captureRequestBroker.openCircuitMonotonicDeadline != nil {
+                        // The shared circuit opened (or was already open); the
+                        // broker has logged it. Defer this display to the
+                        // cooldown restart instead of counting a hard failure.
+                        scheduleCooldownRestart()
+                        continue
+                    }
                     let detail = DiagnosticsLogFormat.describe(error)
                     captureLogger.error("Failed to start capture for \(info.name, privacy: .public): \(detail, privacy: .public)")
                     DiagnosticsLog.shared.log(
                         "Capture",
                         "Failed to start capture for \(info.name): \(detail); \(CaptureSystemState.summary())"
                     )
-                    managed.removeValue(forKey: id)
-                    if error is CaptureError, case CaptureError.permissionDenied = error {
+                    if isPermissionDenied {
                         throw error
                     }
                 }
@@ -213,6 +306,83 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
         }
 
         delegate?.captureCoordinatorDidUpdateDisplays(self)
+    }
+
+    // MARK: - Cooldown restart
+
+    /// Schedules one reconcile pass shortly after the shared circuit's
+    /// cooldown expires. Bounded by design: if the retry's probe fails again,
+    /// the broker reopens the circuit with an escalated cooldown and this
+    /// reschedules for the new, later deadline.
+    private func scheduleCooldownRestart() {
+        guard isRunning else { return }
+        guard let deadline = captureRequestBroker.openCircuitMonotonicDeadline,
+              let remaining = captureRequestBroker.remainingCooldown() else { return }
+        guard cooldownRestartDeadline != deadline else { return }
+
+        cooldownRestartTask?.cancel()
+        cooldownRestartDeadline = deadline
+        cooldownRestartGeneration += 1
+        let generation = cooldownRestartGeneration
+        let delay = remaining + 1
+        DiagnosticsLog.shared.log(
+            "Capture",
+            "Capture start deferred; retrying in \(Int(delay)) seconds when the shared ScreenCaptureKit circuit cooldown ends"
+        )
+        cooldownRestartTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(delay))
+            guard let self else { return }
+            // Keep the task handle registered until this task finishes so
+            // stopCapture() can still cancel it while the reconcile below is
+            // in flight. Only clear state this generation still owns: the
+            // reconcile may reopen the circuit and schedule a replacement.
+            defer {
+                if self.cooldownRestartGeneration == generation {
+                    self.cooldownRestartTask = nil
+                    self.cooldownRestartDeadline = nil
+                }
+            }
+            guard !Task.isCancelled, self.isRunning else { return }
+            // Allow a reopen during this reconcile to schedule the next
+            // restart even if the broker lands on an identical deadline.
+            self.cooldownRestartDeadline = nil
+            do {
+                try await self.reconcileDisplays(startNewManagers: true)
+                guard self.isRunning, !Task.isCancelled else { return }
+                if self.isCapturing, self.captureRequestBroker.isCircuitClosed {
+                    // The broker publishes .normal when its half-open probe
+                    // succeeds, which happens before any display is capturing,
+                    // so the app skips the "Active" status update. Re-publish
+                    // now that capture is actually running again — but only if
+                    // no later display start reopened the circuit.
+                    self.delegate?.captureCoordinator(self, didChangeRecoveryState: .normal)
+                }
+            } catch {
+                guard self.isRunning, !(error is CancellationError) else { return }
+                if case CaptureError.permissionDenied = error {
+                    // A real revocation discovered during a background retry
+                    // must reach the app's restart/permission flow instead of
+                    // being silently dropped.
+                    DiagnosticsLog.shared.log(
+                        "Capture",
+                        "Cooldown restart found screen recording permission revoked; \(CaptureSystemState.summary())"
+                    )
+                    self.delegate?.captureCoordinatorDidStopUnexpectedly(self)
+                }
+                // Cooldown failures already rescheduled another restart from
+                // inside reconcileDisplays; other errors keep the existing
+                // reconcile-on-system-event behaviour.
+            }
+        }
+    }
+
+    private func cancelCooldownRestart() {
+        cooldownRestartTask?.cancel()
+        cooldownRestartTask = nil
+        cooldownRestartDeadline = nil
+        // Invalidate any restart task that is past its cancellation checks so
+        // its deferred cleanup cannot clear state from a later schedule.
+        cooldownRestartGeneration += 1
     }
 
     // MARK: - ScreenCaptureDelegate

--- a/JustNow/Capture/CaptureEventController.swift
+++ b/JustNow/Capture/CaptureEventController.swift
@@ -117,7 +117,9 @@ final class CaptureEventController {
             || current.hasPendingStart
             || (lifecycle.isPausedForOverlay && lifecycle.wasCapturingBeforeOverlay)
         let shouldStopCapture = lifecycle.pauseForSession(
-            captureWasActive: current.isCapturing || current.hasPendingStart,
+            captureWasActive: current.isCapturing
+                || current.isSetupCaptureInProgress
+                || current.hasPendingStart,
             shouldResumeCapture: shouldResumeCaptureAfterSession
         )
         cancelPendingStart()
@@ -207,7 +209,9 @@ final class CaptureEventController {
             || current.hasPendingStart
             || (lifecycle.isPausedForSession && lifecycle.wasCapturingBeforeSession)
         let shouldStopCapture = lifecycle.pauseForOverlay(
-            captureWasActive: current.isCapturing || current.hasPendingStart,
+            captureWasActive: current.isCapturing
+                || current.isSetupCaptureInProgress
+                || current.hasPendingStart,
             shouldResumeCapture: shouldResumeCaptureAfterOverlay
         )
         cancelPendingStart()
@@ -224,13 +228,6 @@ final class CaptureEventController {
     private func resumeCaptureAfterOverlay() {
         guard lifecycle.resumeAfterOverlay() else { return }
 
-        let current = context()
-        if current.isSetupCaptureInProgress {
-            cancelPendingStart()
-            updateStatus(blockedStatus(includeOverlay: false) ?? "Resuming...")
-            return
-        }
-
         scheduleStart(
             CaptureStartRequest(
                 status: "Resuming...",
@@ -245,13 +242,6 @@ final class CaptureEventController {
     }
 
     private func scheduleResume(reason: String) {
-        let current = context()
-        if current.isSetupCaptureInProgress {
-            cancelPendingStart()
-            updateStatus(blockedStatus() ?? "Resuming...")
-            return
-        }
-
         scheduleStart(
             CaptureStartRequest(
                 status: "Resuming...",

--- a/JustNow/Capture/CaptureEventController.swift
+++ b/JustNow/Capture/CaptureEventController.swift
@@ -117,7 +117,7 @@ final class CaptureEventController {
             || current.hasPendingStart
             || (lifecycle.isPausedForOverlay && lifecycle.wasCapturingBeforeOverlay)
         let shouldStopCapture = lifecycle.pauseForSession(
-            captureWasActive: current.isCapturing,
+            captureWasActive: current.isCapturing || current.hasPendingStart,
             shouldResumeCapture: shouldResumeCaptureAfterSession
         )
         cancelPendingStart()
@@ -207,7 +207,7 @@ final class CaptureEventController {
             || current.hasPendingStart
             || (lifecycle.isPausedForSession && lifecycle.wasCapturingBeforeSession)
         let shouldStopCapture = lifecycle.pauseForOverlay(
-            captureWasActive: current.isCapturing,
+            captureWasActive: current.isCapturing || current.hasPendingStart,
             shouldResumeCapture: shouldResumeCaptureAfterOverlay
         )
         cancelPendingStart()

--- a/JustNow/Capture/CaptureReconciliationGate.swift
+++ b/JustNow/Capture/CaptureReconciliationGate.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Serialises coordinator lifecycle work across suspension points. Main-actor
+/// isolation alone does not prevent another task from entering while an
+/// operation awaits ScreenCaptureKit.
+@MainActor
+final class CaptureReconciliationGate {
+    private struct Waiter {
+        let id: UUID
+        let continuation: CheckedContinuation<Bool, Never>
+    }
+
+    private var isHeld = false
+    private var waiters: [Waiter] = []
+
+    func withPermit<T>(
+        _ operation: @escaping @MainActor () async throws -> T
+    ) async throws -> T {
+        guard await acquireUnlessCancelled() else { throw CancellationError() }
+        defer { release() }
+        try Task.checkCancellation()
+        return try await operation()
+    }
+
+    func withPermitIgnoringCancellation<T>(
+        _ operation: @escaping @MainActor () async -> T
+    ) async -> T {
+        await acquireIgnoringCancellation()
+        defer { release() }
+        return await operation()
+    }
+
+    private func acquireUnlessCancelled() async -> Bool {
+        guard isHeld else {
+            guard !Task.isCancelled else { return false }
+            isHeld = true
+            return true
+        }
+
+        let id = UUID()
+        return await withTaskCancellationHandler(operation: {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                waiters.append(Waiter(id: id, continuation: continuation))
+            }
+        }, onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelWaiter(id: id)
+            }
+        })
+    }
+
+    private func acquireIgnoringCancellation() async {
+        guard isHeld else {
+            isHeld = true
+            return
+        }
+        _ = await withCheckedContinuation { continuation in
+            waiters.append(Waiter(id: UUID(), continuation: continuation))
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        guard let index = waiters.firstIndex(where: { $0.id == id }) else { return }
+        waiters.remove(at: index).continuation.resume(returning: false)
+    }
+
+    private func release() {
+        guard !waiters.isEmpty else {
+            isHeld = false
+            return
+        }
+        waiters.removeFirst().continuation.resume(returning: true)
+    }
+
+#if DEBUG
+    var queuedWaiterCountForTesting: Int { waiters.count }
+#endif
+}

--- a/JustNow/Capture/CaptureRequestBroker.swift
+++ b/JustNow/Capture/CaptureRequestBroker.swift
@@ -261,18 +261,12 @@ final class CaptureRequestBroker {
             }
 
             if case .halfOpen = circuitState {
-                if error is CancellationError {
-                    // A display disappearing during the probe must not let it
-                    // reset the circuit for every other display. Keep the
-                    // shared protection in place and retry with a future owner.
-                    // A cancelled probe is not fresh evidence of failure, so
-                    // it keeps the current cooldown without escalating it.
-                    openCircuit(isReopen: true, escalatesCooldown: false)
-                    return
-                }
-                // This was not the beta false-denial signature. Preserve the
-                // manager's normal error handling and let later requests run,
-                // but remain half-open until a capture actually succeeds.
+                // A cancelled or otherwise unsuccessful half-open probe is not
+                // proof that ScreenCaptureKit is healthy. Re-arm the same
+                // bounded cooldown without escalating an unrelated error, so
+                // recovery always retains a future owner and deadline.
+                openCircuit(isReopen: true, escalatesCooldown: false)
+                return
             }
             releaseNextWaiter()
         }

--- a/JustNow/Capture/CaptureRequestBroker.swift
+++ b/JustNow/Capture/CaptureRequestBroker.swift
@@ -19,6 +19,10 @@ enum CaptureRequestBrokerError: Error, Equatable {
 enum CaptureRequestBrokerRecoveryState: Equatable {
     case normal
     case coolingDown
+    /// Repeated false denials have reached the maximum retry interval. Capture
+    /// still retries in the background, but the user should receive one clear
+    /// route to repair a persistent macOS permission-service desync.
+    case needsAttention
 }
 
 /// Serialises all one-shot ScreenCaptureKit calls made by this process.
@@ -27,6 +31,12 @@ enum CaptureRequestBrokerRecoveryState: Equatable {
 /// when TCC remains granted. The broker sees that result before releasing a
 /// waiting display, opens one shared circuit, and makes callers fail fast
 /// until a single half-open probe succeeds.
+///
+/// Each failed probe that reopens the circuit doubles the cooldown (capped at
+/// `CaptureFailureRecovery.falsePermissionDenialMaximumDelay`), because every
+/// ScreenCaptureKit touch during a desync episode risks re-surfacing the
+/// native permission prompt. Escalation resets once the circuit has stayed
+/// closed past `falsePermissionDenialEscalationResetInterval`.
 @MainActor
 final class CaptureRequestBroker {
     private struct Waiter {
@@ -51,6 +61,8 @@ final class CaptureRequestBroker {
     private let hasScreenRecordingPermission: @MainActor () -> Bool
     private let log: @MainActor (String) -> Void
     private let cooldown: TimeInterval
+    private let maximumCooldown: TimeInterval
+    private let escalationResetInterval: TimeInterval
 
     var recoveryStateDidChange: @MainActor (CaptureRequestBrokerRecoveryState) -> Void = { _ in }
 
@@ -58,6 +70,14 @@ final class CaptureRequestBroker {
     private var isRequestInFlight = false
     private var waiters: [Waiter] = []
     private var openedCircuitCount = 0
+    /// Doubles the cooldown per consecutive reopen; bounded so the exponent
+    /// stays sane even though `maximumCooldown` already caps the delay.
+    private var cooldownEscalationLevel = 0
+    private static let maximumCooldownEscalationLevel = 8
+    /// Monotonic time of the most recent half-open probe success. Used to
+    /// decide whether a new denial after recovery continues the same desync
+    /// episode (escalate) or follows a sustained healthy stretch (reset).
+    private var lastRecoveryMonotonicTime: TimeInterval?
 
     init(
         monotonicNow: @escaping @MainActor () -> TimeInterval = {
@@ -67,6 +87,9 @@ final class CaptureRequestBroker {
             ScreenCaptureManager.hasScreenRecordingPermission()
         },
         cooldown: TimeInterval = CaptureFailureRecovery.falsePermissionDenialDelay,
+        maximumCooldown: TimeInterval = CaptureFailureRecovery.falsePermissionDenialMaximumDelay,
+        escalationResetInterval: TimeInterval =
+            CaptureFailureRecovery.falsePermissionDenialEscalationResetInterval,
         log: @escaping @MainActor (String) -> Void = { message in
             captureBrokerLogger.warning("\(message, privacy: .public)")
             DiagnosticsLog.shared.log("Capture", message)
@@ -75,7 +98,31 @@ final class CaptureRequestBroker {
         self.monotonicNow = monotonicNow
         self.hasScreenRecordingPermission = hasScreenRecordingPermission
         self.cooldown = cooldown
+        self.maximumCooldown = maximumCooldown
+        self.escalationResetInterval = escalationResetInterval
         self.log = log
+    }
+
+    /// Monotonic deadline of the currently open circuit, if any. Callers use
+    /// this to defer restart work until the cooldown has expired instead of
+    /// treating a cooling-down circuit as a hard failure.
+    var openCircuitMonotonicDeadline: TimeInterval? {
+        guard case .open(let monotonicDeadline) = circuitState else { return nil }
+        return monotonicDeadline
+    }
+
+    /// True only when the circuit is fully closed — not open and not waiting
+    /// on a half-open probe. Callers use this to avoid reporting a healthy
+    /// state while the shared circuit is still recovering.
+    var isCircuitClosed: Bool {
+        if case .closed = circuitState { return true }
+        return false
+    }
+
+    /// Seconds until the open circuit's cooldown expires, or nil when closed.
+    func remainingCooldown() -> TimeInterval? {
+        guard let deadline = openCircuitMonotonicDeadline else { return nil }
+        return max(0, deadline - monotonicNow())
     }
 
     /// Runs a single one-shot request after process-wide admission.
@@ -90,7 +137,13 @@ final class CaptureRequestBroker {
         try await acquireTurn(owner: owner)
 
         do {
+            try Task.checkCancellation()
             let value = try await operation()
+            // Enforce cancellation at the broker boundary so a cancelled
+            // half-open probe whose OS call still returned successfully cannot
+            // close the shared circuit on behalf of a caller that no longer
+            // wants the result.
+            try Task.checkCancellation()
             finishTurn(after: .success)
             return value
         } catch {
@@ -120,7 +173,7 @@ final class CaptureRequestBroker {
                 // Capture may have been paused and restarted while the shared
                 // circuit was still open. Re-publish the state so the new run
                 // does not briefly present itself as healthy.
-                recoveryStateDidChange(.coolingDown)
+                publishOpenCircuitRecoveryState()
                 throw CaptureRequestBrokerError.cooldown(
                     untilMonotonicTime: monotonicDeadline
                 )
@@ -185,6 +238,7 @@ final class CaptureRequestBroker {
         case .success:
             if case .halfOpen = circuitState {
                 circuitState = .closed
+                lastRecoveryMonotonicTime = monotonicNow()
                 logCircuitRecovery()
                 recoveryStateDidChange(.normal)
             }
@@ -195,14 +249,14 @@ final class CaptureRequestBroker {
                 for: error,
                 hasScreenRecordingPermission: hasScreenRecordingPermission()
             )
-            if case .backOff(let delay) = recovery {
+            if case .backOff = recovery {
                 let isHalfOpenProbe: Bool
                 if case .halfOpen = circuitState {
                     isHalfOpenProbe = true
                 } else {
                     isHalfOpenProbe = false
                 }
-                openCircuit(for: delay, isReopen: isHalfOpenProbe)
+                openCircuit(isReopen: isHalfOpenProbe, escalatesCooldown: true)
                 return
             }
 
@@ -211,7 +265,9 @@ final class CaptureRequestBroker {
                     // A display disappearing during the probe must not let it
                     // reset the circuit for every other display. Keep the
                     // shared protection in place and retry with a future owner.
-                    openCircuit(for: cooldown, isReopen: true)
+                    // A cancelled probe is not fresh evidence of failure, so
+                    // it keeps the current cooldown without escalating it.
+                    openCircuit(isReopen: true, escalatesCooldown: false)
                     return
                 }
                 // This was not the beta false-denial signature. Preserve the
@@ -222,8 +278,30 @@ final class CaptureRequestBroker {
         }
     }
 
-    private func openCircuit(for delay: TimeInterval, isReopen: Bool = false) {
-        let monotonicDeadline = monotonicNow() + delay
+    private func openCircuit(isReopen: Bool, escalatesCooldown: Bool) {
+        let now = monotonicNow()
+        if escalatesCooldown {
+            if isReopen {
+                // A failed half-open probe means no healthy period occurred,
+                // no matter how long the probe was delayed (e.g. by sleep).
+                cooldownEscalationLevel = min(
+                    cooldownEscalationLevel + 1,
+                    Self.maximumCooldownEscalationLevel
+                )
+            } else if let lastRecoveryMonotonicTime,
+                      now - lastRecoveryMonotonicTime < escalationResetInterval {
+                // Quick relapse after recovery: same desync episode.
+                cooldownEscalationLevel = min(
+                    cooldownEscalationLevel + 1,
+                    Self.maximumCooldownEscalationLevel
+                )
+            } else {
+                // First denial ever, or one after a sustained healthy stretch.
+                cooldownEscalationLevel = 0
+            }
+        }
+        let delay = currentCooldownDelay
+        let monotonicDeadline = now + delay
         circuitState = .open(monotonicDeadline: monotonicDeadline)
         openedCircuitCount += 1
 
@@ -233,13 +311,25 @@ final class CaptureRequestBroker {
             "Global ScreenCaptureKit capture circuit \(event) for \(delay) seconds "
                 + "(queuedRequests=\(queuedCount), circuitOpenCount=\(openedCircuitCount))"
         )
-        recoveryStateDidChange(.coolingDown)
+        publishOpenCircuitRecoveryState()
 
         let pending = waiters
         waiters.removeAll()
         isRequestInFlight = false
         for waiter in pending {
             waiter.continuation.resume(returning: .cooldown(monotonicDeadline))
+        }
+    }
+
+    private var currentCooldownDelay: TimeInterval {
+        min(cooldown * pow(2, Double(cooldownEscalationLevel)), maximumCooldown)
+    }
+
+    private func publishOpenCircuitRecoveryState() {
+        if currentCooldownDelay >= maximumCooldown {
+            recoveryStateDidChange(.needsAttention)
+        } else {
+            recoveryStateDidChange(.coolingDown)
         }
     }
 

--- a/JustNow/Capture/CaptureStartController.swift
+++ b/JustNow/Capture/CaptureStartController.swift
@@ -11,6 +11,14 @@ struct CaptureStartRetryPolicy {
     let attempt: CaptureStartAttempt
 }
 
+enum CaptureStartResult: Equatable {
+    case started
+    /// Recovery is already owned by another scheduler, so this attempt must
+    /// not consume the generic delayed-retry policy.
+    case deferred
+    case failed
+}
+
 struct CaptureStartRequest {
     let status: String
     let includeOverlayInBlockedStatus: Bool
@@ -62,7 +70,7 @@ final class CaptureStartController {
         canStartCapture: @escaping () -> Bool,
         blockedStatus: @escaping (Bool) -> String?,
         updateStatus: @escaping (String) -> Void,
-        startCapture: @escaping (CaptureStartAttempt) async -> Bool
+        startCapture: @escaping (CaptureStartAttempt) async -> CaptureStartResult
     ) {
         cancelPendingStart()
         let generation = pendingStartGeneration
@@ -94,8 +102,8 @@ final class CaptureStartController {
                 return
             }
 
-            let didStart = await startCapture(request.attempt)
-            guard !didStart, let retry = request.retry else { return }
+            let result = await startCapture(request.attempt)
+            guard result == .failed, let retry = request.retry else { return }
 
             await sleep(retry.delay)
 

--- a/JustNow/Capture/CaptureStartController.swift
+++ b/JustNow/Capture/CaptureStartController.swift
@@ -19,6 +19,10 @@ enum CaptureStartResult: Equatable {
     case failed
 }
 
+struct CaptureStartGeneration: Equatable {
+    fileprivate let value: Int
+}
+
 struct CaptureStartRequest {
     let status: String
     let includeOverlayInBlockedStatus: Bool
@@ -71,6 +75,15 @@ final class CaptureStartController {
     func completeDeferredStart() {
         deferredCompletionGeneration += 1
         isStartDeferred = false
+    }
+
+    func generationSnapshot() -> CaptureStartGeneration {
+        CaptureStartGeneration(value: pendingStartGeneration)
+    }
+
+    func completeDeferredStartIfNoNewerRequest(since generation: CaptureStartGeneration) {
+        guard generation.value == pendingStartGeneration else { return }
+        completeDeferredStart()
     }
 
     func beginDeferredStart() {

--- a/JustNow/Capture/CaptureStartController.swift
+++ b/JustNow/Capture/CaptureStartController.swift
@@ -46,6 +46,7 @@ final class CaptureStartController {
     private let sleep: (Duration) async -> Void
     private var pendingStartTask: Task<Void, Never>?
     private var pendingStartGeneration = 0
+    private var isStartDeferred = false
 
     init(
         sleep: @escaping (Duration) async -> Void = { duration in
@@ -56,13 +57,18 @@ final class CaptureStartController {
     }
 
     var hasPendingStart: Bool {
-        pendingStartTask != nil
+        pendingStartTask != nil || isStartDeferred
     }
 
     func cancelPendingStart() {
         pendingStartGeneration += 1
         pendingStartTask?.cancel()
         pendingStartTask = nil
+        isStartDeferred = false
+    }
+
+    func completeDeferredStart() {
+        isStartDeferred = false
     }
 
     func scheduleStart(
@@ -103,6 +109,13 @@ final class CaptureStartController {
             }
 
             let result = await startCapture(request.attempt)
+            if result == .deferred {
+                // The coordinator owns the actual cooldown timer, but the app
+                // lifecycle must still see pending recovery so overlay/session
+                // transitions can stop and cancel that coordinator work.
+                self.isStartDeferred = true
+                return
+            }
             guard result == .failed, let retry = request.retry else { return }
 
             await sleep(retry.delay)

--- a/JustNow/Capture/CaptureStartController.swift
+++ b/JustNow/Capture/CaptureStartController.swift
@@ -73,6 +73,10 @@ final class CaptureStartController {
         isStartDeferred = false
     }
 
+    func beginDeferredStart() {
+        isStartDeferred = true
+    }
+
     func scheduleStart(
         request: CaptureStartRequest,
         canStartCapture: @escaping () -> Bool,

--- a/JustNow/Capture/CaptureStartController.swift
+++ b/JustNow/Capture/CaptureStartController.swift
@@ -47,6 +47,7 @@ final class CaptureStartController {
     private var pendingStartTask: Task<Void, Never>?
     private var pendingStartGeneration = 0
     private var isStartDeferred = false
+    private var deferredCompletionGeneration = 0
 
     init(
         sleep: @escaping (Duration) async -> Void = { duration in
@@ -68,6 +69,7 @@ final class CaptureStartController {
     }
 
     func completeDeferredStart() {
+        deferredCompletionGeneration += 1
         isStartDeferred = false
     }
 
@@ -108,12 +110,19 @@ final class CaptureStartController {
                 return
             }
 
+            let initialCompletionGeneration = self.deferredCompletionGeneration
             let result = await startCapture(request.attempt)
+            guard !Task.isCancelled,
+                  generation == self.pendingStartGeneration else {
+                return
+            }
             if result == .deferred {
                 // The coordinator owns the actual cooldown timer, but the app
                 // lifecycle must still see pending recovery so overlay/session
                 // transitions can stop and cancel that coordinator work.
-                self.isStartDeferred = true
+                if initialCompletionGeneration == self.deferredCompletionGeneration {
+                    self.isStartDeferred = true
+                }
                 return
             }
             guard result == .failed, let retry = request.retry else { return }
@@ -126,7 +135,16 @@ final class CaptureStartController {
                 return
             }
 
-            _ = await startCapture(retry.attempt)
+            let retryCompletionGeneration = self.deferredCompletionGeneration
+            let retryResult = await startCapture(retry.attempt)
+            guard !Task.isCancelled,
+                  generation == self.pendingStartGeneration else {
+                return
+            }
+            if retryResult == .deferred,
+               retryCompletionGeneration == self.deferredCompletionGeneration {
+                self.isStartDeferred = true
+            }
         }
     }
 }

--- a/JustNow/Capture/CaptureStopController.swift
+++ b/JustNow/Capture/CaptureStopController.swift
@@ -43,8 +43,12 @@ final class CaptureStopController {
     ) {
         stopGeneration += 1
         let generation = stopGeneration
+        let previousStopTask = pendingStopTask
         pendingStopTask = Task { @MainActor [weak self] in
             guard let self else { return }
+            // Preserve lifecycle intent order even when several system events
+            // enqueue sibling unstructured tasks in the same run-loop turn.
+            await previousStopTask?.value
             await self.performStop(request)
             afterStop()
             if generation == self.stopGeneration {

--- a/JustNow/Capture/CaptureStopController.swift
+++ b/JustNow/Capture/CaptureStopController.swift
@@ -19,6 +19,8 @@ final class CaptureStopController {
     private let stopCapture: () async -> Void
     private let endForegroundActivity: () -> Void
     private let logger: (String) -> Void
+    private var pendingStopTask: Task<Void, Never>?
+    private var stopGeneration = 0
 
     init(
         updateStatus: @escaping (String) -> Void,
@@ -39,9 +41,21 @@ final class CaptureStopController {
         _ request: CaptureStopRequest,
         afterStop: @escaping () -> Void = {}
     ) {
-        Task { @MainActor [weak self] in
-            await self?.performStop(request)
+        stopGeneration += 1
+        let generation = stopGeneration
+        pendingStopTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.performStop(request)
             afterStop()
+            if generation == self.stopGeneration {
+                self.pendingStopTask = nil
+            }
+        }
+    }
+
+    func waitForPendingStop() async {
+        while let pendingStopTask {
+            await pendingStopTask.value
         }
     }
 

--- a/JustNow/Capture/CaptureStopController.swift
+++ b/JustNow/Capture/CaptureStopController.swift
@@ -35,9 +35,13 @@ final class CaptureStopController {
         }
     }
 
-    func scheduleStop(_ request: CaptureStopRequest) {
+    func scheduleStop(
+        _ request: CaptureStopRequest,
+        afterStop: @escaping () -> Void = {}
+    ) {
         Task { @MainActor [weak self] in
             await self?.performStop(request)
+            afterStop()
         }
     }
 

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -20,15 +20,28 @@ enum CaptureFailureRecovery: Equatable {
     case backOff(TimeInterval)
 
     nonisolated static let falsePermissionDenialDelay: TimeInterval = 30
+    /// Upper bound for the shared circuit's escalating cooldown. A sustained
+    /// OS-side desync should settle into one probe every ten minutes instead
+    /// of touching ScreenCaptureKit twice a minute forever.
+    nonisolated static let falsePermissionDenialMaximumDelay: TimeInterval = 600
+    /// A circuit that reopens within this interval of the previous cooldown's
+    /// end is treated as the same desync episode and escalates the next
+    /// cooldown; a longer healthy stretch resets escalation to the base delay.
+    nonisolated static let falsePermissionDenialEscalationResetInterval: TimeInterval = 300
+
+    /// True when the error is ScreenCaptureKit's TCC denial signature,
+    /// regardless of whether preflight considers the denial genuine.
+    nonisolated static func isPermissionDenial(_ error: Error) -> Bool {
+        let nsError = error as NSError
+        return nsError.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain"
+            && nsError.code == -3801
+    }
 
     nonisolated static func disposition(
         for error: Error,
         hasScreenRecordingPermission: Bool
     ) -> CaptureFailureRecovery {
-        let nsError = error as NSError
-        guard hasScreenRecordingPermission,
-              nsError.domain == "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
-              nsError.code == -3801 else {
+        guard hasScreenRecordingPermission, isPermissionDenial(error) else {
             return .countTowardsStop
         }
 
@@ -108,7 +121,27 @@ class ScreenCaptureManager: NSObject {
             throw CaptureError.permissionDenied
         }
 
-        let content = try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+        // Route content discovery through the shared broker so a start attempt
+        // during a false-denial cooldown fails fast instead of touching
+        // ScreenCaptureKit and risking another native permission prompt.
+        let content: SCShareableContent
+        do {
+            content = try await captureRequestBroker.perform(owner: captureRequestOwner) {
+                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+            }
+        } catch {
+            // Permission can be revoked between the preflight above and the
+            // ScreenCaptureKit call. Surface that as a typed permission error
+            // so callers show the permission flow instead of a generic failure.
+            if CaptureFailureRecovery.isPermissionDenial(error), !Self.hasScreenRecordingPermission() {
+                DiagnosticsLog.shared.log(
+                    "Capture",
+                    "Start failed for display \(targetDisplayID): screen recording permission revoked during content discovery; \(CaptureSystemState.summary())"
+                )
+                throw CaptureError.permissionDenied
+            }
+            throw error
+        }
         try Task.checkCancellation()
         guard let display = content.displays.first(where: { $0.displayID == targetDisplayID }) else {
             throw CaptureError.noDisplay
@@ -374,12 +407,15 @@ class ScreenCaptureManager: NSObject {
             captureScheduleRevision += 1
             captureCooldownDeadline = Self.monotonicTime() + delay
             nextCaptureAt = nil
+            // The shared broker owns the authoritative (possibly escalated)
+            // cooldown; this local deadline only parks the loop until its next
+            // attempt adopts the broker's real deadline without touching the OS.
             captureLogger.warning(
-                "ScreenCaptureKit reported a false permission denial; backing off for \(delay, privacy: .public) seconds"
+                "ScreenCaptureKit reported a false permission denial; deferring capture while the shared circuit cools down"
             )
             DiagnosticsLog.shared.log(
                 "Capture",
-                "ScreenCaptureKit reported a permission denial while preflight remained granted; backing off for \(delay) seconds: \(detail)"
+                "ScreenCaptureKit reported a permission denial while preflight remained granted; deferring capture while the shared circuit cools down: \(detail)"
             )
             return
         }

--- a/JustNowTests/CaptureEventControllerTests.swift
+++ b/JustNowTests/CaptureEventControllerTests.swift
@@ -96,6 +96,44 @@ final class CaptureEventControllerTests: XCTestCase {
         )
     }
 
+    func testOverlayPauseStopsLaunchSetupRecovery() {
+        let recorder = CaptureEventControllerRecorder(
+            context: CaptureEventContext(
+                hasCaptureManager: false,
+                isCapturing: false,
+                isSetupCaptureInProgress: true,
+                hasPendingStart: false,
+                isOverlayVisible: true
+            )
+        )
+        let controller = recorder.makeController()
+
+        controller.handleOverlayVisibilityChanged(isVisible: true)
+
+        XCTAssertEqual(
+            recorder.events,
+            ["cancelPendingStart", "stop:Paused (Overlay)"]
+        )
+    }
+
+    func testWakePreservesResumeIntentWhileLaunchSetupIsInProgress() {
+        let recorder = CaptureEventControllerRecorder(
+            context: CaptureEventContext(
+                hasCaptureManager: false,
+                isCapturing: false,
+                isSetupCaptureInProgress: true,
+                hasPendingStart: false,
+                isOverlayVisible: false
+            )
+        )
+        let controller = recorder.makeController()
+
+        controller.handleWake()
+
+        XCTAssertEqual(recorder.events, ["filter:5.0", "start:Resuming..."])
+        XCTAssertEqual(recorder.startRequests.count, 1)
+    }
+
     func testToggleCapturePauseWithoutCaptureManagerUpdatesPauseMenuAndStatus() {
         let recorder = CaptureEventControllerRecorder(
             context: CaptureEventContext(

--- a/JustNowTests/CaptureEventControllerTests.swift
+++ b/JustNowTests/CaptureEventControllerTests.swift
@@ -56,6 +56,46 @@ final class CaptureEventControllerTests: XCTestCase {
         XCTAssertEqual(recorder.startRequests[0].retry?.delay, .seconds(3))
     }
 
+    func testSessionResignStopsDeferredCoordinatorRecovery() {
+        let recorder = CaptureEventControllerRecorder(
+            context: CaptureEventContext(
+                hasCaptureManager: true,
+                isCapturing: false,
+                isSetupCaptureInProgress: false,
+                hasPendingStart: true,
+                isOverlayVisible: false
+            )
+        )
+        let controller = recorder.makeController()
+
+        controller.handleSessionResignActive()
+
+        XCTAssertEqual(
+            recorder.events,
+            ["cancelPendingStart", "stop:Session Inactive"]
+        )
+    }
+
+    func testOverlayPauseStopsDeferredCoordinatorRecovery() {
+        let recorder = CaptureEventControllerRecorder(
+            context: CaptureEventContext(
+                hasCaptureManager: true,
+                isCapturing: false,
+                isSetupCaptureInProgress: false,
+                hasPendingStart: true,
+                isOverlayVisible: true
+            )
+        )
+        let controller = recorder.makeController()
+
+        controller.handleOverlayVisibilityChanged(isVisible: true)
+
+        XCTAssertEqual(
+            recorder.events,
+            ["cancelPendingStart", "stop:Paused (Overlay)"]
+        )
+    }
+
     func testToggleCapturePauseWithoutCaptureManagerUpdatesPauseMenuAndStatus() {
         let recorder = CaptureEventControllerRecorder(
             context: CaptureEventContext(

--- a/JustNowTests/CaptureFailureRecoveryTests.swift
+++ b/JustNowTests/CaptureFailureRecoveryTests.swift
@@ -32,6 +32,25 @@ final class CaptureFailureRecoveryTests: XCTestCase {
         )
     }
 
+    func testIsPermissionDenialMatchesScreenCaptureKitDenialSignature() {
+        XCTAssertTrue(
+            CaptureFailureRecovery.isPermissionDenial(
+                NSError(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain", code: -3801)
+            )
+        )
+        XCTAssertFalse(
+            CaptureFailureRecovery.isPermissionDenial(
+                NSError(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain", code: -3802)
+            )
+        )
+        XCTAssertFalse(
+            CaptureFailureRecovery.isPermissionDenial(
+                NSError(domain: "com.apple.ScreenCaptureKit.CoreGraphicsErrorDomain", code: -3801)
+            )
+        )
+        XCTAssertFalse(CaptureFailureRecovery.isPermissionDenial(CaptureError.permissionDenied))
+    }
+
     func testCountsOtherScreenCaptureKitErrorsTowardsStop() {
         let error = NSError(
             domain: "com.apple.ScreenCaptureKit.CoreGraphicsErrorDomain",

--- a/JustNowTests/CaptureReconciliationGateTests.swift
+++ b/JustNowTests/CaptureReconciliationGateTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import JustNow
+
+@MainActor
+final class CaptureReconciliationGateTests: XCTestCase {
+    func testSerialisesOperationsInFIFOOrder() async throws {
+        let gate = CaptureReconciliationGate()
+        let latch = ReconciliationGateTestLatch()
+        var events: [String] = []
+
+        let first = Task { @MainActor in
+            try await gate.withPermit {
+                events.append("first-enter")
+                await latch.wait()
+                events.append("first-exit")
+            }
+        }
+        await waitUntil { events == ["first-enter"] }
+
+        let second = Task { @MainActor in
+            try await gate.withPermit {
+                events.append("second-enter")
+            }
+        }
+        await waitUntil { gate.queuedWaiterCountForTesting == 1 }
+        XCTAssertEqual(events, ["first-enter"])
+
+        await latch.resume()
+        try await first.value
+        try await second.value
+        XCTAssertEqual(events, ["first-enter", "first-exit", "second-enter"])
+    }
+
+    func testCancellingQueuedOperationDoesNotLeakPermit() async throws {
+        let gate = CaptureReconciliationGate()
+        let latch = ReconciliationGateTestLatch()
+        var secondEntered = false
+
+        let first = Task { @MainActor in
+            try await gate.withPermit { await latch.wait() }
+        }
+        await waitUntil { await latch.waiterCount == 1 }
+
+        let second = Task { @MainActor in
+            try await gate.withPermit { secondEntered = true }
+        }
+        await waitUntil { gate.queuedWaiterCountForTesting == 1 }
+        second.cancel()
+        do {
+            try await second.value
+            XCTFail("Cancelled waiter should not acquire the permit")
+        } catch is CancellationError {
+            // Expected.
+        }
+
+        await latch.resume()
+        try await first.value
+        try await gate.withPermit {}
+        XCTAssertFalse(secondEntered)
+    }
+
+    func testCancellingActiveOperationDoesNotReleaseUntilItUnwinds() async {
+        let gate = CaptureReconciliationGate()
+        let latch = ReconciliationGateTestLatch()
+        var secondEntered = false
+
+        let first = Task { @MainActor in
+            try await gate.withPermit {
+                await latch.wait()
+            }
+        }
+        await waitUntil { await latch.waiterCount == 1 }
+
+        let second = Task { @MainActor in
+            try await gate.withPermit { secondEntered = true }
+        }
+        await waitUntil { gate.queuedWaiterCountForTesting == 1 }
+        first.cancel()
+        await Task.yield()
+        XCTAssertFalse(secondEntered)
+
+        await latch.resume()
+        _ = try? await first.value
+        _ = try? await second.value
+        XCTAssertTrue(secondEntered)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping @MainActor () async -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if await condition() { return }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}
+
+private actor ReconciliationGateTestLatch {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var waiterCount: Int { continuations.count }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func resume() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+}

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -276,6 +276,79 @@ final class CaptureRequestBrokerTests: XCTestCase {
         )
     }
 
+    func testCooldownRestartSchedulerCancellationSuppressesRetry() async {
+        let sleepGate = BrokerTestGate()
+        var retryCount = 0
+        let scheduler = CaptureCooldownRestartScheduler { _ in
+            await sleepGate.wait()
+            try Task.checkCancellation()
+        }
+
+        scheduler.schedule(deadline: 100, delay: .seconds(1)) {
+            retryCount += 1
+        }
+        await waitUntil { sleepGate.waiterCount == 1 }
+
+        scheduler.cancel()
+        sleepGate.resumeNext()
+        await settleTasks()
+
+        XCTAssertEqual(retryCount, 0)
+        XCTAssertNil(scheduler.scheduledDeadline)
+    }
+
+    func testCooldownRestartSchedulerReplacesEarlierDeadline() async {
+        let sleepGate = BrokerTestGate()
+        var retries: [String] = []
+        let scheduler = CaptureCooldownRestartScheduler { _ in
+            await sleepGate.wait()
+            try Task.checkCancellation()
+        }
+
+        scheduler.schedule(deadline: 100, delay: .seconds(1)) {
+            retries.append("first")
+        }
+        await waitUntil { sleepGate.waiterCount == 1 }
+        scheduler.schedule(deadline: 200, delay: .seconds(2)) {
+            retries.append("second")
+        }
+        await waitUntil { sleepGate.waiterCount == 2 }
+
+        sleepGate.resumeNext()
+        sleepGate.resumeNext()
+        await waitUntil { retries == ["second"] }
+
+        XCTAssertEqual(retries, ["second"])
+        XCTAssertNil(scheduler.scheduledDeadline)
+    }
+
+    func testCooldownRestartSchedulerPreservesReentrantReplacement() async {
+        let sleepGate = BrokerTestGate()
+        var retries: [String] = []
+        let scheduler = CaptureCooldownRestartScheduler { _ in
+            await sleepGate.wait()
+            try Task.checkCancellation()
+        }
+
+        scheduler.schedule(deadline: 100, delay: .seconds(1)) {
+            retries.append("first")
+            scheduler.schedule(deadline: 200, delay: .seconds(2)) {
+                retries.append("second")
+            }
+        }
+        await waitUntil { sleepGate.waiterCount == 1 }
+        sleepGate.resumeNext()
+        await waitUntil {
+            retries == ["first"] && scheduler.scheduledDeadline == 200
+                && sleepGate.waiterCount == 1
+        }
+
+        sleepGate.resumeNext()
+        await waitUntil { retries == ["first", "second"] }
+
+        XCTAssertNil(scheduler.scheduledDeadline)
+    }
+
     func testQuickRelapseAfterRecoveryEscalatesCooldown() async throws {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -303,6 +303,37 @@ final class CaptureRequestBrokerTests: XCTestCase {
         )
     }
 
+    func testCoordinatorPublishesReadinessAfterEverySuccessfulReconciliation() {
+        XCTAssertTrue(
+            CaptureCoordinator.shouldPublishReconciledReadiness(
+                isRunning: true,
+                isCapturing: true,
+                isCircuitClosed: true
+            )
+        )
+        XCTAssertFalse(
+            CaptureCoordinator.shouldPublishReconciledReadiness(
+                isRunning: false,
+                isCapturing: true,
+                isCircuitClosed: true
+            )
+        )
+        XCTAssertFalse(
+            CaptureCoordinator.shouldPublishReconciledReadiness(
+                isRunning: true,
+                isCapturing: false,
+                isCircuitClosed: true
+            )
+        )
+        XCTAssertFalse(
+            CaptureCoordinator.shouldPublishReconciledReadiness(
+                isRunning: true,
+                isCapturing: true,
+                isCircuitClosed: false
+            )
+        )
+    }
+
     func testCooldownRestartSchedulerCancellationSuppressesRetry() async {
         let sleepGate = BrokerTestGate()
         var retryCount = 0

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -176,15 +176,233 @@ final class CaptureRequestBrokerTests: XCTestCase {
         let blockedError = await captureError(from: broker, owner: UUID()) {
             XCTFail("A reopened circuit must not call the OS request")
         }
+        // A failed probe is fresh evidence the desync episode is ongoing, so
+        // the reopened circuit escalates to double the base cooldown.
         XCTAssertEqual(
             blockedError as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay * 2
+            )
+        )
+        XCTAssertEqual(logs.filter { $0.contains("circuit opened") }.count, 1)
+        XCTAssertEqual(logs.filter { $0.contains("circuit reopened") }.count, 1)
+    }
+
+    func testReopenedCircuitEscalatesCooldownUpToTheCap() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var recoveryStates: [CaptureRequestBrokerRecoveryState] = []
+        broker.recoveryStateDidChange = { recoveryStates.append($0) }
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        var expectedDelay = CaptureFailureRecovery.falsePermissionDenialDelay
+        for _ in 0..<6 {
+            clock.advance(by: expectedDelay)
+            _ = await captureError(from: broker, owner: UUID()) {
+                throw self.falsePermissionDenial()
+            }
+            expectedDelay = min(
+                expectedDelay * 2,
+                CaptureFailureRecovery.falsePermissionDenialMaximumDelay
+            )
+
+            let blocked = await captureError(from: broker, owner: UUID()) {
+                XCTFail("An open circuit must not call the OS request")
+            }
+            XCTAssertEqual(
+                blocked as? CaptureRequestBrokerError,
+                .cooldown(untilMonotonicTime: clock.monotonicTime + expectedDelay)
+            )
+        }
+
+        XCTAssertEqual(recoveryStates.last, .needsAttention)
+    }
+
+    func testMaximumCooldownRepublishesNeedsAttentionAfterCaptureRestart() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        var recoveryStates: [CaptureRequestBrokerRecoveryState] = []
+        broker.recoveryStateDidChange = { recoveryStates.append($0) }
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        var delay = CaptureFailureRecovery.falsePermissionDenialDelay
+        while delay < CaptureFailureRecovery.falsePermissionDenialMaximumDelay {
+            clock.advance(by: delay)
+            _ = await captureError(from: broker, owner: UUID()) {
+                throw self.falsePermissionDenial()
+            }
+            delay = min(
+                delay * 2,
+                CaptureFailureRecovery.falsePermissionDenialMaximumDelay
+            )
+        }
+
+        recoveryStates.removeAll()
+        _ = await captureError(from: broker, owner: UUID()) {
+            XCTFail("A maximum-cooldown circuit must not call ScreenCaptureKit")
+        }
+
+        XCTAssertEqual(recoveryStates, [.needsAttention])
+    }
+
+    func testCoordinatorStartReadinessPrefersGlobalCooldownOverPartialCapture() {
+        XCTAssertEqual(
+            CaptureCoordinator.startReadiness(
+                isCapturing: true,
+                openCircuitDeadline: 1_234
+            ),
+            .coolingDown(untilMonotonicTime: 1_234)
+        )
+        XCTAssertEqual(
+            CaptureCoordinator.startReadiness(
+                isCapturing: true,
+                openCircuitDeadline: nil
+            ),
+            .ready
+        )
+        XCTAssertEqual(
+            CaptureCoordinator.startReadiness(
+                isCapturing: false,
+                openCircuitDeadline: nil
+            ),
+            .noDisplay
+        )
+    }
+
+    func testQuickRelapseAfterRecoveryEscalatesCooldown() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+        try await broker.perform(owner: UUID()) {}
+
+        // Capture worked briefly, then the same episode resumed well inside
+        // the escalation reset window.
+        clock.advance(by: 20)
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        let blocked = await captureError(from: broker, owner: UUID()) {
+            XCTFail("An open circuit must not call the OS request")
+        }
+        XCTAssertEqual(
+            blocked as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay * 2
+            )
+        )
+    }
+
+    func testDelayedFailedProbeStillEscalatesCooldown() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        // The probe was delayed long past the reset interval (e.g. the Mac
+        // slept through the cooldown). No healthy capture happened, so the
+        // failed probe must still escalate rather than reset to the base.
+        clock.advance(
+            by: CaptureFailureRecovery.falsePermissionDenialDelay
+                + CaptureFailureRecovery.falsePermissionDenialEscalationResetInterval + 100
+        )
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        let blocked = await captureError(from: broker, owner: UUID()) {
+            XCTFail("An open circuit must not call the OS request")
+        }
+        XCTAssertEqual(
+            blocked as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay * 2
+            )
+        )
+    }
+
+    func testQuickRelapseAfterDelayedRecoveryStillEscalates() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        // The successful probe ran long after the cooldown deadline (e.g.
+        // after sleep). The healthy period starts at that recovery, so a
+        // relapse moments later is the same episode and must escalate.
+        clock.advance(
+            by: CaptureFailureRecovery.falsePermissionDenialDelay
+                + CaptureFailureRecovery.falsePermissionDenialEscalationResetInterval + 100
+        )
+        try await broker.perform(owner: UUID()) {}
+
+        clock.advance(by: 10)
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        let blocked = await captureError(from: broker, owner: UUID()) {
+            XCTFail("An open circuit must not call the OS request")
+        }
+        XCTAssertEqual(
+            blocked as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay * 2
+            )
+        )
+    }
+
+    func testEscalationResetsAfterSustainedRecovery() async throws {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay * 2)
+        try await broker.perform(owner: UUID()) {}
+
+        // A healthy stretch longer than the reset interval means the next
+        // denial is a fresh episode and starts from the base cooldown again.
+        clock.advance(
+            by: CaptureFailureRecovery.falsePermissionDenialEscalationResetInterval + 1
+        )
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        let blocked = await captureError(from: broker, owner: UUID()) {
+            XCTFail("An open circuit must not call the OS request")
+        }
+        XCTAssertEqual(
+            blocked as? CaptureRequestBrokerError,
             .cooldown(
                 untilMonotonicTime: clock.monotonicTime
                     + CaptureFailureRecovery.falsePermissionDenialDelay
             )
         )
-        XCTAssertEqual(logs.filter { $0.contains("circuit opened") }.count, 1)
-        XCTAssertEqual(logs.filter { $0.contains("circuit reopened") }.count, 1)
     }
 
     func testCancelledHalfOpenProbeKeepsSharedCircuitOpen() async {
@@ -212,6 +430,42 @@ final class CaptureRequestBrokerTests: XCTestCase {
 
         let otherOwnerError = await captureError(from: broker, owner: UUID()) {
             XCTFail("A cancelled probe must not clear the shared circuit")
+        }
+        XCTAssertEqual(
+            otherOwnerError as? CaptureRequestBrokerError,
+            .cooldown(
+                untilMonotonicTime: clock.monotonicTime
+                    + CaptureFailureRecovery.falsePermissionDenialDelay
+            )
+        )
+    }
+
+    func testCancelledHalfOpenProbeWithSuccessfulOSCallKeepsSharedCircuitOpen() async {
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        let gate = BrokerTestGate()
+
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+
+        let probe = Task { @MainActor () -> Error? in
+            await self.captureError(from: broker, owner: UUID()) {
+                // The OS call returns successfully even though the probe's
+                // task was cancelled while it was in flight.
+                await gate.wait()
+            }
+        }
+        await waitUntil { gate.waiterCount == 1 }
+
+        probe.cancel()
+        gate.resumeNext()
+        let probeError = await probe.value
+        XCTAssertTrue(probeError is CancellationError)
+
+        let otherOwnerError = await captureError(from: broker, owner: UUID()) {
+            XCTFail("A cancelled probe must not close the shared circuit even when its OS call succeeded")
         }
         XCTAssertEqual(
             otherOwnerError as? CaptureRequestBrokerError,

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -436,6 +436,31 @@ final class CaptureRequestBrokerTests: XCTestCase {
         )
     }
 
+    func testGenericHalfOpenFailureRearmsCooldownForFutureRecovery() async {
+        enum ProbeError: Error { case unavailable }
+
+        let clock = BrokerTestClock()
+        let broker = makeBroker(clock: clock)
+        _ = await captureError(from: broker, owner: UUID()) {
+            throw self.falsePermissionDenial()
+        }
+
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
+        let probeError = await captureError(from: broker, owner: UUID()) {
+            throw ProbeError.unavailable
+        }
+        XCTAssertTrue(probeError is ProbeError)
+        XCTAssertEqual(
+            broker.openCircuitMonotonicDeadline,
+            clock.monotonicTime + CaptureFailureRecovery.falsePermissionDenialDelay
+        )
+
+        let blocked = await captureError(from: broker, owner: UUID()) {
+            XCTFail("Rearmed cooldown must block another immediate OS request")
+        }
+        XCTAssertTrue(blocked is CaptureRequestBrokerError)
+    }
+
     func testDelayedFailedProbeStillEscalatesCooldown() async {
         let clock = BrokerTestClock()
         let broker = makeBroker(clock: clock)
@@ -846,8 +871,9 @@ final class CaptureRequestBrokerTests: XCTestCase {
                 code: 1004
             )
         }
-        XCTAssertEqual(states, [.coolingDown])
+        XCTAssertEqual(states, [.coolingDown, .coolingDown])
 
+        clock.advance(by: CaptureFailureRecovery.falsePermissionDenialDelay)
         try await broker.perform(owner: UUID()) {}
         XCTAssertEqual(states.last, .normal)
     }

--- a/JustNowTests/CaptureRequestBrokerTests.swift
+++ b/JustNowTests/CaptureRequestBrokerTests.swift
@@ -276,6 +276,33 @@ final class CaptureRequestBrokerTests: XCTestCase {
         )
     }
 
+    func testCoordinatorSuppressesIntermediateNormalDuringReconciliation() {
+        XCTAssertFalse(
+            CaptureCoordinator.shouldForwardBrokerRecoveryState(
+                .normal,
+                activeReconciliationCount: 1
+            )
+        )
+        XCTAssertTrue(
+            CaptureCoordinator.shouldForwardBrokerRecoveryState(
+                .normal,
+                activeReconciliationCount: 0
+            )
+        )
+        XCTAssertTrue(
+            CaptureCoordinator.shouldForwardBrokerRecoveryState(
+                .coolingDown,
+                activeReconciliationCount: 1
+            )
+        )
+        XCTAssertTrue(
+            CaptureCoordinator.shouldForwardBrokerRecoveryState(
+                .needsAttention,
+                activeReconciliationCount: 1
+            )
+        )
+    }
+
     func testCooldownRestartSchedulerCancellationSuppressesRetry() async {
         let sleepGate = BrokerTestGate()
         var retryCount = 0

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -24,7 +24,7 @@ final class CaptureStartControllerTests: XCTestCase {
             updateStatus: { statuses.append($0) },
             startCapture: { _ in
                 startAttempts += 1
-                return true
+                return .started
             }
         )
 
@@ -67,7 +67,7 @@ final class CaptureStartControllerTests: XCTestCase {
             updateStatus: { statuses.append($0) },
             startCapture: { attempt in
                 startAttempts.append(attempt)
-                return startAttempts.count == 2
+                return startAttempts.count == 2 ? .started : .failed
             }
         )
 
@@ -119,7 +119,7 @@ final class CaptureStartControllerTests: XCTestCase {
             updateStatus: { _ in },
             startCapture: { _ in
                 startAttempts += 1
-                return true
+                return .started
             }
         )
 
@@ -134,6 +134,48 @@ final class CaptureStartControllerTests: XCTestCase {
 
         XCTAssertEqual(startAttempts, 0)
         XCTAssertFalse(controller.hasPendingStart)
+    }
+
+    func testDeferredStartDoesNotConsumeRetryPolicy() async {
+        let sleeper = CaptureStartControllerSleepProbe()
+        let controller = CaptureStartController(
+            sleep: { duration in
+                await sleeper.sleep(for: duration)
+            }
+        )
+        var startAttempts: [String] = []
+
+        controller.scheduleStart(
+            request: CaptureStartRequest(
+                status: "Restarting...",
+                attempt: CaptureStartAttempt(
+                    successMessage: "first",
+                    failurePrefix: "first deferred",
+                    failureStatus: "Recovering"
+                ),
+                retry: CaptureStartRetryPolicy(
+                    delay: .seconds(3),
+                    attempt: CaptureStartAttempt(
+                        successMessage: "second",
+                        failurePrefix: "second failed",
+                        failureStatus: "Failed"
+                    )
+                )
+            ),
+            canStartCapture: { true },
+            blockedStatus: { _ in nil },
+            updateStatus: { _ in },
+            startCapture: { attempt in
+                startAttempts.append(attempt.successMessage)
+                return .deferred
+            }
+        )
+
+        await waitUntil { !controller.hasPendingStart }
+
+        XCTAssertEqual(startAttempts, ["first"])
+        let recordedDurations = await sleeper.recordedDurations()
+        XCTAssertTrue(recordedDurations.isEmpty)
     }
 
     private func settleScheduledTasks() async {

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -182,6 +182,102 @@ final class CaptureStartControllerTests: XCTestCase {
         XCTAssertFalse(controller.hasPendingStart)
     }
 
+    func testDeferredRetryRemainsVisibleToLifecycle() async {
+        let sleeper = CaptureStartControllerSleepProbe()
+        let controller = CaptureStartController(
+            sleep: { duration in
+                await sleeper.sleep(for: duration)
+            }
+        )
+        var attemptCount = 0
+
+        controller.scheduleStart(
+            request: CaptureStartRequest(
+                status: "Restarting...",
+                attempt: CaptureStartAttempt(
+                    successMessage: "first",
+                    failurePrefix: "first failed",
+                    failureStatus: "Error"
+                ),
+                retry: CaptureStartRetryPolicy(
+                    delay: .seconds(3),
+                    attempt: CaptureStartAttempt(
+                        successMessage: "second",
+                        failurePrefix: "second deferred",
+                        failureStatus: "Recovering"
+                    )
+                )
+            ),
+            canStartCapture: { true },
+            blockedStatus: { _ in nil },
+            updateStatus: { _ in },
+            startCapture: { _ in
+                attemptCount += 1
+                return attemptCount == 1 ? .failed : .deferred
+            }
+        )
+
+        await waitUntil { await sleeper.recordedDurations() == [.seconds(3)] }
+        await sleeper.resumeAll()
+        await waitUntil { attemptCount == 2 && controller.hasPendingStart }
+
+        XCTAssertTrue(controller.hasPendingStart)
+        controller.cancelPendingStart()
+    }
+
+    func testCancellationCannotRestoreDeferredState() async {
+        let attemptGate = CaptureStartControllerAttemptGate()
+        let controller = CaptureStartController()
+
+        controller.scheduleStart(
+            request: CaptureStartRequest(
+                status: "Restarting...",
+                attempt: CaptureStartAttempt(
+                    successMessage: "first",
+                    failurePrefix: "first deferred",
+                    failureStatus: "Recovering"
+                )
+            ),
+            canStartCapture: { true },
+            blockedStatus: { _ in nil },
+            updateStatus: { _ in },
+            startCapture: { _ in await attemptGate.waitThenDefer() }
+        )
+
+        await waitUntil { await attemptGate.isWaiting }
+        controller.cancelPendingStart()
+        await attemptGate.resume()
+        await settleScheduledTasks()
+
+        XCTAssertFalse(controller.hasPendingStart)
+    }
+
+    func testRecoveryCompletionBeforeDeferredResultDoesNotLeaveStaleState() async {
+        let controller = CaptureStartController()
+
+        controller.scheduleStart(
+            request: CaptureStartRequest(
+                status: "Restarting...",
+                attempt: CaptureStartAttempt(
+                    successMessage: "first",
+                    failurePrefix: "first deferred",
+                    failureStatus: "Recovering"
+                )
+            ),
+            canStartCapture: { true },
+            blockedStatus: { _ in nil },
+            updateStatus: { _ in },
+            startCapture: { _ in
+                controller.completeDeferredStart()
+                return .deferred
+            }
+        )
+
+        await settleScheduledTasks()
+
+        XCTAssertFalse(controller.hasPendingStart)
+    }
+
     private func settleScheduledTasks() async {
         await Task.yield()
         await Task.yield()
@@ -230,5 +326,24 @@ private actor CaptureStartControllerSleepProbe {
         for continuation in pendingContinuations {
             continuation.resume()
         }
+    }
+}
+
+private actor CaptureStartControllerAttemptGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private(set) var isWaiting = false
+
+    func waitThenDefer() async -> CaptureStartResult {
+        isWaiting = true
+        await withCheckedContinuation { continuation in
+            self.continuation = continuation
+        }
+        return .deferred
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
+        isWaiting = false
     }
 }

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -291,6 +291,20 @@ final class CaptureStartControllerTests: XCTestCase {
         XCTAssertTrue(controller.hasPendingStart)
     }
 
+    func testStopCompletionClearsDeferredOwnershipRestoredAfterCancellation() {
+        let controller = CaptureStartController()
+
+        controller.cancelPendingStart()
+        // Models a late broker cooldown callback before the queued coordinator
+        // stop begins executing.
+        controller.beginDeferredStart()
+        XCTAssertTrue(controller.hasPendingStart)
+
+        // The stop completion performs the same final cancellation.
+        controller.cancelPendingStart()
+        XCTAssertFalse(controller.hasPendingStart)
+    }
+
     private func settleScheduledTasks() async {
         await Task.yield()
         await Task.yield()

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -278,6 +278,19 @@ final class CaptureStartControllerTests: XCTestCase {
         XCTAssertFalse(controller.hasPendingStart)
     }
 
+    func testLaterCooldownReestablishesDeferredLifecycleOwnership() {
+        let controller = CaptureStartController()
+
+        controller.beginDeferredStart()
+        XCTAssertTrue(controller.hasPendingStart)
+
+        controller.completeDeferredStart()
+        XCTAssertFalse(controller.hasPendingStart)
+
+        controller.beginDeferredStart()
+        XCTAssertTrue(controller.hasPendingStart)
+    }
+
     private func settleScheduledTasks() async {
         await Task.yield()
         await Task.yield()

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -295,13 +295,60 @@ final class CaptureStartControllerTests: XCTestCase {
         let controller = CaptureStartController()
 
         controller.cancelPendingStart()
+        let stopGeneration = controller.generationSnapshot()
         // Models a late broker cooldown callback before the queued coordinator
         // stop begins executing.
         controller.beginDeferredStart()
         XCTAssertTrue(controller.hasPendingStart)
 
-        // The stop completion performs the same final cancellation.
+        controller.completeDeferredStartIfNoNewerRequest(since: stopGeneration)
+        XCTAssertFalse(controller.hasPendingStart)
+    }
+
+    func testStopCompletionDoesNotCancelNewerStartRequest() async {
+        let sleeper = CaptureStartControllerSleepProbe()
+        let controller = CaptureStartController(
+            sleep: { duration in
+                await sleeper.sleep(for: duration)
+            }
+        )
+        var startAttempts = 0
+
         controller.cancelPendingStart()
+        let stopGeneration = controller.generationSnapshot()
+        controller.beginDeferredStart()
+
+        controller.scheduleStart(
+            request: CaptureStartRequest(
+                status: "Resuming...",
+                initialDelay: .seconds(1),
+                attempt: CaptureStartAttempt(
+                    successMessage: "started",
+                    failurePrefix: "failed",
+                    failureStatus: "Error"
+                )
+            ),
+            canStartCapture: { true },
+            blockedStatus: { _ in nil },
+            updateStatus: { _ in },
+            startCapture: { _ in
+                startAttempts += 1
+                return .started
+            }
+        )
+
+        await waitUntil {
+            await sleeper.recordedDurations() == [.seconds(1)]
+                && controller.hasPendingStart
+        }
+
+        controller.completeDeferredStartIfNoNewerRequest(since: stopGeneration)
+        XCTAssertTrue(controller.hasPendingStart)
+
+        await sleeper.resumeAll()
+        await waitUntil { startAttempts == 1 && !controller.hasPendingStart }
+
+        XCTAssertEqual(startAttempts, 1)
         XCTAssertFalse(controller.hasPendingStart)
     }
 

--- a/JustNowTests/CaptureStartControllerTests.swift
+++ b/JustNowTests/CaptureStartControllerTests.swift
@@ -171,11 +171,15 @@ final class CaptureStartControllerTests: XCTestCase {
             }
         )
 
-        await waitUntil { !controller.hasPendingStart }
+        await waitUntil { startAttempts == ["first"] }
 
         XCTAssertEqual(startAttempts, ["first"])
         let recordedDurations = await sleeper.recordedDurations()
         XCTAssertTrue(recordedDurations.isEmpty)
+        XCTAssertTrue(controller.hasPendingStart)
+
+        controller.cancelPendingStart()
+        XCTAssertFalse(controller.hasPendingStart)
     }
 
     private func settleScheduledTasks() async {

--- a/JustNowTests/CaptureStopControllerTests.swift
+++ b/JustNowTests/CaptureStopControllerTests.swift
@@ -92,6 +92,42 @@ final class CaptureStopControllerTests: XCTestCase {
         XCTAssertEqual(events, ["stop-enter", "stop-exit", "start"])
     }
 
+    func testWaitForPendingStopIncludesEveryQueuedStop() async {
+        let firstStopGate = CaptureStopControllerTestGate()
+        var events: [String] = []
+        var stopCount = 0
+        let controller = CaptureStopController(
+            updateStatus: { _ in },
+            stopCapture: {
+                stopCount += 1
+                events.append("stop-\(stopCount)-enter")
+                if stopCount == 1 {
+                    await firstStopGate.wait()
+                }
+                events.append("stop-\(stopCount)-exit")
+            },
+            endForegroundActivity: {}
+        )
+
+        controller.scheduleStop(CaptureStopRequest(status: "First"))
+        await waitUntil { events == ["stop-1-enter"] }
+        controller.scheduleStop(CaptureStopRequest(status: "Second"))
+
+        let laterStart = Task { @MainActor in
+            await controller.waitForPendingStop()
+            events.append("start")
+        }
+        await Task.yield()
+        XCTAssertEqual(events, ["stop-1-enter"])
+
+        await firstStopGate.resume()
+        await laterStart.value
+        XCTAssertEqual(
+            events,
+            ["stop-1-enter", "stop-1-exit", "stop-2-enter", "stop-2-exit", "start"]
+        )
+    }
+
     private func waitUntil(
         timeout: Duration = .seconds(1),
         file: StaticString = #filePath,

--- a/JustNowTests/CaptureStopControllerTests.swift
+++ b/JustNowTests/CaptureStopControllerTests.swift
@@ -63,6 +63,50 @@ final class CaptureStopControllerTests: XCTestCase {
             ]
         )
     }
+
+    func testWaitForPendingStopOrdersLaterStartAfterStopCompletion() async {
+        let stopGate = CaptureStopControllerTestGate()
+        var events: [String] = []
+        let controller = CaptureStopController(
+            updateStatus: { _ in },
+            stopCapture: {
+                events.append("stop-enter")
+                await stopGate.wait()
+                events.append("stop-exit")
+            },
+            endForegroundActivity: {}
+        )
+
+        controller.scheduleStop(CaptureStopRequest(status: "Stopping"))
+        await waitUntil { events == ["stop-enter"] }
+
+        let laterStart = Task { @MainActor in
+            await controller.waitForPendingStop()
+            events.append("start")
+        }
+        await Task.yield()
+        XCTAssertEqual(events, ["stop-enter"])
+
+        await stopGate.resume()
+        await laterStart.value
+        XCTAssertEqual(events, ["stop-enter", "stop-exit", "start"])
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping @MainActor () -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if condition() { return }
+            await Task.yield()
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
 }
 
 @MainActor
@@ -83,5 +127,18 @@ private final class CaptureStopControllerRecorder {
 
     func recordLog(_ message: String) {
         events.append("log:\(message)")
+    }
+}
+
+private actor CaptureStopControllerTestGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+
+    func wait() async {
+        await withCheckedContinuation { continuation = $0 }
+    }
+
+    func resume() {
+        continuation?.resume()
+        continuation = nil
     }
 }


### PR DESCRIPTION
## Summary

- serialise ScreenCaptureKit requests behind one process-wide recovery circuit for false `SCStreamErrorDomain/-3801` denials while TCC preflight remains granted
- escalate repeated cooldowns, surface persistent recovery guidance, and keep global recovery state authoritative during partial multi-display startup
- schedule and safely cancel/re-arm capture reconciliation after cooldown expiry
- add deterministic coverage for broker admission, escalation, cancellation, partial startup, and cooldown scheduler replacement

## Verification

- `xcodebuild test -project JustNow.xcodeproj -scheme JustNow -destination 'platform=macOS' -derivedDataPath /tmp/JustNow-pr-finalfull-b85c4e8 CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO`
  - 273 tests passed, 0 failures on exact head `a4aca25`
- `git diff --check origin/main...HEAD`
- three independent final reviewers reported no actionable findings on exact head
- CodeRabbit status passed and every inline review thread is resolved
- the final signed reinstall was attempted through tmux, but macOS denied detached keychain signing with `errSecInternalComponent`; the previously installed Developer ID build remains valid, running, and capturing fresh frames

## Adversarial review

Three independent high-rigour Codex reviewers repeatedly inspected correctness/regressions, tests/types/edge cases, and lifecycle/operations as automated review added new findings. The resulting fixes cover reconciliation serialisation, generation-safe stop/start ordering, setup-time resume barriers, no-display fallback ownership, and multi-display readiness. The final exact head is clean across all three reviewers.

Related follow-up: #51 tracks strengthening the local installer signing-identity guard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core capture startup, permission-error handling, and async lifecycle ordering across ScreenCaptureKit; regressions could leave capture stuck, show wrong status, or miss real permission revocation.
> 
> **Overview**
> **Hardens screen recording recovery** when ScreenCaptureKit returns false permission denials (`-3801`) while TCC still shows access granted.
> 
> The **shared `CaptureRequestBroker` circuit** now **escalates cooldowns** (doubling up to a 10-minute cap), exposes **`needsAttention`** at max backoff, and **re-arms** after failed half-open probes without treating unrelated errors as healthy. **`CaptureCoordinator`** routes discovery through the broker, **serializes reconciliation** via a new gate, **schedules cooldown/fallback retries**, and only reports **healthy** after full multi-display reconciliation—not after an early probe.
> 
> **App lifecycle** treats broker cooldown and **no display** as **deferred** starts (not hard failures), shows **"Recovering…"** / **"Capture Help Needed"**, and presents a **one-time persistent recovery alert** with Screen Recording repair steps. **Start/stop ordering** waits for queued stops, tracks **deferred recovery** across overlay/session/launch setup, and avoids clearing deferred state when a newer resume wins.
> 
> **Tests** cover broker escalation, gate FIFO/cancellation, cooldown scheduler replacement, and deferred-start lifecycle edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4aca25d61b91e25bf4f480ef8359a11dbff4e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved capture recovery when Screen Recording access temporarily fails or enters a cooldown period.
  * Capture attempts now retry automatically after recovery instead of showing misleading generic errors.
  * Added clearer statuses such as “Recovering…” and “Capture Help Needed.”
  * Detects permission revocation more reliably during capture startup and display changes.

* **New Features**
  * Added a persistent recovery alert with guidance for restoring Screen Recording permission.
  * Added a menu option to open the relevant system permission settings.
  * Improved handling of repeated failures with escalating recovery assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->