### PR TITLE
fix: prevent screenshot capture stalls

### DIFF
--- a/JustNow/Capture/CaptureCoordinator.swift
+++ b/JustNow/Capture/CaptureCoordinator.swift
@@ -322,7 +322,12 @@ final class CaptureCoordinator: NSObject, ScreenCaptureDelegate {
             // while it is cooling down after a false TCC denial, no code path
             // may touch ScreenCaptureKit and risk another native prompt.
             content = try await captureRequestBroker.perform(owner: reconcileRequestOwner) {
-                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                try await ScreenshotCaptureExecution.run {
+                    try await SCShareableContent.excludingDesktopWindows(
+                        false,
+                        onScreenWindowsOnly: true
+                    )
+                }
             }
         } catch {
             // A genuine revocation must reach the app's permission flow even

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -16,6 +16,72 @@ enum CaptureError: Error {
 }
 
 enum ScreenshotCaptureExecution {
+    private actor RequestGate {
+        private var isHeld = false
+        private var waiters: [CheckedContinuation<Void, Never>] = []
+
+        func withPermit<T: Sendable>(
+            _ operation: @escaping @Sendable () async throws -> T
+        ) async throws -> T {
+            await acquire()
+            defer { release() }
+            return try await operation()
+        }
+
+        private func acquire() async {
+            guard isHeld else {
+                isHeld = true
+                return
+            }
+            await withCheckedContinuation { continuation in
+                waiters.append(continuation)
+            }
+        }
+
+        private func release() {
+            guard !waiters.isEmpty else {
+                isHeld = false
+                return
+            }
+            waiters.removeFirst().resume()
+        }
+    }
+
+    private final class CancellationRace<T: Sendable>: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<T, Error>?
+        private var resolvedResult: Result<T, Error>?
+
+        /// Returns false when cancellation won before the continuation was
+        /// installed, so the caller can avoid starting unnecessary OS work.
+        func install(_ continuation: CheckedContinuation<T, Error>) -> Bool {
+            lock.lock()
+            if let resolvedResult {
+                lock.unlock()
+                continuation.resume(with: resolvedResult)
+                return false
+            }
+            self.continuation = continuation
+            lock.unlock()
+            return true
+        }
+
+        func resolve(_ result: Result<T, Error>) {
+            lock.lock()
+            guard resolvedResult == nil else {
+                lock.unlock()
+                return
+            }
+            resolvedResult = result
+            let continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+            continuation?.resume(with: result)
+        }
+    }
+
+    private nonisolated static let requestGate = RequestGate()
+
     private struct SendableFilter: @unchecked Sendable {
         let value: SCContentFilter
     }
@@ -23,9 +89,25 @@ enum ScreenshotCaptureExecution {
     nonisolated static func run<T: Sendable>(
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
-        try await Task.detached(priority: .userInitiated) {
-            try await operation()
-        }.value
+        let race = CancellationRace<T>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                guard race.install(continuation) else { return }
+                Task.detached(priority: .userInitiated) {
+                    let result: Result<T, Error>
+                    do {
+                        result = .success(
+                            try await requestGate.withPermit(operation)
+                        )
+                    } catch {
+                        result = .failure(error)
+                    }
+                    race.resolve(result)
+                }
+            }
+        } onCancel: {
+            race.resolve(.failure(CancellationError()))
+        }
     }
 
     nonisolated static func captureImage(

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -3,7 +3,7 @@
 //  JustNow
 //
 
-import ScreenCaptureKit
+@preconcurrency import ScreenCaptureKit
 import AppKit
 import CoreVideo
 import os.log
@@ -13,6 +13,61 @@ private let captureLogger = Logger(subsystem: "sg.tk.JustNow", category: "Captur
 enum CaptureError: Error {
     case permissionDenied
     case noDisplay
+}
+
+enum ScreenshotCaptureExecution {
+    private struct SendableFilter: @unchecked Sendable {
+        let value: SCContentFilter
+    }
+
+    nonisolated static func run<T: Sendable>(
+        _ operation: @escaping @Sendable () async throws -> T
+    ) async throws -> T {
+        try await Task.detached(priority: .userInitiated) {
+            try await operation()
+        }.value
+    }
+
+    nonisolated static func captureImage(
+        contentFilter: SCContentFilter,
+        outputDimensions: (width: Int, height: Int)
+    ) async throws -> CGImage {
+        let filter = SendableFilter(value: contentFilter)
+        return try await run {
+            if #available(macOS 26.0, *) {
+                let configuration = SCScreenshotConfiguration()
+                configuration.width = outputDimensions.width
+                configuration.height = outputDimensions.height
+                configuration.showsCursor = true
+                configuration.dynamicRange = .sdr
+
+                let output = try await SCScreenshotManager.captureScreenshot(
+                    contentFilter: filter.value,
+                    configuration: configuration
+                )
+                guard let image = output.sdrImage else {
+                    throw ScreenshotCaptureError.missingImage
+                }
+                return image
+            }
+
+            let configuration = SCStreamConfiguration()
+            configuration.width = outputDimensions.width
+            configuration.height = outputDimensions.height
+            configuration.showsCursor = true
+            configuration.capturesAudio = false
+            configuration.pixelFormat = kCVPixelFormatType_32BGRA
+            configuration.colorSpaceName = CGColorSpace.sRGB
+            return try await SCScreenshotManager.captureImage(
+                contentFilter: filter.value,
+                configuration: configuration
+            )
+        }
+    }
+}
+
+private enum ScreenshotCaptureError: Error {
+    case missingImage
 }
 
 enum CaptureFailureRecovery: Equatable {
@@ -67,8 +122,8 @@ class ScreenCaptureManager: NSObject {
     private let maximumConsecutiveCaptureFailures = 3
 
     private var filter: SCContentFilter?
-    private var config: SCStreamConfiguration?
     private var displayDimensions: (width: Int, height: Int)?
+    private var captureOutputDimensions: (width: Int, height: Int)?
     private var displayBackingScale: CGFloat = 1
     private var captureScale: Int = 2
 
@@ -151,20 +206,12 @@ class ScreenCaptureManager: NSObject {
         displayBackingScale = Self.backingScale(for: targetDisplayID)
         let filter = SCContentFilter(display: display, excludingApplications: [], exceptingWindows: [])
 
-        let cfg = SCStreamConfiguration()
-        applyCaptureScale(to: cfg, dimensions: dimensions)
-        cfg.showsCursor = true
-        cfg.capturesAudio = false
-        // Pin the surface format so SCK doesn't pick a wider, more expensive
-        // default. BGRA + sRGB matches the JPEG encode path and avoids hidden
-        // colour-space conversion on every capture.
-        cfg.pixelFormat = kCVPixelFormatType_32BGRA
-        cfg.colorSpaceName = CGColorSpace.sRGB
+        let outputDimensions = captureDimensions(for: dimensions)
         try Task.checkCancellation()
 
         self.filter = filter
         displayDimensions = dimensions
-        config = cfg
+        captureOutputDimensions = outputDimensions
 
         consecutiveCaptureFailures = 0
         isCapturing = true
@@ -220,8 +267,8 @@ class ScreenCaptureManager: NSObject {
 
     func updateCaptureScale(_ scale: Int) {
         captureScale = max(1, scale)
-        guard let config else { return }
-        applyCaptureScale(to: config)
+        guard let displayDimensions else { return }
+        captureOutputDimensions = captureDimensions(for: displayDimensions)
     }
 
     /// Capture a single frame immediately and return it (for overlay open).
@@ -330,7 +377,7 @@ class ScreenCaptureManager: NSObject {
         ) { [weak self] in
             guard let self else { throw CancellationError() }
             try Task.checkCancellation()
-            guard let filter = self.filter, let config = self.config else {
+            guard let filter = self.filter, let outputDimensions = self.captureOutputDimensions else {
                 throw CancellationError()
             }
             if let expectedLoopSerial {
@@ -339,9 +386,9 @@ class ScreenCaptureManager: NSObject {
                 }
             }
 
-            let image = try await SCScreenshotManager.captureImage(
+            let image = try await ScreenshotCaptureExecution.captureImage(
                 contentFilter: filter,
-                configuration: config
+                outputDimensions: outputDimensions
             )
             // Keep cancellation inside the brokered operation. If a display
             // disappears while a half-open probe is in ScreenCaptureKit, a
@@ -438,19 +485,14 @@ class ScreenCaptureManager: NSObject {
         delegate?.captureManagerDidStop(self)
     }
 
-    private func applyCaptureScale(to config: SCStreamConfiguration) {
-        guard let displayDimensions else { return }
-        applyCaptureScale(to: config, dimensions: displayDimensions)
-    }
-
-    private func applyCaptureScale(to config: SCStreamConfiguration, dimensions: (width: Int, height: Int)) {
-        let output = ScreenCaptureSizing.outputDimensions(
-            displayDimensions: dimensions,
+    private func captureDimensions(
+        for displayDimensions: (width: Int, height: Int)
+    ) -> (width: Int, height: Int) {
+        ScreenCaptureSizing.outputDimensions(
+            displayDimensions: displayDimensions,
             desiredScale: captureScale,
             displayBackingScale: displayBackingScale
         )
-        config.width = output.width
-        config.height = output.height
     }
 
     private static func backingScale(for displayID: CGDirectDisplayID) -> CGFloat {

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -17,24 +17,41 @@ enum CaptureError: Error {
 
 enum ScreenshotCaptureExecution {
     private actor RequestGate {
+        private struct Waiter {
+            let id: UUID
+            let continuation: CheckedContinuation<Void, Error>
+        }
+
         private var isHeld = false
-        private var waiters: [CheckedContinuation<Void, Never>] = []
+        private var waiters: [Waiter] = []
 
         func withPermit<T: Sendable>(
+            id: UUID,
+            cancellation: RequestCancellation,
             _ operation: @escaping @Sendable () async throws -> T
         ) async throws -> T {
-            await acquire()
+            try cancellation.check()
+            try await acquire(id: id)
             defer { release() }
+            try cancellation.check()
             return try await operation()
         }
 
-        private func acquire() async {
+        func cancel(id: UUID) {
+            guard let index = waiters.firstIndex(where: { $0.id == id }) else {
+                return
+            }
+            let waiter = waiters.remove(at: index)
+            waiter.continuation.resume(throwing: CancellationError())
+        }
+
+        private func acquire(id: UUID) async throws {
             guard isHeld else {
                 isHeld = true
                 return
             }
-            await withCheckedContinuation { continuation in
-                waiters.append(continuation)
+            try await withCheckedThrowingContinuation { continuation in
+                waiters.append(Waiter(id: id, continuation: continuation))
             }
         }
 
@@ -43,11 +60,31 @@ enum ScreenshotCaptureExecution {
                 isHeld = false
                 return
             }
-            waiters.removeFirst().resume()
+            waiters.removeFirst().continuation.resume()
         }
     }
 
-    private final class CancellationRace<T: Sendable>: @unchecked Sendable {
+    private nonisolated final class RequestCancellation: @unchecked Sendable {
+        private let lock = NSLock()
+        private var isCancelled = false
+
+        func cancel() {
+            lock.lock()
+            isCancelled = true
+            lock.unlock()
+        }
+
+        func check() throws {
+            lock.lock()
+            let isCancelled = self.isCancelled
+            lock.unlock()
+            if isCancelled {
+                throw CancellationError()
+            }
+        }
+    }
+
+    private nonisolated final class CancellationRace<T: Sendable>: @unchecked Sendable {
         private let lock = NSLock()
         private var continuation: CheckedContinuation<T, Error>?
         private var resolvedResult: Result<T, Error>?
@@ -87,17 +124,25 @@ enum ScreenshotCaptureExecution {
     }
 
     nonisolated static func run<T: Sendable>(
+        workerDidStart: (@Sendable () -> Void)? = nil,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
+        let requestID = UUID()
+        let cancellation = RequestCancellation()
         let race = CancellationRace<T>()
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { continuation in
                 guard race.install(continuation) else { return }
                 Task.detached(priority: .userInitiated) {
+                    workerDidStart?()
                     let result: Result<T, Error>
                     do {
                         result = .success(
-                            try await requestGate.withPermit(operation)
+                            try await requestGate.withPermit(
+                                id: requestID,
+                                cancellation: cancellation,
+                                operation
+                            )
                         )
                     } catch {
                         result = .failure(error)
@@ -106,7 +151,11 @@ enum ScreenshotCaptureExecution {
                 }
             }
         } onCancel: {
+            cancellation.cancel()
             race.resolve(.failure(CancellationError()))
+            Task {
+                await requestGate.cancel(id: requestID)
+            }
         }
     }
 

--- a/JustNow/Capture/ScreenCaptureManager.swift
+++ b/JustNow/Capture/ScreenCaptureManager.swift
@@ -28,10 +28,15 @@ enum ScreenshotCaptureExecution {
         func withPermit<T: Sendable>(
             id: UUID,
             cancellation: RequestCancellation,
+            waiterDidEnqueue: (@Sendable () -> Void)?,
             _ operation: @escaping @Sendable () async throws -> T
         ) async throws -> T {
             try cancellation.check()
-            try await acquire(id: id)
+            try await acquire(
+                id: id,
+                cancellation: cancellation,
+                waiterDidEnqueue: waiterDidEnqueue
+            )
             defer { release() }
             try cancellation.check()
             return try await operation()
@@ -45,13 +50,21 @@ enum ScreenshotCaptureExecution {
             waiter.continuation.resume(throwing: CancellationError())
         }
 
-        private func acquire(id: UUID) async throws {
+        private func acquire(
+            id: UUID,
+            cancellation: RequestCancellation,
+            waiterDidEnqueue: (@Sendable () -> Void)?
+        ) async throws {
+            // Actor serialisation makes this check-and-enqueue atomic with
+            // cancel(id:), closing the cancel-before-enqueue race.
+            try cancellation.check()
             guard isHeld else {
                 isHeld = true
                 return
             }
             try await withCheckedThrowingContinuation { continuation in
                 waiters.append(Waiter(id: id, continuation: continuation))
+                waiterDidEnqueue?()
             }
         }
 
@@ -124,7 +137,7 @@ enum ScreenshotCaptureExecution {
     }
 
     nonisolated static func run<T: Sendable>(
-        workerDidStart: (@Sendable () -> Void)? = nil,
+        waiterDidEnqueue: (@Sendable () -> Void)? = nil,
         _ operation: @escaping @Sendable () async throws -> T
     ) async throws -> T {
         let requestID = UUID()
@@ -134,13 +147,13 @@ enum ScreenshotCaptureExecution {
             try await withCheckedThrowingContinuation { continuation in
                 guard race.install(continuation) else { return }
                 Task.detached(priority: .userInitiated) {
-                    workerDidStart?()
                     let result: Result<T, Error>
                     do {
                         result = .success(
                             try await requestGate.withPermit(
                                 id: requestID,
                                 cancellation: cancellation,
+                                waiterDidEnqueue: waiterDidEnqueue,
                                 operation
                             )
                         )
@@ -313,7 +326,12 @@ class ScreenCaptureManager: NSObject {
         let content: SCShareableContent
         do {
             content = try await captureRequestBroker.perform(owner: captureRequestOwner) {
-                try await SCShareableContent.excludingDesktopWindows(false, onScreenWindowsOnly: true)
+                try await ScreenshotCaptureExecution.run {
+                    try await SCShareableContent.excludingDesktopWindows(
+                        false,
+                        onScreenWindowsOnly: true
+                    )
+                }
             }
         } catch {
             // Permission can be revoked between the preflight above and the

--- a/JustNowTests/ScreenshotCaptureExecutionTests.swift
+++ b/JustNowTests/ScreenshotCaptureExecutionTests.swift
@@ -34,7 +34,7 @@ final class ScreenshotCaptureExecutionTests: XCTestCase {
 
         let second = Task {
             try await ScreenshotCaptureExecution.run(
-                workerDidStart: {
+                waiterDidEnqueue: {
                     Task {
                         await state.noteSecondWorkerStarted()
                     }
@@ -67,7 +67,7 @@ final class ScreenshotCaptureExecutionTests: XCTestCase {
         let queued = Task {
             do {
                 try await ScreenshotCaptureExecution.run(
-                    workerDidStart: {
+                    waiterDidEnqueue: {
                         Task {
                             await state.noteQueuedWorkerStarted()
                         }

--- a/JustNowTests/ScreenshotCaptureExecutionTests.swift
+++ b/JustNowTests/ScreenshotCaptureExecutionTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+@testable import JustNow
+
+final class ScreenshotCaptureExecutionTests: XCTestCase {
+    func testRunKeepsSynchronousFrameworkWorkOffMainThread() async throws {
+        let ranOnMainThread = try await ScreenshotCaptureExecution.run {
+            Thread.isMainThread
+        }
+
+        XCTAssertFalse(ranOnMainThread)
+    }
+}

--- a/JustNowTests/ScreenshotCaptureExecutionTests.swift
+++ b/JustNowTests/ScreenshotCaptureExecutionTests.swift
@@ -33,11 +33,17 @@ final class ScreenshotCaptureExecutionTests: XCTestCase {
         await waitUntil { await state.cancellationReturned }
 
         let second = Task {
-            try await ScreenshotCaptureExecution.run {
+            try await ScreenshotCaptureExecution.run(
+                workerDidStart: {
+                    Task {
+                        await state.noteSecondWorkerStarted()
+                    }
+                }
+            ) {
                 await state.noteSecondOperationStarted()
             }
         }
-        try await Task.sleep(for: .milliseconds(50))
+        await waitUntil { await state.secondWorkerStarted }
         let startedWhileFirstRequestWasBlocked = await state.secondOperationStarted
         XCTAssertFalse(startedWhileFirstRequestWasBlocked)
 
@@ -45,6 +51,49 @@ final class ScreenshotCaptureExecutionTests: XCTestCase {
         try await second.value
         let startedAfterFirstRequestCompleted = await state.secondOperationStarted
         XCTAssertTrue(startedAfterFirstRequestCompleted)
+    }
+
+    func testCancellingQueuedRequestPreventsItsOperationFromStarting() async throws {
+        let latch = ScreenshotCaptureExecutionTestLatch()
+        let state = ScreenshotCaptureExecutionTestState()
+
+        let holder = Task {
+            try await ScreenshotCaptureExecution.run {
+                await latch.wait()
+            }
+        }
+        await waitUntil { await latch.waiterCount == 1 }
+
+        let queued = Task {
+            do {
+                try await ScreenshotCaptureExecution.run(
+                    workerDidStart: {
+                        Task {
+                            await state.noteQueuedWorkerStarted()
+                        }
+                    }
+                ) {
+                    await state.noteQueuedOperationStarted()
+                }
+                XCTFail("Cancelled queued capture should not return a value")
+            } catch is CancellationError {
+                await state.noteQueuedCancellationReturned()
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+        await waitUntil { await state.queuedWorkerStarted }
+
+        queued.cancel()
+        await waitUntil { await state.queuedCancellationReturned }
+
+        await latch.resume()
+        try await holder.value
+        try await ScreenshotCaptureExecution.run {}
+        await queued.value
+
+        let queuedOperationStarted = await state.queuedOperationStarted
+        XCTAssertFalse(queuedOperationStarted)
     }
 
     private func waitUntil(
@@ -82,13 +131,33 @@ private actor ScreenshotCaptureExecutionTestLatch {
 
 private actor ScreenshotCaptureExecutionTestState {
     private(set) var cancellationReturned = false
+    private(set) var secondWorkerStarted = false
     private(set) var secondOperationStarted = false
+    private(set) var queuedWorkerStarted = false
+    private(set) var queuedOperationStarted = false
+    private(set) var queuedCancellationReturned = false
 
     func noteCancellationReturned() {
         cancellationReturned = true
     }
 
+    func noteSecondWorkerStarted() {
+        secondWorkerStarted = true
+    }
+
     func noteSecondOperationStarted() {
         secondOperationStarted = true
+    }
+
+    func noteQueuedWorkerStarted() {
+        queuedWorkerStarted = true
+    }
+
+    func noteQueuedOperationStarted() {
+        queuedOperationStarted = true
+    }
+
+    func noteQueuedCancellationReturned() {
+        queuedCancellationReturned = true
     }
 }

--- a/JustNowTests/ScreenshotCaptureExecutionTests.swift
+++ b/JustNowTests/ScreenshotCaptureExecutionTests.swift
@@ -9,4 +9,86 @@ final class ScreenshotCaptureExecutionTests: XCTestCase {
 
         XCTAssertFalse(ranOnMainThread)
     }
+
+    func testCancellationReturnsWhileUnderlyingWorkRetainsSerialPermit() async throws {
+        let latch = ScreenshotCaptureExecutionTestLatch()
+        let state = ScreenshotCaptureExecutionTestState()
+
+        let first = Task {
+            do {
+                _ = try await ScreenshotCaptureExecution.run {
+                    await latch.wait()
+                    return true
+                }
+                XCTFail("Cancelled capture should not return a value")
+            } catch is CancellationError {
+                await state.noteCancellationReturned()
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
+        }
+        await waitUntil { await latch.waiterCount == 1 }
+
+        first.cancel()
+        await waitUntil { await state.cancellationReturned }
+
+        let second = Task {
+            try await ScreenshotCaptureExecution.run {
+                await state.noteSecondOperationStarted()
+            }
+        }
+        try await Task.sleep(for: .milliseconds(50))
+        let startedWhileFirstRequestWasBlocked = await state.secondOperationStarted
+        XCTAssertFalse(startedWhileFirstRequestWasBlocked)
+
+        await latch.resume()
+        try await second.value
+        let startedAfterFirstRequestCompleted = await state.secondOperationStarted
+        XCTAssertTrue(startedAfterFirstRequestCompleted)
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(1),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        condition: @escaping @Sendable () async -> Bool
+    ) async {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+        while clock.now < deadline {
+            if await condition() { return }
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        XCTFail("Timed out waiting for condition", file: file, line: line)
+    }
+}
+
+private actor ScreenshotCaptureExecutionTestLatch {
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    var waiterCount: Int { continuations.count }
+
+    func wait() async {
+        await withCheckedContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func resume() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+}
+
+private actor ScreenshotCaptureExecutionTestState {
+    private(set) var cancellationReturned = false
+    private(set) var secondOperationStarted = false
+
+    func noteCancellationReturned() {
+        cancellationReturned = true
+    }
+
+    func noteSecondOperationStarted() {
+        secondOperationStarted = true
+    }
 }


### PR DESCRIPTION
## Summary

- move one-shot screenshot work off the main actor
- use the macOS 26 screenshot configuration API to avoid the audio-clock path
- keep all ScreenCaptureKit discovery and capture calls behind one serial execution gate
- let lifecycle cancellation return promptly while active native work retains the gate
- remove cancelled queued requests before they can run stale capture work

## Verification

- 276 unit tests pass
- Release build succeeds for arm64 and x86_64
- live macOS 26 capture previously verified with fresh frames on both displays and no CoreAudio clock calls
- three independent adversarial review passes completed; cancellation and cross-operation serialisation findings were fixed and re-reviewed

## Known platform limitation

If a native ScreenCaptureKit request never returns, later capture operations remain gated until relaunch. The UI and stop lifecycle still return promptly.